### PR TITLE
Enhance PR review workflow with progress tracking

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,20 +1,40 @@
-name: Code Review
+name: PR Review with Progress Tracking
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-  review:
+  review-with-tracking:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Enable progress tracking
+          track_progress: true
+
+          # Your custom review instructions
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
             Run /code-review --comment
 
             Review this PR against the AgentLab2 constitution defined in:
             - .claude/rules/constitution.md (the full constitution with pillars and directives)
             - .claude/rules/review-rules.md (enforceable rules with severity levels and examples)
-          claude_args: "--max-turns 5"
+          # Tools for comprehensive PR review
+          claude_args: |
+            --max-turns 5 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+    


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for PR reviews to improve automation, add progress tracking, and enhance permissions. The workflow now supports more PR events, checks out the repository before review, and configures the review action with additional tools and tracking.

Workflow enhancements:

* The workflow name is updated to "PR Review with Progress Tracking" and now responds to additional pull request events, including `ready_for_review` and `reopened`.
* The job name is changed to `review-with-tracking`, and repository checkout is added as a step before running the review action.

Permissions and configuration:

* The workflow now explicitly sets permissions for `contents`, `pull-requests`, and `id-token` to enable better integration and progress tracking.
* The `anthropics/claude-code-action` step is configured to enable progress tracking, pass repository and PR information, and allow additional tools for more comprehensive PR reviews.