### PR TITLE
TEST-auto-review (DO NOT MERGE): feat(radar): add agentlab CLI with radar subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 # entries we added plus Python and Ruby .gitignore files
 # generated at https://www.toptal.com/developers/gitignore/
 
+# AgentLab2 experiment outputs
+runs/
+demo_output/
+test_metrics_output/
+hello_world_1/
+
+# Playwright MCP screenshots
+.playwright-mcp/
+
 # A "temporary" place to put stuff...
 tmp/
 temp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ line-ending = "auto"
 [tool.ruff.lint]
 extend-select = ["I"] # sort imports
 
+[project.scripts]
+al2-viewer = "agentlab2.viewer:main"
+agentlab = "agentlab2.radar.cli:main"
+
 [dependency-groups]
 dev = [
     "ruff>=0.14.7",

--- a/src/agentlab2/radar/__init__.py
+++ b/src/agentlab2/radar/__init__.py
@@ -1,0 +1,1 @@
+"""AgentLab2 Radar - Runtime monitoring and visualization for agent experiments."""

--- a/src/agentlab2/radar/cli.py
+++ b/src/agentlab2/radar/cli.py
@@ -1,0 +1,80 @@
+"""CLI entry point for agentlab radar."""
+
+import argparse
+import sys
+from pathlib import Path
+
+DEFAULT_RESULTS_DIR = "~/agentlab_results/al2"
+
+
+def main() -> None:
+    """Main entry point for the agentlab CLI."""
+    parser = argparse.ArgumentParser(
+        prog="agentlab",
+        description="AgentLab2 - Agent evaluation and monitoring tools",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # radar subcommand
+    radar_parser = subparsers.add_parser(
+        "radar",
+        help="Launch the experiment monitoring dashboard",
+        description="Real-time monitoring and visualization of agent experiments.",
+    )
+    radar_parser.add_argument(
+        "directory",
+        type=str,
+        nargs="?",
+        default=DEFAULT_RESULTS_DIR,
+        help=f"Path to experiment output directory (default: {DEFAULT_RESULTS_DIR})",
+    )
+    radar_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Server port number (default: auto-select available port)",
+    )
+    radar_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode with hot reloading",
+    )
+    radar_parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Enable Gradio share link for remote access",
+    )
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.command == "radar":
+        run_radar(args)
+
+
+def run_radar(args: argparse.Namespace) -> None:
+    """Run the radar dashboard."""
+    from agentlab2.viewer import run_viewer
+
+    results_dir = Path(args.directory).expanduser().resolve()
+
+    if not results_dir.exists():
+        print(f"Error: Directory does not exist: {results_dir}", file=sys.stderr)
+        print("\nUsage: agentlab radar <directory>", file=sys.stderr)
+        print("Example: agentlab radar ./output/my_experiment/", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting Radar dashboard for: {results_dir}")
+    run_viewer(
+        results_dir=results_dir,
+        debug=args.debug,
+        port=args.port,
+        share=args.share,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_radar_cli.py
+++ b/tests/test_radar_cli.py
@@ -1,0 +1,64 @@
+"""Tests for the agentlab radar CLI."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+class TestRadarCLI:
+    """Tests for the radar CLI module."""
+
+    def test_main_help(self) -> None:
+        """Test that main help displays available commands."""
+        result = subprocess.run(
+            [sys.executable, "-m", "agentlab2.radar.cli", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "radar" in result.stdout
+        assert "Launch the experiment monitoring dashboard" in result.stdout
+
+    def test_radar_help(self) -> None:
+        """Test that radar subcommand help displays options."""
+        result = subprocess.run(
+            [sys.executable, "-m", "agentlab2.radar.cli", "radar", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--port" in result.stdout
+        assert "--debug" in result.stdout
+        assert "--share" in result.stdout
+        assert "directory" in result.stdout
+
+    def test_no_command_shows_help(self) -> None:
+        """Test that running without subcommand shows help and exits with error."""
+        result = subprocess.run(
+            [sys.executable, "-m", "agentlab2.radar.cli"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "radar" in result.stdout
+
+    def test_nonexistent_directory_error(self, tmp_dir: Path) -> None:
+        """Test that non-existent directory shows error message on stderr."""
+        nonexistent = tmp_dir / "does_not_exist"
+        result = subprocess.run(
+            [sys.executable, "-m", "agentlab2.radar.cli", "radar", str(nonexistent)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "Error: Directory does not exist" in result.stderr
+        assert "Usage:" in result.stderr
+
+    def test_argument_parsing(self) -> None:
+        """Test that arguments are parsed correctly."""
+
+        from agentlab2.radar.cli import main
+
+        # We can't easily test the full flow without starting Gradio,
+        # but we can verify the module imports and basic structure
+        assert callable(main)


### PR DESCRIPTION
Add `agentlab radar` CLI command that launches the Gradio experiment viewer. This establishes the CLI framework for future radar features (stats, export, live monitoring).

Usage:
  agentlab radar ./output/       # Launch dashboard
  agentlab radar --port 8484     # Custom port
  agentlab radar --share         # Public URL

Click the `Preview` tab and select a PR template:

