### PR TITLE
feat: OSWorld QEMU VM backend abstraction

### DIFF
--- a/cubes/osworld-cube/README.md
+++ b/cubes/osworld-cube/README.md
@@ -35,6 +35,7 @@ uv pip install -e .
 
 ```python
 from osworld_cube import OSWorldTask, ComputerConfig
+from osworld_cube.vm_backend import OSWorldQEMUVMBackend
 from cube.task import TaskMetadata
 
 task = OSWorldTask(
@@ -49,7 +50,8 @@ task = OSWorldTask(
             "related_apps": [],
         },
     ),
-    tool_config=ComputerConfig(provider="docker"),
+    tool_config=ComputerConfig(),
+    vm_backend=OSWorldQEMUVMBackend(),
 )
 
 obs, info = task.reset()
@@ -65,9 +67,11 @@ task.close()
 
 ```python
 from osworld_cube import OSWorldBenchmark, ComputerConfig
+from osworld_cube.vm_backend import OSWorldQEMUVMBackend
 
 bench = OSWorldBenchmark(
-    default_tool_config=ComputerConfig(provider="docker"),
+    default_tool_config=ComputerConfig(),
+    vm_backend=OSWorldQEMUVMBackend(),
 )
 bench.setup()
 for task_config in bench.get_task_configs():
@@ -195,9 +199,16 @@ python -m osworld_cube.debug
 ```
 src/osworld_cube/
 ├── __init__.py       # Public exports
-├── computer.py       # ComputerBase, Computer13, PyAutoGUIComputer, ComputerConfig
+├── computer.py       # Re-exports from cube_computer_tool; sets osworld-cube cache default
 ├── task.py           # OSWorldTask
 ├── benchmark.py      # OSWorldBenchmark, OSWorldTaskConfig
 ├── axtree.py         # Accessibility tree parsing and Set-of-Marks annotation
-└── debug.py          # get_debug_task_configs, make_debug_agent
+├── debug.py          # get_debug_task_configs, make_debug_agent
+└── vm_backend/       # QEMU VM backend (auto-downloads OSWorld images from HuggingFace)
+    ├── __init__.py   # OSWorldQEMUVMBackend, ensure_base_image
+    ├── evaluator.py  # Task evaluation logic
+    ├── setup_controller.py  # VM setup/teardown
+    ├── pyautogui_utils.py   # PyAutoGUI helpers
+    ├── getters/      # Per-app state extractors (chrome, calc, file, gimp, …)
+    └── metrics/      # Per-app evaluation metrics (basic_os, chrome, docs, …)
 ```

--- a/cubes/osworld-cube/src/osworld_cube/benchmark.py
+++ b/cubes/osworld-cube/src/osworld_cube/benchmark.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Paths — rooted under CUBE_CACHE_DIR (default ~/.agentlab2)
+# Paths — rooted under CUBE_CACHE_DIR (default ~/.cube)
 # ---------------------------------------------------------------------------
 
 OSWORLD_BASE_DIR = _CUBE_CACHE_ROOT

--- a/cubes/osworld-cube/tests/test_run_osworld.py
+++ b/cubes/osworld-cube/tests/test_run_osworld.py
@@ -4,7 +4,7 @@ Integration test for OSWorldTask against a real desktop_env Docker VM.
 Requires:
   - Docker running and the OSWorld VM image available
   - desktop_env installed
-  - CUBE_CACHE_DIR set (or default ~/.agentlab2 used for VM storage)
+  - CUBE_CACHE_DIR set (or default ~/.cube used for VM storage)
 
 Run with:
   pytest tests/test_run_osworld.py -s -v

--- a/recipes/osworld/eval_osworld.py
+++ b/recipes/osworld/eval_osworld.py
@@ -5,7 +5,7 @@ the linearized accessibility tree for element coordinates, without screenshots
 or Set-of-Marks scaffolding.
 
 Prerequisites:
-    OSWorld repo cloned to ~/.agentlab2/OSWorld/
+    OSWorld repo cloned to ~/.cube/OSWorld/
     (auto-cloned on first run if missing)
 
 Usage:

--- a/recipes/osworld/haiku.py
+++ b/recipes/osworld/haiku.py
@@ -10,7 +10,7 @@ v2: Updated system prompt — adds sudo password, environment context, and tips 
 the OSWorld reference prompt (home dir, curl vs wget, zoom, large-output handling, date).
 
 Prerequisites:
-    OSWorld repo cloned to ~/.agentlab2/OSWorld/
+    OSWorld repo cloned to ~/.cube/OSWorld/
     (auto-cloned on first run if missing)
 
 Usage:


### PR DESCRIPTION
## Summary

- Replaces the `desktop_env` third-party dependency with a bare QEMU/KVM backend (`qemu-system-x86_64` + qcow2 overlays)
- VM lifecycle managed via `QEMUManager` (start/stop/reset with QMP), guest communication via `GuestAgent` HTTP client to Flask server in the VM
- Lazy-loading `__getattr__` in `vm_backend/getters/__init__.py` and `metrics/__init__.py` so heavy eval deps are not imported at startup
- `OSWorldBenchmark` gains `test_set_path` field for test isolation
- `setup_controller.py` proxy pool code replaced with `NotImplementedError` (AWS-specific, not applicable to bare QEMU)
- Recipe `eval_osworld.py` cleaned up: removed stale `provider="docker"` field

## Eval Results with Haiku Genny

<img width="1244" height="169" alt="Screenshot 2026-03-17 at 6 31 39 PM" src="https://github.com/user-attachments/assets/f330f3a3-3974-43c0-b6fc-3b32a54d515b" />

Eval on TEST_SMALL, leaderboard value is 50%

## Test plan

- [x] `uv run pytest tests/test_osworld.py tests/test_cube.py -v` → 38/38 pass
- [x] `uv run python -m osworld_cube.debug` → both debug tasks complete with `reward=1.0`
- [x] KVM acceleration auto-detected (~14s boot); overlays provide clean reset without full reboot
- [x] Reproduce best scores on TEST_SMALL, matching osworld-cube
- [x] Update the target branch to main, rebase or create a merge commit to get the latest changes from main and test. 