### PR TITLE
Migrate to LiteLLM native OTEL and enhance tracing

### DIFF
--- a/src/agentlab2/episode.py
+++ b/src/agentlab2/episode.py
@@ -67,6 +67,9 @@ class Episode:
                         self.save_step(env_output)
 
                         span.set_attribute("agent_output", agent_output.model_dump_json())
+                        span.set_attribute("env_output", env_output.model_dump_json())
+                        span.set_attribute("done", env_output.done)
+                        span.set_attribute("reward", env_output.reward)
                         turns += 1
         except Exception as e:
             logger.exception(f"Error during agent run: {e}")

--- a/src/agentlab2/llm.py
+++ b/src/agentlab2/llm.py
@@ -1,16 +1,23 @@
 """LLM interaction abstractions, LiteLLM based."""
 
+import os
 import pprint
 from datetime import datetime
 from functools import partial
 from typing import Callable, List, Literal
 from uuid import uuid4
 
+import litellm
 from litellm import Message, completion_with_retries
 from litellm.utils import token_counter
 from pydantic import Field
 
 from agentlab2.base import TypedBaseModel
+
+os.environ["USE_OTEL_LITELLM_REQUEST_SPAN"] = "true"
+litellm.callbacks = ["otel"]
+# LiteLLM creates "litellm_request" spans with ~50 GenAI semantic attributes (tokens, cost, etc).
+# See: litellm/integrations/opentelemetry.py, https://opentelemetry.io/docs/specs/semconv/gen-ai/
 
 
 class Prompt(TypedBaseModel):

--- a/src/agentlab2/metrics/tracer.py
+++ b/src/agentlab2/metrics/tracer.py
@@ -1,7 +1,10 @@
+import json
+import logging
 import os
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
+from uuid import uuid4
 
 from opentelemetry import trace
 from opentelemetry.context import Context
@@ -10,13 +13,40 @@ from opentelemetry.propagate import extract, inject
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanKind
 
+from agentlab2.core import Action
 from agentlab2.metrics.disk_exporter import DiskSpanExporter
 from agentlab2.metrics.processor import AL2_EXPERIMENT, AL2_NAME, AL2_TYPE, TYPE_EPISODE, TYPE_EXPERIMENT, TYPE_STEP
+
+_logger = logging.getLogger(__name__)
 
 ENV_TRACEPARENT = "TRACEPARENT"
 ENV_TRACE_OUTPUT = "AGENTLAB_TRACE_OUTPUT"
 ENV_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#gen-ai-agent-attributes
+GEN_AI_AGENT_NAME = "gen_ai.agent.name"
+GEN_AI_AGENT_ID = "gen_ai.agent.id"
+GEN_AI_AGENT_DESCRIPTION = "gen_ai.agent.description"
+
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool
+GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"
+GEN_AI_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments"
+GEN_AI_TOOL_CALL_RESULT = "gen_ai.tool.call.result"
+
+_tool_tracer = trace.get_tracer(__name__)
+
+
+@contextmanager
+def tool_span(action: Action) -> Iterator[trace.Span]:
+    """Create a span for tool execution with GenAI semantic attributes."""
+    with _tool_tracer.start_as_current_span(f"execute_tool {action.name}", kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(GEN_AI_TOOL_NAME, action.name)
+        span.set_attribute(GEN_AI_TOOL_CALL_ID, action.id)
+        span.set_attribute(GEN_AI_TOOL_CALL_ARGUMENTS, json.dumps(action.arguments))
+        yield span
 
 
 class _AgentTracer:
@@ -27,11 +57,23 @@ class _AgentTracer:
         service_name: str,
         output_dir: str | Path | None = None,
         otlp_endpoint: str | None = None,
+        agent_name: str | None = None,
+        agent_id: str | None = None,
+        agent_description: str | None = None,
     ) -> None:
         assert output_dir or otlp_endpoint, "At least one collector (output_dir or otlp_endpoint) required"
+        _logger.info(f"Creating _AgentTracer: service={service_name}, output_dir={output_dir}, otlp_endpoint={otlp_endpoint}")
 
         self.output_dir: Path | None = None
-        self._provider = TracerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
+        resource_attrs = {SERVICE_NAME: service_name}
+
+        default_agent_id = agent_id or agent_name or uuid4().hex
+        resource_attrs[GEN_AI_AGENT_NAME] = agent_name or default_agent_id
+        resource_attrs[GEN_AI_AGENT_ID] = agent_id or default_agent_id
+        if agent_description is not None:
+            resource_attrs[GEN_AI_AGENT_DESCRIPTION] = agent_description
+
+        self._provider = TracerProvider(resource=Resource.create(resource_attrs))
 
         if output_dir:
             self.output_dir = Path(output_dir)
@@ -98,7 +140,9 @@ class _AgentTracer:
 
 
     def shutdown(self) -> None:
+        _logger.info("Shutting down tracer and flushing spans")
         self._provider.shutdown()
+        _logger.info("Tracer shutdown complete")
 
 
 def _set_traceparent_env() -> None:
@@ -115,7 +159,6 @@ def _get_parent_ctx_env() -> Context | None:
 
 
 def get_trace_env_vars() -> dict[str, str]:
-    # This helper is used only mainly by ray to propagate parameters to the workers.
     env_vars = {}
     if tp := os.environ.get(ENV_TRACEPARENT):
         env_vars[ENV_TRACEPARENT] = tp
@@ -165,8 +208,10 @@ def get_tracer(
     service_name: str,
     output_dir: str | Path | None = None,
     otlp_endpoint: str | None = None,
+    agent_name: str | None = None,
+    agent_id: str | None = None,
+    agent_description: str | None = None,
 ) -> _AgentTracer | _NoOpTracer:
-    # Code params override env vars
     output_dir = output_dir or os.environ.get(ENV_TRACE_OUTPUT)
     otlp_endpoint = otlp_endpoint or os.environ.get(ENV_OTLP_ENDPOINT)
 
@@ -175,5 +220,8 @@ def get_tracer(
             service_name=service_name,
             output_dir=output_dir,
             otlp_endpoint=otlp_endpoint,
+            agent_name=agent_name,
+            agent_id=agent_id,
+            agent_description=agent_description,
         )
     return _NoOpTracer()

--- a/src/agentlab2/tool.py
+++ b/src/agentlab2/tool.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, List, get_protocol_members
 
 from agentlab2.core import Action, ActionSchema, Content, Observation, TypedBaseModel
+from agentlab2.metrics.tracer import GEN_AI_TOOL_CALL_RESULT, tool_span
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class Tool(AbstractTool):
     """
     Base class for tool that implements an action space protocol.
 
-    :var Returns: Description
+    :var action_space: Protocol defining the actions this tool supports
     """
 
     action_space: Any
@@ -59,11 +60,16 @@ class Tool(AbstractTool):
 
     def execute_action(self, action: Action) -> Observation:
         fn = self.get_action_method(action)
-        try:
-            action_result = fn(**action.arguments) or "Success"
-        except Exception as e:
-            action_result = f"Error executing action {action.name}: {e}"
-            logger.exception(action_result)
+
+        with tool_span(action) as span:
+            try:
+                action_result = fn(**action.arguments) or "Success"
+            except Exception as e:
+                action_result = f"Error executing action {action.name}: {e}"
+                logger.exception(action_result)
+
+            span.set_attribute(GEN_AI_TOOL_CALL_RESULT, str(action_result))
+
         return Observation(contents=[Content(data=action_result, tool_call_id=action.id)])
 
     @property

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -128,7 +128,7 @@ class TestLLM:
         assert result.content == "Hello! How can I help?"
 
     @patch("agentlab2.llm.completion_with_retries")
-    def test_llm_call_with_tools(self, mock_completion, sample_llm_config):
+    def test_llm_call_with_tools(self, mock_completion, sample_llm_config) -> None:
         """Test LLM call with tools."""
         mock_message = MagicMock()
         mock_message.tool_calls = [MagicMock(function=MagicMock(name="search", arguments='{"query": "test"}'))]
@@ -147,7 +147,6 @@ class TestLLM:
         assert call_kwargs["tools"] == tools
         assert result.tool_calls is not None
         assert result.content == "Tool call made."
-
 
 class TestLLMCall:
     """Tests for LLMCall class."""

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,6 +1,7 @@
 """Tests for agentlab2.tool module."""
 
 from typing import Protocol, runtime_checkable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -191,3 +192,61 @@ class TestTool:
         assert "btn1" in results[0]
         assert "btn2" in results[1]
         assert "test" in results[2]
+
+
+class TestToolExecutionSpans:
+    """Tests for tool execution OpenTelemetry spans following GenAI conventions.
+
+    Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+    """
+
+    @patch("agentlab2.metrics.tracer._tool_tracer")
+    def test_execute_action_creates_span(self, mock_tracer, mock_tool) -> None:
+        """Test that execute_action creates a span with correct name and kind."""
+        mock_span = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = Action(name="click", arguments={"element_id": "btn1"})
+        mock_tool.execute_action(action)
+
+        mock_tracer.start_as_current_span.assert_called_once()
+        call_args = mock_tracer.start_as_current_span.call_args
+        assert call_args[0][0] == "execute_tool click"
+        from opentelemetry.trace import SpanKind
+        assert call_args[1]["kind"] == SpanKind.INTERNAL
+
+    @patch("agentlab2.metrics.tracer._tool_tracer")
+    def test_execute_action_sets_required_attributes(self, mock_tracer, mock_tool) -> None:
+        """Test that execute_action sets required GenAI tool attributes."""
+        mock_span = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = Action(id="call_123", name="click", arguments={"element_id": "btn1"})
+        mock_tool.execute_action(action)
+
+        set_attr_calls = {call[0][0]: call[0][1] for call in mock_span.set_attribute.call_args_list}
+        assert set_attr_calls["gen_ai.tool.name"] == "click"
+        assert set_attr_calls["gen_ai.tool.call.id"] == "call_123"
+        assert set_attr_calls["gen_ai.tool.call.arguments"] == '{"element_id": "btn1"}'
+        assert set_attr_calls["gen_ai.tool.call.result"] == "Clicked on btn1"
+
+    @patch("agentlab2.metrics.tracer._tool_tracer")
+    def test_execute_action_traces_error_result(self, mock_tracer, mock_tool) -> None:
+        """Test that error results are traced."""
+        mock_span = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+        def raise_error(element_id: str) -> str:
+            raise ValueError("Element not found")
+
+        mock_tool.click = raise_error
+
+        action = Action(name="click", arguments={"element_id": "nonexistent"})
+        mock_tool.execute_action(action)
+
+        set_attr_calls = {call[0][0]: call[0][1] for call in mock_span.set_attribute.call_args_list}
+        assert "Error executing action click" in set_attr_calls["gen_ai.tool.call.result"]
+        assert "Element not found" in set_attr_calls["gen_ai.tool.call.result"]


### PR DESCRIPTION
## Summary

Use LiteLLM's built-in OpenTelemetry callback instead of manual span creation for LLM calls. This leverages LiteLLM's comprehensive GenAI semantic conventions support (~50+ attributes including tokens, cost, latency).

**Key changes:**

- Enable LiteLLM OTEL via `litellm.callbacks = ["otel"]`
- Set `USE_OTEL_LITELLM_REQUEST_SPAN=true` so LiteLLM creates its own `litellm_request` span (prevents async callback timing issues)
- Add tool execution spans with GenAI semantic attributes
- Always trace tool I/O (arguments and results) for full observability
- Log reward as float and forward empty agent_description
- Remove auth_code handling from tracer (unused)

**Span hierarchy after this change:**
```
episode
└── step/turn_N (reward, done, agent_output, env_output)
    ├── litellm_request (LiteLLM manages: gen_ai.*, tokens, cost)
    └── execute_tool (gen_ai.tool.name, arguments, result)
```

Before (main):
<img width="3814" height="1206" alt="image" src="https://github.com/user-attachments/assets/cb1190ee-f47f-4970-9d1e-3858b4145611" />

Now (with tools and native llmlite):
<img width="3814" height="1866" alt="image" src="https://github.com/user-attachments/assets/151f9c04-bcbd-48d8-8101-dffd00e5fbae" />


**Reference:** https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/

## Test plan

- [x] Unit tests pass (177 tests)
- [x] Integration test with 2 MiniWob tasks
- [x] Verified traces in Jaeger UI