### PR TITLE
Capture per-episode logs for viewer integration

### DIFF
--- a/src/agentlab2/episode_logs.py
+++ b/src/agentlab2/episode_logs.py
@@ -1,0 +1,64 @@
+"""Helpers for per-episode logging."""
+
+import logging
+import sys
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Iterator, TextIO
+
+LOG_FORMAT = "[%(levelname)s] %(asctime)s - %(name)s:%(lineno)d %(funcName)s() - %(message)s"
+
+
+class _TeeWriter:
+    """Write the same output to multiple text streams."""
+
+    def __init__(self, *writers: TextIO) -> None:
+        self.writers = writers
+
+    def write(self, data: str) -> int:
+        for writer in self.writers:
+            writer.write(data)
+        return len(data)
+
+    def flush(self) -> None:
+        for writer in self.writers:
+            writer.flush()
+
+
+def trajectory_log_id(task_id: str, episode_id: int) -> str:
+    """Build a stable trajectory identifier used by storage and logs."""
+    return f"{task_id}_ep{episode_id}"
+
+
+def get_log_path(output_dir: str | Path, trajectory_id: str) -> Path:
+    """Return log file path for a trajectory."""
+    return Path(output_dir) / "logs" / f"{trajectory_id}.log"
+
+
+@contextmanager
+def redirect_output_to_log(
+    log_file: Path,
+    *,
+    append: bool,
+    tee: bool,
+    log_format: str = LOG_FORMAT,
+) -> Iterator[None]:
+    """Capture stdout/stderr into a log file and reconfigure logging stream."""
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    mode = "a" if append else "w"
+
+    with log_file.open(mode, buffering=1) as log_stream:
+        output_writer: TextIO = log_stream
+        error_writer: TextIO = log_stream
+        if tee:
+            output_writer = _TeeWriter(original_stdout, log_stream)
+            error_writer = _TeeWriter(original_stderr, log_stream)
+
+        with redirect_stdout(output_writer), redirect_stderr(error_writer):  # type: ignore[type-var]
+            logging.basicConfig(level=logging.INFO, format=log_format, stream=error_writer, force=True)
+            try:
+                yield
+            finally:
+                logging.basicConfig(level=logging.INFO, format=log_format, stream=original_stderr, force=True)

--- a/src/agentlab2/exp_runner.py
+++ b/src/agentlab2/exp_runner.py
@@ -1,49 +1,19 @@
 """Run experiments with Ray or sequentially."""
 
 import logging
-import sys
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Iterator, TextIO
 from uuid import uuid4
 
 import ray
 
 from agentlab2.core import Trajectory
 from agentlab2.episode import Episode
+from agentlab2.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from agentlab2.experiment import Experiment, ExpResult
 from agentlab2.metrics.tracer import get_trace_env_vars, get_tracer
 
-LOG_FORMAT = "[%(levelname)s] %(asctime)s - %(name)s:%(lineno)d %(funcName)s() - %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
-
-
-class TeeWriter:
-    def __init__(self, *writers: TextIO) -> None:
-        self.writers = writers
-
-    def write(self, data: str) -> int:
-        for writer in self.writers:
-            writer.write(data)
-        return len(data)
-
-    def flush(self) -> None:
-        for writer in self.writers:
-            writer.flush()
-
-
-@contextmanager
-def tee_to_file(log_file: Path) -> Iterator[None]:
-    original_stdout = sys.stdout
-    original_stderr = sys.stderr
-    with log_file.open("w") as f:
-        tee_out = TeeWriter(original_stdout, f)
-        tee_err = TeeWriter(original_stderr, f)
-        with redirect_stdout(tee_out), redirect_stderr(tee_err):  # type: ignore[type-var]
-            logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, stream=tee_err, force=True)
-            yield
-    logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, stream=original_stderr, force=True)
 
 
 def _extract_model(exp: Experiment) -> str | None:
@@ -78,18 +48,15 @@ def run_with_ray(
 
 def _run_with_ray_impl(exp: Experiment, n_cpus: int, ray_poll_timeout: float) -> ExpResult:
     exp.save_config()
-    log_dir = Path(exp.output_dir) / "logs"
 
     @ray.remote
     def run_episode(episode: Episode) -> Trajectory:
-        trajectory_id = f"{episode.config.task_id}_ep{episode.config.id}"
-        log_file = log_dir / f"{trajectory_id}.log"
-        sys.stdout = sys.stderr = log_file.open("a", buffering=1)
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, stream=sys.stdout, force=True)
-        return episode.run()
+        trajectory_id = trajectory_log_id(episode.config.task_id, episode.config.id)
+        log_file = get_log_path(exp.output_dir, trajectory_id)
+        with redirect_output_to_log(log_file, append=True, tee=False, log_format=LOG_FORMAT):
+            return episode.run()
 
     if not ray.is_initialized():
-        log_dir.mkdir(parents=True, exist_ok=True)
         ray.init(
             num_cpus=n_cpus,
             dashboard_host="0.0.0.0",
@@ -162,8 +129,6 @@ def run_sequentially(
 
 def _run_sequentially_impl(exp: Experiment, debug_limit: int | None) -> ExpResult:
     exp.save_config()
-    log_dir = Path(exp.output_dir) / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
     exp.benchmark.setup()
     try:
         episodes = exp.get_episodes_to_run()
@@ -172,9 +137,9 @@ def _run_sequentially_impl(exp: Experiment, debug_limit: int | None) -> ExpResul
             episodes = episodes[:debug_limit]
         trajectories = []
         for episode in episodes:
-            trajectory_id = f"{episode.config.task_id}_ep{episode.config.id}"
-            log_file = log_dir / f"{trajectory_id}.log"
-            with tee_to_file(log_file):
+            trajectory_id = trajectory_log_id(episode.config.task_id, episode.config.id)
+            log_file = get_log_path(exp.output_dir, trajectory_id)
+            with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
                 trajectories.append(episode.run())
         results = ExpResult(
             tasks_num=len(episodes),

--- a/src/agentlab2/storage.py
+++ b/src/agentlab2/storage.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 from pydantic import BaseModel
 
 from agentlab2.core import AgentOutput, Trajectory, TrajectoryStep
+from agentlab2.episode_logs import get_log_path as get_episode_log_path
 
 if TYPE_CHECKING:
     from agentlab2.episode import EpisodeConfig
@@ -198,7 +199,7 @@ class FileStorage:
         return step_data
 
     def get_log_path(self, trajectory_id: str) -> Path:
-        return self.output_dir / "logs" / f"{trajectory_id}.log"
+        return get_episode_log_path(self.output_dir, trajectory_id)
 
     def load_logs(self, trajectory_id: str) -> str:
         log_path = self.get_log_path(trajectory_id)

--- a/src/agentlab2/viewer.py
+++ b/src/agentlab2/viewer.py
@@ -434,17 +434,17 @@ def run_viewer(results_dir: Path, debug: bool = False, port: int | None = None, 
 
         return exp_stats, traj_data, first_traj
 
-    def on_select_trajectory(evt: gr.SelectData, traj_table: Any) -> StepId | None:
+    def on_select_trajectory(evt: gr.SelectData, traj_table: Any) -> TrajectoryId | None:
         """Handle trajectory selection from table."""
         if traj_table is None or len(traj_table) == 0:
             return None
 
         row = evt.index[0]
-        traj_id = traj_table.iloc[row, 0]
-        state.select_trajectory(traj_id)
-        return StepId(trajectory_id=TrajectoryId(trajectory_name=traj_id), step=0)
+        traj_name = traj_table.iloc[row, 0]
+        state.select_trajectory(traj_name)
+        return TrajectoryId(exp_dir=str(state.current_exp_dir) if state.current_exp_dir else None, trajectory_name=traj_name)
 
-    def new_trajectory(traj_id: TrajectoryId) -> StepId:
+    def new_trajectory(traj_id: TrajectoryId | None) -> StepId:
         """Handle new trajectory selection."""
         if traj_id and traj_id.trajectory_name:
             state.select_trajectory(traj_id.trajectory_name)
@@ -953,7 +953,7 @@ def run_viewer(results_dir: Path, debug: bool = False, port: int | None = None, 
         trajectory_table.select(
             fn=on_select_trajectory,
             inputs=trajectory_table,
-            outputs=step_id,
+            outputs=traj_id,
         )
 
         traj_id.change(fn=new_trajectory, inputs=traj_id, outputs=step_id)

--- a/tests/test_episode_logs.py
+++ b/tests/test_episode_logs.py
@@ -1,0 +1,54 @@
+"""Tests for agentlab2.episode_logs."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from agentlab2.episode_logs import get_log_path, redirect_output_to_log, trajectory_log_id
+
+
+def test_trajectory_log_id() -> None:
+    """Test trajectory log naming convention."""
+    assert trajectory_log_id("my_task", 7) == "my_task_ep7"
+
+
+def test_get_log_path(tmp_path: Path) -> None:
+    """Test log path construction."""
+    assert get_log_path(tmp_path, "traj_1") == tmp_path / "logs" / "traj_1.log"
+
+
+def test_redirect_output_to_log_restores_logging_on_exception(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test logger stream restoration even when body raises."""
+    log_file = tmp_path / "logs" / "traj_exception.log"
+    test_logger = logging.getLogger("tests.episode_logs")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with redirect_output_to_log(log_file, append=False, tee=True):
+            print("stdout-before-error")
+            test_logger.info("inside-context")
+            raise RuntimeError("boom")
+
+    test_logger.info("outside-context")
+    captured = capsys.readouterr()
+    assert "outside-context" in captured.err
+    assert "I/O operation on closed file" not in captured.err
+
+    content = log_file.read_text()
+    assert "stdout-before-error" in content
+    assert "inside-context" in content
+    assert "outside-context" not in content
+
+
+def test_redirect_output_to_log_append_mode(tmp_path: Path) -> None:
+    """Test append mode preserves previous log output."""
+    log_file = tmp_path / "logs" / "traj_append.log"
+
+    with redirect_output_to_log(log_file, append=False, tee=False):
+        print("first-line")
+    with redirect_output_to_log(log_file, append=True, tee=False):
+        print("second-line")
+
+    assert log_file.read_text() == "first-line\nsecond-line\n"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -154,6 +154,39 @@ class TestFileStorageWithSteps:
             storage.save_step(TrajectoryStep(output=sample_env_output), "unknown_traj", 0)
 
 
+class TestFileStorageLogs:
+    """Tests for per-episode log helpers in FileStorage."""
+
+    def test_get_log_path(self, tmp_dir: Path) -> None:
+        """Test that log path uses logs/{trajectory_id}.log convention."""
+        storage = FileStorage(tmp_dir)
+
+        log_path = storage.get_log_path("task_a_ep3")
+
+        assert log_path == Path(tmp_dir) / "logs" / "task_a_ep3.log"
+
+    def test_load_logs_returns_full_file_contents(self, tmp_dir: Path) -> None:
+        """Test that load_logs returns complete log file content."""
+        storage = FileStorage(tmp_dir)
+        log_path = storage.get_log_path("task_b_ep1")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("line 1\nline 2\nline 3\n")
+
+        loaded = storage.load_logs("task_b_ep1")
+
+        assert loaded == "line 1\nline 2\nline 3\n"
+        assert storage.has_logs("task_b_ep1") is True
+
+    def test_load_logs_missing_file(self, tmp_dir: Path) -> None:
+        """Test missing log file handling."""
+        storage = FileStorage(tmp_dir)
+
+        loaded = storage.load_logs("missing_ep0")
+
+        assert loaded == ""
+        assert storage.has_logs("missing_ep0") is False
+
+
 class TestFileStorageWithLLMCalls:
     """Tests for FileStorage LLM call extraction."""
 


### PR DESCRIPTION
## Summary
- Writes episode logs to `output_dir/logs/{trajectory_id}.log` matching the trajectory ID
- Sequential mode: `TeeWriter` tees stdout/stderr to both console and log file
- Ray mode: redirects worker stdout/stderr to log file with trajectory-aligned naming
- Connects with existing `storage.load_logs()` / `has_logs()` and viewer's "Episode Logs" tab

Supersedes #52 — the storage/viewer/TrajectoryStep parts of that PR already landed on main separately. This PR extracts just the missing log-capture feature.

Closes #38