### PR TITLE
fix: xray experiment selection requires double-click

### DIFF
--- a/src/agentlab2/analyze/xray.py
+++ b/src/agentlab2/analyze/xray.py
@@ -1321,7 +1321,7 @@ def run_xray(
             bg_timer,
         ]
 
-        exp_table.input(fn=on_experiments_change, inputs=exp_table, outputs=_hierarchy_outputs)
+        exp_table.change(fn=on_experiments_change, inputs=exp_table, outputs=_hierarchy_outputs)
         exp_refresh_btn.click(fn=_exp_table_value, outputs=exp_table)
         exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs])
 


### PR DESCRIPTION
## Summary

- `DataFrame.input` fires immediately on click but passes the **old** value (before the checkbox toggle is committed). On the first click, `selected_names=[]` matched the initial `state._selected_exp_names=[]`, triggering the early-return `gr.skip()` — so nothing happened and the user had to click, unclick, then click again.
- Changed to `DataFrame.change`, which fires after the value is committed and sends the correct checked state.
- The existing duplicate-fire guard (`set(selected_names) == set(state._selected_exp_names)`) handles any spurious `.change` triggers from the Refresh button gracefully.

## Test plan

- [ ] Open xray viewer with at least one experiment in the results dir
- [ ] Click an experiment checkbox — hierarchy (Agents/Tasks/Seeds tabs) should populate immediately on the first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)