### PR TITLE
refactor: rename ActionSubset to ActionSpace in WorkArenaTask

### DIFF
--- a/src/agentlab2/benchmarks/workarena/task.py
+++ b/src/agentlab2/benchmarks/workarena/task.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 from termcolor import colored
 
 from agentlab2.action_spaces.browser_action_space import BidBrowserActionSpace
-from agentlab2.core import ActionSchema, ActionSubset, Observation, Task
+from agentlab2.core import ActionSchema, ActionSpace, Observation, Task
 from agentlab2.tools.browsergym import BrowsergymTool
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class WorkArenaTask(Task):
     """
 
     validate_per_step: bool = True
-    supported_actions: ActionSubset = (
+    supported_actions: ActionSpace = ActionSpace(
         BidBrowserActionSpace.browser_press_key,
         BidBrowserActionSpace.browser_type,
         BidBrowserActionSpace.browser_click,


### PR DESCRIPTION
## Summary

- `WorkArenaTask` was importing and using `ActionSubset` from `agentlab2.core`, which has been renamed to `ActionSpace`
- Updates the import and the `supported_actions` field type annotation accordingly
- Wraps the tuple of supported actions in `ActionSpace()` to match the new type

## Test plan

- [ ] Verify `WorkArenaBenchmark` instantiates correctly with the updated type
- [ ] Run a WorkArena episode end-to-end and confirm action filtering works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)