### PR TITLE
feat: accumulate summary info and stats at every step (#148)

### DIFF
--- a/src/agentlab2/episode.py
+++ b/src/agentlab2/episode.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import Self
+from typing import Callable, Self
 
 from opentelemetry.trace import Span, StatusCode
 from termcolor import colored
@@ -56,6 +56,7 @@ class Episode:
         self.env_config = env_config
         self.storage = storage or FileStorage(output_dir)
         self.allow_overwrite = False
+        self.on_step_saved: Callable[[Path, Trajectory], None] | None = None
 
     @classmethod
     def load_episode_from_config(cls, config_path: Path, benchmark) -> Self:
@@ -137,6 +138,8 @@ class Episode:
                     start_time=start_time,
                 )
                 self.storage.save_trajectory(trajectory, allow_overwrite=self.allow_overwrite)
+                if self.on_step_saved is not None:
+                    self.on_step_saved(self.config.output_dir, trajectory)
                 logger.info(colored(f"Start env output: {env_output}", "blue"))
                 turns = 0
                 while not env_output.done and turns < self.config.max_steps:
@@ -150,12 +153,16 @@ class Episode:
                             agent_step = TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time())
                             self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
                             trajectory.steps.append(agent_step)
+                            if self.on_step_saved is not None:
+                                self.on_step_saved(self.config.output_dir, trajectory)
                             raise e
 
                         self.log_agent_output(turns, agent_output)
                         agent_step = TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time())
                         self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
                         trajectory.steps.append(agent_step)
+                        if self.on_step_saved is not None:
+                            self.on_step_saved(self.config.output_dir, trajectory)
 
                         env_ts = time.time()
                         try:
@@ -167,17 +174,23 @@ class Episode:
                             env_step = TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time())
                             self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
                             trajectory.steps.append(env_step)
+                            if self.on_step_saved is not None:
+                                self.on_step_saved(self.config.output_dir, trajectory)
                             raise e
 
                         logger.info(colored(f"Turn {turns} Env output: {env_output}", "blue"))
                         env_step = TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time())
                         self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
                         trajectory.steps.append(env_step)
+                        if self.on_step_saved is not None:
+                            self.on_step_saved(self.config.output_dir, trajectory)
                         self._record_step_attributes(span, agent_output, env_output)
                         turns += 1
                 trajectory.end_time = time.time()
                 trajectory.reward_info = {"reward": env_output.reward, "done": env_output.done, **env_output.info}
                 self.storage.save_trajectory(trajectory)
+                if self.on_step_saved is not None:
+                    self.on_step_saved(self.config.output_dir, trajectory)
                 logger.info(colored(f"Episode completed in {turns} turns, reward: {env_output.reward}", "blue"))
                 final_reward = trajectory.last_env_step().reward
                 status = StatusCode.OK if final_reward > 0 else StatusCode.ERROR

--- a/src/agentlab2/exp_runner.py
+++ b/src/agentlab2/exp_runner.py
@@ -11,6 +11,7 @@ from agentlab2.episode import Episode
 from agentlab2.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from agentlab2.experiment import Experiment, ExpResult
 from agentlab2.metrics.tracer import get_trace_env_vars, get_tracer
+from agentlab2.summary_info import get_global_accumulator
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
@@ -71,6 +72,7 @@ def _run_with_ray_impl(exp: Experiment, n_cpus: int, ray_poll_timeout: float) ->
         ref_to_id = {run_episode.remote(episode): episode.config.task_id for episode in episodes}
         logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
         results = _poll_ray(exp, ref_to_id, ray_poll_timeout)
+        get_global_accumulator().flush(exp.output_dir)
         exp.print_stats(results)
         return results
     finally:
@@ -97,6 +99,7 @@ def _poll_ray(exp: Experiment, ref_to_id: dict[ray.ObjectRef, str], ray_poll_tim
                 traj: Trajectory = ray.get(task_ref)
                 logger.info(f"Completed trajectory for task {task_id} with {len(traj.steps)} steps")
                 results.trajectories[task_id] = traj
+                get_global_accumulator().update(exp.output_dir, traj)
             except Exception as e:
                 logger.exception(f"Run failed with exception: {e}")
                 results.failures[task_id] = str(e)
@@ -135,8 +138,10 @@ def _run_sequentially_impl(exp: Experiment, debug_limit: int | None) -> ExpResul
         if debug_limit is not None:
             logger.info(f"Running only first {debug_limit} episodes for debugging")
             episodes = episodes[:debug_limit]
+        acc = get_global_accumulator()
         trajectories = []
         for episode in episodes:
+            episode.on_step_saved = lambda out_dir, traj: acc.update(out_dir, traj)
             trajectory_id = trajectory_log_id(episode.config.task_id, episode.config.id)
             log_file = get_log_path(exp.output_dir, trajectory_id)
             with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
@@ -147,6 +152,7 @@ def _run_sequentially_impl(exp: Experiment, debug_limit: int | None) -> ExpResul
             config=exp.config,
             exp_id=f"{exp.name}_{uuid4().hex}",
         )
+        acc.flush(exp.output_dir)
         exp.print_stats(results)
         return results
     finally:

--- a/src/agentlab2/summary_info.py
+++ b/src/agentlab2/summary_info.py
@@ -1,0 +1,255 @@
+"""Accumulate and save experiment summary info (Issue #148).
+
+Saves cumulative statistics at every step to summary_info.json so the viewer
+and users get a quick overview without loading full trajectories. Saving is
+non-blocking so the main loop is not slowed by I/O.
+"""
+
+import json
+import logging
+import threading
+from pathlib import Path
+from queue import Empty, Queue
+
+from agentlab2.core import AgentOutput, EnvironmentOutput, Trajectory, TrajectoryStep
+from agentlab2.llm import Usage
+
+logger = logging.getLogger(__name__)
+
+SUMMARY_FILENAME = "summary_info.json"
+
+
+def _safe_float(value: object) -> float:
+    if value is None:
+        return float("nan")
+    if isinstance(value, (int, float)):
+        return float(value)
+    return float("nan")
+
+
+def _safe_int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def extract_step_stats(step: TrajectoryStep) -> dict[str, float | int | None]:
+    """Extract numeric and error stats from a single step for aggregation.
+
+    Returns a flat dict of stat keys to values. Agent steps contribute
+    usage stats (prompt_tokens, completion_tokens, total_tokens, cost);
+    env steps contribute reward, done. Errors contribute err_msg and stack_trace
+    as non-numeric fields (handled separately in summary).
+    """
+    stats: dict[str, float | int | None] = {}
+    out = step.output
+
+    if isinstance(out, EnvironmentOutput):
+        stats["reward"] = out.reward
+        stats["done"] = 1.0 if out.done else 0.0
+        if out.error:
+            stats["error_type"] = out.error.error_type  # store as sentinel; aggregate can count
+    elif isinstance(out, AgentOutput):
+        prompt_tokens = 0
+        completion_tokens = 0
+        total_tokens = 0
+        cost = 0.0
+        for llm_call in out.llm_calls:
+            u: Usage = getattr(llm_call, "usage", None) or Usage()
+            prompt_tokens += _safe_int(getattr(u, "prompt_tokens", 0))
+            completion_tokens += _safe_int(getattr(u, "completion_tokens", 0))
+            total_tokens += _safe_int(getattr(u, "total_tokens", 0))
+            cost += _safe_float(getattr(u, "cost", 0.0))
+        stats["prompt_tokens"] = prompt_tokens
+        stats["completion_tokens"] = completion_tokens
+        stats["total_tokens"] = total_tokens
+        stats["cost"] = cost
+        if out.error:
+            stats["error_type"] = out.error.error_type
+
+    return stats
+
+
+def aggregate_stats(step_stats_list: list[dict[str, float | int | None]]) -> dict[str, float | int | None]:
+    """Aggregate step stats: compute sum and max per key (stats-agnostic).
+
+    For each numeric key we produce cum_<key> (sum) and max_<key> (max).
+    None/NaN are skipped in sum/max. Returns a dict suitable for summary_info.
+    """
+    if not step_stats_list:
+        return {"cum_steps": 0}
+
+    # Collect values per key (skip non-numeric and error_type)
+    key_to_values: dict[str, list[float]] = {}
+    for d in step_stats_list:
+        for key, val in d.items():
+            if key == "error_type":
+                continue
+            if val is None:
+                continue
+            try:
+                f = float(val) if not isinstance(val, (int, float)) else float(val)
+            except (TypeError, ValueError):
+                continue
+            if key not in key_to_values:
+                key_to_values[key] = []
+            key_to_values[key].append(f)
+
+    aggregated: dict[str, float | int | None] = {
+        "cum_steps": len(step_stats_list),
+    }
+
+    for key, values in key_to_values.items():
+        if not values:
+            continue
+        # Use standard library; avoid numpy dependency
+        valid = [v for v in values if v == v]  # drop nan
+        if valid:
+            aggregated[f"cum_{key}"] = sum(valid)
+            aggregated[f"max_{key}"] = max(valid)
+
+    return aggregated
+
+
+def _last_error_from_trajectory(trajectory: Trajectory) -> tuple[str | None, str | None]:
+    """Get err_msg and stack_trace from the last step that has an error."""
+    err_msg: str | None = None
+    stack_trace: str | None = None
+    for step in reversed(trajectory.steps):
+        out = step.output
+        err = getattr(out, "error", None)
+        if err is not None:
+            err_msg = getattr(err, "exception_str", None) or str(err)
+            stack_trace = getattr(err, "stack_trace", None)
+            break
+    return err_msg, stack_trace
+
+
+def build_summary_info(
+    trajectories: list[Trajectory],
+    err_msg: str | None = None,
+    stack_trace: str | None = None,
+) -> dict:
+    """Build the summary_info dict from a list of trajectories (cumulative so far)."""
+    all_step_stats: list[dict[str, float | int | None]] = []
+    n_steps = 0
+    cum_reward = 0.0
+    last_done = False
+    last_truncated = False
+
+    for traj in trajectories:
+        for step in traj.steps:
+            st = extract_step_stats(step)
+            all_step_stats.append(st)
+            if "reward" in st:
+                cum_reward += _safe_float(st["reward"]) if st["reward"] is not None else 0.0
+        n_steps += len(traj.steps)
+        if traj.steps:
+            last_out = traj.steps[-1].output
+            if isinstance(last_out, EnvironmentOutput):
+                last_done = last_out.done
+                last_truncated = last_out.info.get("truncated", False) if last_out.info else False
+        if err_msg is None and stack_trace is None:
+            err_msg, stack_trace = _last_error_from_trajectory(traj)
+
+    summary: dict = {
+        "n_steps": n_steps,
+        "n_trajectories": len(trajectories),
+        "cum_reward": cum_reward,
+        "err_msg": err_msg,
+        "stack_trace": stack_trace,
+        "terminated": last_done,
+        "truncated": last_truncated,
+    }
+
+    agg = aggregate_stats(all_step_stats)
+    for key, val in agg.items():
+        if val is not None and (val == val):  # not nan
+            summary[f"stats.{key}"] = val
+
+    return summary
+
+
+def save_summary_info_sync(output_dir: Path, summary: dict) -> None:
+    """Write summary_info.json to output_dir (blocking)."""
+    path = Path(output_dir) / SUMMARY_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=4)
+
+
+class SummaryAccumulator:
+    """Maintains cumulative stats per output_dir and writes summary_info.json non-blocking."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._trajectories_by_dir: dict[Path, list[Trajectory]] = {}
+        self._write_queue: Queue[tuple[Path, list[Trajectory]]] = Queue()
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
+    def update(self, output_dir: Path, trajectory: Trajectory) -> None:
+        """Record the current state of this trajectory and queue a non-blocking write.
+
+        Call this after each save_step or save_trajectory. We merge this trajectory
+        into the in-memory list for this output_dir (by id), then enqueue a write.
+        """
+        output_dir = Path(output_dir).resolve()
+        with self._lock:
+            if output_dir not in self._trajectories_by_dir:
+                self._trajectories_by_dir[output_dir] = []
+            trajs = self._trajectories_by_dir[output_dir]
+            # Replace or append by trajectory id
+            existing_ids = {t.id for t in trajs}
+            if trajectory.id in existing_ids:
+                trajs = [t if t.id != trajectory.id else trajectory for t in trajs]
+            else:
+                trajs = list(trajs) + [trajectory]
+            self._trajectories_by_dir[output_dir] = trajs
+            self._write_queue.put((output_dir, list(trajs)))
+
+    def _worker_loop(self) -> None:
+        while True:
+            try:
+                output_dir, trajectories = self._write_queue.get(timeout=1.0)
+            except Empty:
+                continue
+            try:
+                summary = build_summary_info(trajectories)
+                save_summary_info_sync(output_dir, summary)
+                logger.debug(f"Wrote {SUMMARY_FILENAME} to {output_dir}")
+            except Exception as e:
+                logger.warning(f"Failed to write summary_info: {e}")
+
+    def flush(self, output_dir: Path | None = None) -> None:
+        """Drain the write queue for the given dir (or all). Blocking."""
+        to_flush: list[tuple[Path, list[Trajectory]]] = []
+        while True:
+            try:
+                d, t = self._write_queue.get_nowait()
+                if output_dir is None or Path(d).resolve() == Path(output_dir).resolve():
+                    to_flush.append((d, t))
+            except Empty:
+                break
+        for d, t in to_flush:
+            try:
+                save_summary_info_sync(d, build_summary_info(t))
+            except Exception as e:
+                logger.warning(f"Failed to write summary_info: {e}")
+
+
+# Module-level accumulator for sequential runs; workers can use their own
+_accumulator: SummaryAccumulator | None = None
+_accumulator_lock = threading.Lock()
+
+
+def get_global_accumulator() -> SummaryAccumulator:
+    with _accumulator_lock:
+        global _accumulator
+        if _accumulator is None:
+            _accumulator = SummaryAccumulator()
+        return _accumulator

--- a/tests/test_summary_info.py
+++ b/tests/test_summary_info.py
@@ -1,0 +1,85 @@
+"""Tests for agentlab2.summary_info (Issue #148)."""
+
+from pathlib import Path
+
+import pytest
+
+from agentlab2.core import EnvironmentOutput, Observation, Trajectory, TrajectoryStep
+from agentlab2.summary_info import (
+    SUMMARY_FILENAME,
+    aggregate_stats,
+    build_summary_info,
+    extract_step_stats,
+    save_summary_info_sync,
+)
+
+
+def test_extract_step_stats_env_step() -> None:
+    obs = Observation.from_text("test")
+    env_out = EnvironmentOutput(obs=obs, reward=0.5, done=False)
+    step = TrajectoryStep(output=env_out)
+    stats = extract_step_stats(step)
+    assert stats["reward"] == 0.5
+    assert stats["done"] == 0.0
+
+
+def test_extract_step_stats_env_step_done() -> None:
+    obs = Observation.from_text("test")
+    env_out = EnvironmentOutput(obs=obs, reward=1.0, done=True)
+    step = TrajectoryStep(output=env_out)
+    stats = extract_step_stats(step)
+    assert stats["reward"] == 1.0
+    assert stats["done"] == 1.0
+
+
+def test_aggregate_stats_empty() -> None:
+    assert aggregate_stats([]) == {"cum_steps": 0}
+
+
+def test_aggregate_stats_single_step() -> None:
+    stats_list = [{"reward": 0.5, "done": 0.0}]
+    agg = aggregate_stats(stats_list)
+    assert agg["cum_steps"] == 1
+    assert agg["cum_reward"] == 0.5
+    assert agg["max_reward"] == 0.5
+
+
+def test_aggregate_stats_multiple_steps() -> None:
+    stats_list = [
+        {"reward": 0.0, "prompt_tokens": 10, "completion_tokens": 5},
+        {"reward": 0.5, "prompt_tokens": 20, "completion_tokens": 10},
+    ]
+    agg = aggregate_stats(stats_list)
+    assert agg["cum_steps"] == 2
+    assert agg["cum_reward"] == 0.5
+    assert agg["cum_prompt_tokens"] == 30
+    assert agg["cum_completion_tokens"] == 15
+    assert agg["max_prompt_tokens"] == 20
+    assert agg["max_completion_tokens"] == 10
+
+
+def test_build_summary_info_single_trajectory() -> None:
+    obs = Observation.from_text("x")
+    env_out = EnvironmentOutput(obs=obs, reward=0.5, done=False)
+    traj = Trajectory(
+        id="t1",
+        steps=[TrajectoryStep(output=env_out)],
+        metadata={"task_id": "task1"},
+    )
+    summary = build_summary_info([traj])
+    assert summary["n_steps"] == 1
+    assert summary["n_trajectories"] == 1
+    assert summary["cum_reward"] == 0.5
+    assert "stats.cum_steps" in summary
+    assert summary["terminated"] is False
+
+
+def test_save_summary_info_sync(tmp_path: Path) -> None:
+    summary = {"n_steps": 1, "cum_reward": 0.5}
+    save_summary_info_sync(tmp_path, summary)
+    path = tmp_path / SUMMARY_FILENAME
+    assert path.exists()
+    import json
+    data = json.loads(path.read_text())
+    assert data["n_steps"] == 1
+    assert data["cum_reward"] == 0.5


### PR DESCRIPTION
- Add summary_info module: extract_step_stats, aggregate_stats (stats-agnostic), build_summary_info, save_summary_info_sync, SummaryAccumulator (non-blocking)
- Hook Episode.on_step_saved after each save_step/save_trajectory
- Wire accumulator in exp_runner (sequential + Ray), flush at end
- Add tests in test_summary_info.py

Click the `Preview` tab and select a PR template:

- [Docs/Website-only change](?expand=1&template=docs_website_pr.md)
- [Other change](?expand=1&template=general_code_pr.md)

[//]: # (Dumb that we have to do this hack, see https://github.com/orgs/community/discussions/4620 for progress on github fixing this)