### PR TITLE
Update Claude code review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,35 +1,20 @@
-name: Claude PR Review
+name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_comment:
-    types: [created]
-  issue_comment:
-    types: [created]
+    types: [opened, synchronize]
 
 jobs:
-  claude-review:
+  review:
     runs-on: ubuntu-latest
-    # Only run on PR comments (not issue comments)
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Run /code-review --comment
+
+            Review this PR against the AgentLab2 constitution defined in:
+            - .claude/rules/constitution.md (the full constitution with pillars and directives)
+            - .claude/rules/review-rules.md (enforceable rules with severity levels and examples)
           claude_args: "--max-turns 5"
-          use_bedrock: false
-          use_vertex: false
-          prompt: "/review"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for automated code review, streamlining the configuration and simplifying the event triggers and job steps.

**Workflow configuration cleanup and simplification:**

* Renamed the workflow from `Claude PR Review` to `Code Review` and removed unnecessary event triggers, so it now only runs on `pull_request` events of type `opened` and `synchronize` (`.github/workflows/claude-pr-review.yml`).
* Simplified the job definition by removing redundant job and step names, permissions, and checkout steps, leaving only the essential `anthropics/claude-code-action@v1` step with updated arguments for running code reviews (`.github/workflows/claude-pr-review.yml`).
* Updated the `prompt` and added `claude_args: "--max-turns 5"` to better control the behavior of the code review action (`.github/workflows/claude-pr-review.yml`).