### PR TITLE
Fix Ray tracing consumer spans export

### DIFF
--- a/src/agentlab2/episode.py
+++ b/src/agentlab2/episode.py
@@ -2,10 +2,11 @@ import logging
 import time
 from pathlib import Path
 
+from opentelemetry.trace import Span
 from termcolor import colored
 
 from agentlab2.agent import AgentConfig
-from agentlab2.core import AgentOutput, Trajectory, TrajectoryStep
+from agentlab2.core import AgentOutput, EnvironmentOutput, Trajectory, TrajectoryStep
 from agentlab2.environment import EnvConfig
 from agentlab2.metrics.tracer import get_tracer
 from agentlab2.storage import FileStorage, Storage
@@ -36,6 +37,17 @@ class Episode:
         self.exp_name = exp_name
         self.max_steps = max_steps
         self.storage = storage or FileStorage(output_dir)
+
+    def _record_step_attributes(
+        self,
+        span: Span,
+        agent_output: AgentOutput,
+        env_output: EnvironmentOutput,
+    ) -> None:
+        span.set_attribute("agent_output", agent_output.model_dump_json())
+        span.set_attribute("env_output", env_output.model_dump_json())
+        span.set_attribute("done", env_output.done)
+        span.set_attribute("reward", env_output.reward)
 
     def run(self) -> Trajectory:
         """Main loop to run the agent on a single specific task.
@@ -77,10 +89,7 @@ class Episode:
                         env_step = TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time())
                         self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
                         trajectory.steps.append(env_step)
-                        span.set_attribute("agent_output", agent_output.model_dump_json())
-                        span.set_attribute("env_output", env_output.model_dump_json())
-                        span.set_attribute("done", env_output.done)
-                        span.set_attribute("reward", env_output.reward)
+                        self._record_step_attributes(span, agent_output, env_output)
                         turns += 1
                 trajectory.end_time = time.time()
                 self.storage.save_trajectory(trajectory)  # save final trajectory with end_time

--- a/src/agentlab2/metrics/tracer.py
+++ b/src/agentlab2/metrics/tracer.py
@@ -134,6 +134,11 @@ class _AgentTracer:
             yield span
 
     def shutdown(self) -> None:
+        """Shutdown the tracer provider.
+
+        Note: The provider is shared. Only call once per process. Calling
+        shutdown() multiple times will cause errors on subsequent calls.
+        """
         _logger.info("Shutting down tracer and flushing spans")
         self._provider.shutdown()
         _logger.info("Tracer shutdown complete")


### PR DESCRIPTION
## Summary

Fix Ray OpenTelemetry integration so consumer spans (`ray.remote_worker`) are properly exported to collectors (Jaeger, disk).

**The problem:** Ray's tracing wrapper creates consumer spans but doesn't properly end them when the task function returns, causing them not to be exported.

**The fix:** Manually end Ray's consumer span in a `traced_task()` context manager before the task returns.

## Changes

- Add `provider.py` - shared TracerProvider factory that reuses Ray's existing provider
- Add `ray_tracing.py` - `setup_tracing()` hook, `traced_task()` context manager, `get_ray_tracing_config()` helper
- Update `exp_runner.py` - use `traced_task` wrapper, add `_tracing_startup_hook` to ray.init
- Refactor `tracer.py` - use shared provider, fix `_get_parent_ctx_env()` to check `is_recording()` first
- Add observation data (`pruned_html`, `done`, `success`) to OTLP step spans

## Trace hierarchy

```
experiment (main process)
└── ray.remote (producer span)
    └── ray.remote_worker (consumer span) ← now properly exported
        └── episode_task-123 (our span)
```

## Known limitations for Bench integration

The following are not yet implemented:

1. **Screenshots** - `episode.py` only sends string data, images are excluded:
   ```python
   if content.name and isinstance(content.data, str):
       span.set_attribute(content.name, content.data)
   ```
   Need to serialize PIL images to base64 and send them.

2. **Task display name** - `al2.task_display_name` attribute not set on episode spans

3. **Episode success status** - Currently derived from OTEL span status code, not explicit attribute. May need to call `span.set_status()` on episode completion.

## Test plan

- [x] Run `uv run pytest tests/` - all 198 tests pass
- [x] Run `recipes/test_ray_tracing_simple.py` with Jaeger running
- [x] Verify spans appear in Jaeger with correct parent-child hierarchy
- [ ] Run `recipes/miniwob_bench.py` and verify traces appear in Bench

Closes #100
Closes #54 (partially, for now)