### PR TITLE
add claude-code-analysis

### DIFF
--- a/.github/workflows/manual-code-analysis.yml
+++ b/.github/workflows/manual-code-analysis.yml
@@ -1,0 +1,42 @@
+name: Claude Commit Analysis
+
+on:
+  workflow_dispatch:
+    inputs:
+      analysis_type:
+        description: "Type of analysis to perform"
+        required: true
+        type: choice
+        options:
+          - summarize-commit
+          - security-review
+        default: "summarize-commit"
+
+jobs:
+  analyze-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2 # Need at least 2 commits to analyze the latest
+
+      - name: Run Claude Analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            BRANCH: ${{ github.ref_name }}
+
+            Analyze the latest commit in this repository.
+
+            ${{ github.event.inputs.analysis_type == 'summarize-commit' && 'Task: Provide a clear, concise summary of what changed in the latest commit. Include the commit message, files changed, and the purpose of the changes.' || '' }}
+
+            ${{ github.event.inputs.analysis_type == 'security-review' && 'Task: Review the latest commit for potential security vulnerabilities. Check for exposed secrets, insecure coding patterns, dependency vulnerabilities, or any other security concerns. Provide specific recommendations if issues are found.' || '' }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enable manual commit analysis using Claude. The workflow allows team members to trigger either a commit summary or a security review of the latest commit, improving code review processes and security oversight.
- This can triggered manually by going to github actions tab.

**New workflow for manual commit analysis:**

* Added `.github/workflows/manual-code-analysis.yml` to provide a manual workflow dispatch for commit analysis, with options for "summarize-commit" or "security-review" using the Claude code action.