### PR TITLE
Test PR DO-NOT-MERGE: Parallel Claude code review based on constitution

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,35 +1,20 @@
-name: Claude PR Review
+name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_comment:
-    types: [created]
-  issue_comment:
-    types: [created]
+    types: [opened, synchronize]
 
 jobs:
-  claude-review:
+  review:
     runs-on: ubuntu-latest
-    # Only run on PR comments (not issue comments)
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Run /code-review --comment
+
+            Review this PR against the AgentLab2 constitution defined in:
+            - .claude/rules/constitution.md (the full constitution with pillars and directives)
+            - .claude/rules/review-rules.md (enforceable rules with severity levels and examples)
           claude_args: "--max-turns 5"
-          use_bedrock: false
-          use_vertex: false
-          prompt: "/review"


### PR DESCRIPTION
This pull request introduces a formal constitution and automated code review standards to the AgentLab2 project. It adds a comprehensive set of rules and processes for code quality, ownership, review, and compliance, and integrates these standards into the development workflow via documentation, review templates, and GitHub Actions.

**Key changes:**

**Governance & Documentation**

* Added `.claude/rules/constitution.md` to define the AgentLab2 Constitution, outlining pillars for team contracts, code explicitness, scalable research, protocol standards, and code craft. Includes update instructions and references for maintaining consistency.
* Added `.claude/rules/review-rules.md` containing enforceable review rules mapped to constitution directives, with severity levels, code examples, and a quick reference table.
* Added `.claude/commands/update-constitution.md` describing the process for updating the constitution and propagating changes to dependent files.

**Developer Workflow Integration**

* Updated `.github/PULL_REQUEST_TEMPLATE/general_code_pr.md` to include a "Constitution Compliance" checklist, ensuring PRs confirm adherence to core rules (e.g., no imports inside functions, type hints, RFCs for API changes, standard integrations, single-process compatibility).
* Added `.github/workflows/claude-pr-review.yml` to automatically run code reviews against the constitution and review rules using the Claude Code Review GitHub Action on every PR/comment.
* Enabled the official Claude code review plugin in `.claude/settings.json`.

**Contributor Guidance**

* Updated `AGENTS.md` with a section on constitution-based code review, directing contributors to the constitution and review rules for reference.