### PR TITLE
fix(browsergym): surface infeasible action errors and last_action_error

### DIFF
--- a/src/cube_harness/tools/browsergym.py
+++ b/src/cube_harness/tools/browsergym.py
@@ -145,6 +145,7 @@ class BrowsergymTool(ToolWithTelemetry, BrowserTool, BidBrowserActionSpace):
         """Execute a BrowserGym action string and return result message."""
         logger.info(f"Execute bgym step: {action_str}")
         result = "Success"
+        infeasible_messages: list[str] = []
 
         try:
             code = self._action_set.to_python_code(action_str)
@@ -152,9 +153,14 @@ class BrowsergymTool(ToolWithTelemetry, BrowserTool, BidBrowserActionSpace):
                 code=code,
                 page=self.page,
                 send_message_to_user=lambda message: logger.info(f"BrowserGym message: {message}"),
-                report_infeasible_instructions=lambda message: logger.warning(f"Infeasible instruction: {message}"),
+                report_infeasible_instructions=lambda message: infeasible_messages.append(message),
             )
-            self._last_info = {"source": "action", "action": action_str, "action_error": ""}
+            if infeasible_messages:
+                error_msg = "; ".join(infeasible_messages)
+                self._last_info = {"source": "action", "action": action_str, "action_error": error_msg}
+                result = f"Failed (infeasible): {error_msg}"
+            else:
+                self._last_info = {"source": "action", "action": action_str, "action_error": ""}
         except Exception as e:
             error_msg = f"{type(e).__name__}: {e}"
             self._last_info = {"source": "action", "action": action_str, "action_error": error_msg}
@@ -369,6 +375,7 @@ class BrowsergymTool(ToolWithTelemetry, BrowserTool, BidBrowserActionSpace):
             "axtree_object": axtree,
             "extra_element_properties": extra_properties,
             "focused_element_bid": focused_element_bid,
+            "last_action_error": self._last_info.get("action_error", "") if self._last_info else "",
         }
         if self.config.use_screenshot:
             obs["screenshot"] = extract_screenshot(page)


### PR DESCRIPTION
## Summary

- **Bug 1**: `report_infeasible_instructions` callback in `_execute_bgym_step` was silently logging a warning — the agent received `"Success"` even when bgym reported an action as infeasible (e.g. bid doesn't exist). Now captured and returned as `"Failed (infeasible): ..."`.
- **Bug 2**: `last_action_error` was checked in `_bgym_obs_to_cube_obs` but never populated by `_extract_bgym_obs`, making it dead code. Now populated from `_last_info["action_error"]`.

## Context

When comparing cube-harness's `BrowsergymTool._execute_bgym_step()` against browsergym's native `BrowserEnv.step()`, these two error propagation paths were missing. This likely explains why agents never see bgym-level errors during runs.

## Test plan

- [ ] Run a MiniWoB or WorkArena task that triggers an invalid BID — verify agent receives `"Failed (infeasible): ..."` instead of `"Success"`
- [ ] Verify `last_action_error` appears in observation contents after a failed action

🤖 Generated with [Claude Code](https://claude.com/claude-code)