### PR TITLE
fix: avoid splitting tool_call/tool_result pairs in compact_history

### DIFF
--- a/src/agentlab2/agents/react.py
+++ b/src/agentlab2/agents/react.py
@@ -127,12 +127,23 @@ class ReactAgent(Agent):
             short_tokens = self.token_counter(messages=self.history)
             logger.info(f"Compacted history from {tokens} to {short_tokens} tokens.")
 
+    def _get_role(self, msg: dict | Message) -> str:
+        if isinstance(msg, dict):
+            return msg.get("role", "")
+        return getattr(msg, "role", "")
+
     def compact_history(self):
         """
         Compact the history by summarizing the first half of messages with the LLM.
         Updates self.history in place by replacing the first half with the summary message.
         """
         midpoint = len(self.history) // 2
+        # Advance past any tool messages to avoid splitting tool_call/tool_result pairs
+        while midpoint < len(self.history) and self._get_role(self.history[midpoint]) == "tool":
+            midpoint += 1
+        if midpoint >= len(self.history):
+            logger.warning("compact_history: could not find a clean split point, skipping compaction.")
+            return
         first_half = self.history[:midpoint]
         second_half = self.history[midpoint:]
         messages = [


### PR DESCRIPTION
## Summary

- `compact_history()` in `ReactAgent` split the history at a midpoint that could fall between an assistant `tool_calls` message and its corresponding `tool` result messages
- The LLM API (Azure OpenAI) rejects such prompts with a 400 error: *"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'"*
- LiteLLM maps this to a `ContentPolicyViolationError`, causing the episode to crash

## Fix

- Added `_get_role()` helper to safely extract the role from either a `dict` or `litellm.Message`
- After picking the initial midpoint, advance it forward past any `tool` role messages to ensure the split always lands on a clean turn boundary
- If no clean split point can be found (degenerate case), log a warning and skip compaction instead of crashing

## Test plan

- [ ] Run WorkArena experiment with parallel workers — `ContentPolicyViolationError` during history compaction should no longer appear
- [ ] Unit test: construct a history where the midpoint lands on a `tool` message, call `compact_history()`, assert it completes without error and the prompt sent to the LLM ends with a non-tool-call assistant or user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)