### PR TITLE
Otel: Include a valid episode UUID in episode spans, and make tracer testable.

### DIFF
--- a/src/cube_harness/metrics/processor.py
+++ b/src/cube_harness/metrics/processor.py
@@ -9,6 +9,7 @@ from cube_harness.metrics.store import JsonlSpanWriter
 CH_TYPE = "ch.type"
 CH_NAME = "ch.name"
 CH_EXPERIMENT = "ch.experiment"
+CH_EPISODE = "ch.episode"
 
 TYPE_EXPERIMENT = "experiment"
 TYPE_EPISODE = "episode"

--- a/src/cube_harness/metrics/tracer.py
+++ b/src/cube_harness/metrics/tracer.py
@@ -3,22 +3,30 @@ import logging
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Protocol, override
 from uuid import uuid4
 
 import litellm
 from cube.core import Action
-from opentelemetry import trace
+from opentelemetry import baggage, context, trace
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.propagate import extract, inject
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import SpanKind
 
 from cube_harness.metrics.disk_exporter import DiskSpanExporter
-from cube_harness.metrics.processor import CH_EXPERIMENT, CH_NAME, CH_TYPE, TYPE_EPISODE, TYPE_EXPERIMENT, TYPE_STEP
+from cube_harness.metrics.processor import (
+    CH_EPISODE,
+    CH_EXPERIMENT,
+    CH_NAME,
+    CH_TYPE,
+    TYPE_EPISODE,
+    TYPE_EXPERIMENT,
+    TYPE_STEP,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -43,6 +51,16 @@ GEN_AI_TOOL_CALL_RESULT = "gen_ai.tool.call.result"
 _tool_tracer = trace.get_tracer(__name__)
 
 
+class _EpisodeBaggageSpanProcessor(SpanProcessor):
+    """Stamps the episode ID baggage value as a span attribute on every span."""
+
+    @override
+    def on_start(self, span: trace.Span, parent_context: Context | None = None) -> None:
+        episode_id = baggage.get_baggage(CH_EPISODE, context=parent_context)
+        if episode_id is not None:
+            span.set_attribute(CH_EPISODE, str(episode_id))
+
+
 @contextmanager
 def tool_span(action: Action) -> Iterator[trace.Span]:
     """Create a span for tool execution with GenAI semantic attributes."""
@@ -53,58 +71,26 @@ def tool_span(action: Action) -> Iterator[trace.Span]:
         yield span
 
 
+class Tracer(Protocol):
+    @contextmanager
+    def benchmark(self, name: str) -> Iterator[trace.Span]: ...
+    @contextmanager
+    def episode(self, name: str, experiment: str | None = None) -> Iterator[trace.Span]: ...
+    @contextmanager
+    def step(self, name: str) -> Iterator[trace.Span]: ...
+    @contextmanager
+    def span(self, name: str) -> Iterator[trace.Span]: ...
+    def log(self, data: dict[str, Any], name: str = "step") -> None: ...
+    def shutdown(self) -> None: ...
+
+
 class _AgentTracer:
     """Internal tracer. Use get_tracer() to create instances."""
 
-    def __init__(
-        self,
-        service_name: str,
-        output_dir: str | Path | None = None,
-        otlp_endpoint: str | None = None,
-        agent_name: str | None = None,
-        agent_id: str | None = None,
-        agent_description: str | None = None,
-        model: str | None = None,
-    ) -> None:
-        assert output_dir or otlp_endpoint, "At least one collector (output_dir or otlp_endpoint) required"
-        _logger.info(
-            f"Creating _AgentTracer: service={service_name}, output_dir={output_dir}, otlp_endpoint={otlp_endpoint}"
-        )
-
-        self.output_dir: Path | None = None
-        resource_attrs = {SERVICE_NAME: service_name}
-
-        default_agent_id = agent_id or agent_name or uuid4().hex
-        resource_attrs[GEN_AI_AGENT_NAME] = agent_name or default_agent_id
-        resource_attrs[GEN_AI_AGENT_ID] = agent_id or default_agent_id
-        if agent_description is not None:
-            resource_attrs[GEN_AI_AGENT_DESCRIPTION] = agent_description
-        if model:
-            resource_attrs[GEN_AI_REQUEST_MODEL] = model
-            os.environ[RAY_ENV_MODEL] = model
-        os.environ[RAY_ENV_AGENT_NAME] = resource_attrs[GEN_AI_AGENT_NAME]
-
-        self._provider = TracerProvider(resource=Resource.create(resource_attrs))
-
-        if output_dir:
-            self.output_dir = Path(output_dir)
-            self.output_dir.mkdir(parents=True, exist_ok=True)
-            self._provider.add_span_processor(BatchSpanProcessor(DiskSpanExporter(self.output_dir)))
-            os.environ[RAY_ENV_TRACE_OUTPUT] = str(self.output_dir)
-
-        if otlp_endpoint:
-            os.environ[RAY_ENV_OTLP_ENDPOINT] = otlp_endpoint
-            self._provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
-
-        # Set as global provider so OTEL-instrumented libraries emit spans into this trace
-        trace.set_tracer_provider(self._provider)
-
-        # Enable litellm OTEL callback now that a proper TracerProvider is configured.
-        # This must happen after set_tracer_provider() to avoid ConsoleSpanExporter fallback.
-        os.environ["USE_OTEL_LITELLM_REQUEST_SPAN"] = "true"
-        litellm.callbacks = ["otel"]
-
-        self._tracer = self._provider.get_tracer(__name__)
+    def __init__(self, provider: TracerProvider, output_dir: Path | None = None) -> None:
+        self.output_dir = output_dir
+        self._provider = provider
+        self._tracer = provider.get_tracer(__name__)
         self._current_experiment: str | None = None
 
     @contextmanager
@@ -127,12 +113,18 @@ class _AgentTracer:
     ) -> Iterator[trace.Span]:
         exp = experiment or self._current_experiment or "default"
         parent_ctx = _get_parent_ctx_env()
+        episode_id = str(uuid4())
 
-        with self._tracer.start_as_current_span(name, context=parent_ctx) as span:
-            span.set_attribute(CH_TYPE, TYPE_EPISODE)
-            span.set_attribute(CH_NAME, name)
-            span.set_attribute(CH_EXPERIMENT, exp)
-            yield span
+        ctx = baggage.set_baggage(CH_EPISODE, episode_id, context=parent_ctx)
+        token = context.attach(ctx)
+        try:
+            with self._tracer.start_as_current_span(name) as span:
+                span.set_attribute(CH_TYPE, TYPE_EPISODE)
+                span.set_attribute(CH_NAME, name)
+                span.set_attribute(CH_EXPERIMENT, exp)
+                yield span
+        finally:
+            context.detach(token)
 
     @contextmanager
     def step(self, name: str) -> Iterator[trace.Span]:
@@ -217,6 +209,11 @@ class _NoOpTracer:
         pass
 
 
+def make_tracer(provider: TracerProvider, output_dir: Path | None = None) -> Tracer:
+    provider.add_span_processor(_EpisodeBaggageSpanProcessor())
+    return _AgentTracer(provider, output_dir=output_dir)
+
+
 def get_tracer(
     service_name: str,
     output_dir: str | Path | None = None,
@@ -225,20 +222,49 @@ def get_tracer(
     agent_id: str | None = None,
     agent_description: str | None = None,
     model: str | None = None,
-) -> _AgentTracer | _NoOpTracer:
+) -> Tracer:
     output_dir = output_dir or os.environ.get(RAY_ENV_TRACE_OUTPUT)
     otlp_endpoint = otlp_endpoint or os.environ.get(RAY_ENV_OTLP_ENDPOINT)
     model = model or os.environ.get(RAY_ENV_MODEL)
     agent_name = agent_name or os.environ.get(RAY_ENV_AGENT_NAME)
 
-    if output_dir or otlp_endpoint:
-        return _AgentTracer(
-            service_name=service_name,
-            output_dir=output_dir,
-            otlp_endpoint=otlp_endpoint,
-            agent_name=agent_name,
-            agent_id=agent_id,
-            agent_description=agent_description,
-            model=model,
-        )
-    return _NoOpTracer()
+    if not (output_dir or otlp_endpoint):
+        return _NoOpTracer()
+
+    _logger.info(
+        f"Creating _AgentTracer: service={service_name}, output_dir={output_dir}, otlp_endpoint={otlp_endpoint}"
+    )
+
+    resource_attrs: dict[str, str] = {SERVICE_NAME: service_name}
+    default_agent_id = agent_id or agent_name or uuid4().hex
+    resource_attrs[GEN_AI_AGENT_NAME] = agent_name or default_agent_id
+    resource_attrs[GEN_AI_AGENT_ID] = agent_id or default_agent_id
+    if agent_description is not None:
+        resource_attrs[GEN_AI_AGENT_DESCRIPTION] = agent_description
+    if model:
+        resource_attrs[GEN_AI_REQUEST_MODEL] = model
+        os.environ[RAY_ENV_MODEL] = model
+    os.environ[RAY_ENV_AGENT_NAME] = resource_attrs[GEN_AI_AGENT_NAME]
+
+    provider = TracerProvider(resource=Resource.create(resource_attrs))
+
+    resolved_output_dir: Path | None = None
+    if output_dir:
+        resolved_output_dir = Path(output_dir)
+        resolved_output_dir.mkdir(parents=True, exist_ok=True)
+        provider.add_span_processor(BatchSpanProcessor(DiskSpanExporter(resolved_output_dir)))
+        os.environ[RAY_ENV_TRACE_OUTPUT] = str(resolved_output_dir)
+
+    if otlp_endpoint:
+        os.environ[RAY_ENV_OTLP_ENDPOINT] = otlp_endpoint
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+
+    # Set as global provider so OTEL-instrumented libraries emit spans into this trace
+    trace.set_tracer_provider(provider)
+
+    # Enable litellm OTEL callback now that a proper TracerProvider is configured.
+    # This must happen after set_tracer_provider() to avoid ConsoleSpanExporter fallback.
+    os.environ["USE_OTEL_LITELLM_REQUEST_SPAN"] = "true"
+    litellm.callbacks = ["otel"]
+
+    return make_tracer(provider, output_dir=resolved_output_dir)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,100 @@
+from collections.abc import Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+from cube_harness.metrics.processor import CH_EPISODE
+from cube_harness.metrics.tracer import Tracer, make_tracer
+
+
+class _CollectingExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+
+def _make_test_tracer() -> tuple[Tracer, _CollectingExporter]:
+    exporter = _CollectingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = make_tracer(provider)
+    return tracer, exporter
+
+
+def test_step_span_has_episode_id() -> None:
+    tracer, exporter = _make_test_tracer()
+    with tracer.episode("ep1"):
+        with tracer.step("step1"):
+            pass
+    tracer.shutdown()
+
+    step_span = next(s for s in exporter.spans if s.name == "step1")
+    episode_span = next(s for s in exporter.spans if s.name == "ep1")
+
+    assert step_span.attributes is not None
+    assert episode_span.attributes is not None
+    assert step_span.attributes[CH_EPISODE] is not None
+    assert step_span.attributes[CH_EPISODE] == episode_span.attributes[CH_EPISODE]
+
+
+def test_episode_span_has_episode_id() -> None:
+    tracer, exporter = _make_test_tracer()
+    with tracer.episode("ep1"):
+        pass
+    tracer.shutdown()
+
+    episode_span = next(s for s in exporter.spans if s.name == "ep1")
+    assert episode_span.attributes is not None
+    assert episode_span.attributes[CH_EPISODE] is not None
+
+
+def test_sequential_episodes_have_distinct_ids() -> None:
+    tracer, exporter = _make_test_tracer()
+    with tracer.episode("ep1"):
+        pass
+    with tracer.episode("ep2"):
+        pass
+    tracer.shutdown()
+
+    ep1 = next(s for s in exporter.spans if s.name == "ep1")
+    ep2 = next(s for s in exporter.spans if s.name == "ep2")
+    assert ep1.attributes is not None
+    assert ep2.attributes is not None
+    assert ep1.attributes[CH_EPISODE] != ep2.attributes[CH_EPISODE]
+
+
+def test_baggage_does_not_leak_across_episodes() -> None:
+    tracer, exporter = _make_test_tracer()
+    with tracer.episode("ep1"):
+        with tracer.step("step1"):
+            pass
+    with tracer.episode("ep2"):
+        with tracer.step("step2"):
+            pass
+    tracer.shutdown()
+
+    ep1 = next(s for s in exporter.spans if s.name == "ep1")
+    step1 = next(s for s in exporter.spans if s.name == "step1")
+    ep2 = next(s for s in exporter.spans if s.name == "ep2")
+    step2 = next(s for s in exporter.spans if s.name == "step2")
+
+    assert ep1.attributes is not None
+    assert ep2.attributes is not None
+    assert step1.attributes is not None
+    assert step2.attributes is not None
+    assert step1.attributes[CH_EPISODE] == ep1.attributes[CH_EPISODE]
+    assert step2.attributes[CH_EPISODE] == ep2.attributes[CH_EPISODE]
+    assert step1.attributes[CH_EPISODE] != step2.attributes[CH_EPISODE]
+
+
+def test_span_outside_episode_has_no_episode_id() -> None:
+    tracer, exporter = _make_test_tracer()
+    with tracer.step("orphan"):
+        pass
+    tracer.shutdown()
+
+    orphan = next(s for s in exporter.spans if s.name == "orphan")
+    assert CH_EPISODE not in (orphan.attributes or {})


### PR DESCRIPTION
## Description of Changes

Within a single otel trace we can have more than one task (very much expected) as well as more than one run for the same task (seeded with different values).

If a single batch of otel spans is taken in isolation, or if the top-level episode span is lost due to a system error or the benchmark crashing, it's impossible to know which top-level (`TYPE_EPISODE`) span each step refers to.

This change propagates a unique `CH_EPISODE` UUID (via otel's context baggage) to all descendants of an episode span. This makes it trivial to group together spans for the same episode without further context.

To make this testable, I had to shuffle around the tracing code so the bulk of the logic is self-contained, and global state is changed in some controlled points. Functionally, there should be no change to the existing code path.

## Related Issues

(Internal) fixes https://github.com/silverstream-ai/silver_stream/issues/3821.

## Testing Performed

* Added `tests/test_tracer.py` with 5 tests covering: episode ID on step spans, episode ID on episode spans, distinct IDs across sequential episodes, no baggage leaking between episodes, and no episode ID on spans outside an episode.
* Full test suite passes (666 tests).

## Code Changes

* Main feature:
  - Added `_EpisodeBaggageSpanProcessor` — a span processor that copies `CH_EPISODE` from otel baggage into span attributes.
  - `episode()` now generates a UUID and sets it as context baggage before creating the span.
* Testing refactor:
  - Extracted `_AgentTracer.__init__` to only take a `TracerProvider`.
  - Added `make_tracer(provider)` as the public factory for creating a tracer from a provider.
  - `get_tracer()` now builds the provider, registers exporters, sets global state, then delegates to `make_tracer()`.
  - Added `Tracer` protocol so tests can type against the public interface.

## Example Usage

```python
# Production (unchanged)
tracer = get_tracer("my-service", output_dir="/tmp/traces")

# Testing — no global state touched
provider = TracerProvider()
provider.add_span_processor(SimpleSpanProcessor(my_exporter))
tracer = make_tracer(provider)
```

## Checklist

* [ ] All new functions have been documented in the `docs/` directory (no user facing stuff, it's implementation details)
* [x] Unit tests have been added for new functions
* [x] Code follows the existing style and convention
* [x] API keys or sensitive information have been removed

## Constitution Compliance

* [x] No imports inside functions/classes (Pillar II: Explicitness)
* [x] No global mutable state (Pillar II: Explicitness)
* [x] All functions have type hints (Pillar V: Code Craft)
* [x] Breaking API changes have RFC reference (Pillar I: Team Contract) — N/A, no breaking changes
* [x] Uses standard integrations - LiteLLM, MCP, ADP (Pillar IV: Protocol Strategy)
* [x] New features work in single-process mode (Pillar III: Scalable Research)

## Additional Context

The `_EpisodeBaggageSpanProcessor` follows the standard otel pattern: baggage propagates through context, a span processor reads it on `on_start` and stamps it as an attribute. This is how otel expects baggage-to-attribute propagation to work — baggage doesn't land on spans automatically.
