### PR TITLE
feat: Atlas EvalLog — structured evaluation records for community-scale benchmarking

### DIFF
--- a/openspec/README.md
+++ b/openspec/README.md
@@ -21,6 +21,7 @@ breaking changes), see [cube-standard's openspec/README.md](https://github.com/T
 | Metrics / OTel | `src/cube_harness/metrics/` | [metrics/spec.md](specs/metrics/spec.md) |
 | XRay / Analyze | `src/cube_harness/analyze/` | [analyze/spec.md](specs/analyze/spec.md) |
 | MCP server | `src/cube_harness/mcp/` | [mcp/spec.md](specs/mcp/spec.md) |
+| EvalLog | `src/cube_harness/eval_log.py` | [eval_log/spec.md](specs/eval_log/spec.md) |
 
 Cross-repo: cube-harness consumes cube-standard's contracts (`Task`, `Benchmark`, `Tool`,
 `Resource`). When your change touches the base protocol, check cube-standard's spec first.

--- a/openspec/changes/atlas-eval-log/deltas.md
+++ b/openspec/changes/atlas-eval-log/deltas.md
@@ -69,12 +69,15 @@ No task re-instantiation; all data comes from persisted files.
 
 ```
 <output_dir>/
-├── experiment_record.json    ← ADDED: ExperimentRecord (once per experiment)
-├── eval_log.jsonl            ← ADDED: one EpisodeRecord JSON line per completed episode
+├── experiment_record.json                    ← ADDED: ExperimentRecord (once per experiment)
+└── episodes/
+    └── <trajectory_id>/
+        └── episode_record.json               ← ADDED: one per completed episode
 ```
 
 Written by `Experiment.export_eval_log()`. Not written automatically during runs;
-must be called explicitly post-experiment.
+must be called explicitly post-experiment. For ATLAS submission, call
+`eval_log.to_jsonl(path)` to assemble a flat JSONL from the per-trajectory records.
 
 ---
 

--- a/openspec/changes/atlas-eval-log/deltas.md
+++ b/openspec/changes/atlas-eval-log/deltas.md
@@ -1,0 +1,95 @@
+# Deltas — Atlas EvalLog
+
+Changes against current specs in `openspec/specs/`.
+
+---
+
+## `episode/spec.md`
+
+### MODIFIED — `Episode._run_loop`
+
+After `agent = self.config.agent_config.make(action_set)`, add:
+
+```python
+action_schemas = [a.as_dict() for a in action_set]
+```
+
+Add `"action_schemas": action_schemas` to `trajectory.metadata`:
+
+```python
+metadata={
+    "task_id": task_id,
+    "agent_name": agent_name,
+    "action_schemas": action_schemas,    # ← ADDED
+    **env_output.info,
+},
+```
+
+**Why:** action schemas are only available at `task.reset()` time. Persisting them in
+metadata lets `export_eval_log()` reconstruct `AgentInfo.tools` post-hoc without
+re-instantiating the task or environment.
+
+---
+
+## `experiment/spec.md`
+
+### ADDED — `Experiment.export_eval_log`
+
+```python
+def export_eval_log(
+    self,
+    output_path: Path | None = None,
+    git_cwd: str | None = None,
+) -> EvalLog
+```
+
+- Iterates `storage.list_trajectory_ids()`.
+- Builds one `TaskEvalRecord` per trajectory (reads action schemas from
+  `trajectory.metadata["action_schemas"]`).
+- Resolves `task_config` from the episode config index for `task_version_hash` and `seed`.
+- Writes to `output_path` or `<output_dir>/eval_log.jsonl` by default.
+- Returns the in-memory `EvalLog`.
+
+No task re-instantiation; all data comes from persisted files.
+
+---
+
+## `storage/spec.md`
+
+### ADDED — output file
+
+```
+<output_dir>/
+├── eval_log.jsonl    ← ADDED: one JSON line per completed episode
+```
+
+Written by `Experiment.export_eval_log()`. Not written automatically during runs;
+must be called explicitly post-experiment.
+
+---
+
+## New module — `eval_log/spec.md`
+
+### ADDED — `src/cube_harness/eval_log.py`
+
+Five public classes:
+
+| Class | Purpose |
+|---|---|
+| `UsageSummary` | Aggregated LLM token/cost stats across an episode |
+| `AgentInfo` | Agent descriptor: agent_id, config, tools, git provenance, dependency versions |
+| `TaskInfo` | Task descriptor: benchmark metadata, task_id, hash, seed, split, first_observation_text |
+| `TaskEvalRecord` | Complete episode record (task + agent + outcome + usage + declaration) |
+| `EvalLog` | JSONL collection with `save_jsonl` / `load_jsonl` / `append_record` |
+
+Key invariants:
+
+- `AgentInfo.agent_id` — SHA-256 of sorted serialized agent config JSON. Stable across
+  runs with the same config. Primary matrix row key for ATLAS.
+- `TaskInfo.task_version_hash` — SHA-256 of `TaskConfig.model_dump_json()`. Changes when
+  the task config changes, even if `task_id` stays the same. Detects silent benchmark drift.
+- `TaskInfo.first_observation_text` — extracted from the first `EnvironmentOutput` in the
+  trajectory (what the agent actually saw, not the static eval spec).
+- `TaskEvalRecord.declaration` — MNAR bias correction fields. Optional; required for ATLAS
+  community submissions.
+- JSONL format: one JSON object per line, no envelope, no cube-harness dependency to read.

--- a/openspec/changes/atlas-eval-log/deltas.md
+++ b/openspec/changes/atlas-eval-log/deltas.md
@@ -6,21 +6,24 @@ Changes against current specs in `openspec/specs/`.
 
 ## `episode/spec.md`
 
-### MODIFIED — `Episode._run_loop`
+### MODIFIED — `Episode.run` and `Episode._run_loop`
 
-After `agent = self.config.agent_config.make(action_set)`, add:
+`Episode.run` collects action schemas immediately after the agent is constructed and
+passes them via the `extra_metadata` parameter:
 
 ```python
-action_schemas = [a.as_dict() for a in action_set]
+extra_metadata = {"action_schemas": [a.as_dict() for a in action_set]}
+return self._run_loop(setup_fn, step_fn, close_fn, agent, extra_metadata=extra_metadata)
 ```
 
-Add `"action_schemas": action_schemas` to `trajectory.metadata`:
+`_run_loop` accepts `extra_metadata: dict | None = None` and merges it into
+`trajectory.metadata`:
 
 ```python
 metadata={
     "task_id": task_id,
     "agent_name": agent_name,
-    "action_schemas": action_schemas,    # ← ADDED
+    **(extra_metadata or {}),    # ← injects action_schemas
     **env_output.info,
 },
 ```

--- a/openspec/changes/atlas-eval-log/deltas.md
+++ b/openspec/changes/atlas-eval-log/deltas.md
@@ -39,7 +39,7 @@ re-instantiating the task or environment.
 ### MODIFIED — `Experiment.export_eval_log`
 
 Signature change: `output_path: Path | None` → `output_dir: Path | None` (now writes
-two files instead of one JSONL file).
+structured records instead of a single flat JSONL).
 
 ```python
 def export_eval_log(
@@ -56,7 +56,7 @@ def export_eval_log(
 - Resolves `task_config` from the episode config index for `task_version_hash` and `seed`.
 - Writes to `output_dir` or `self.output_dir` by default:
   - `experiment_record.json` — one JSON object
-  - `eval_log.jsonl` — one JSON line per episode
+  - `episodes/<trajectory_id>/episode_record.json` — one per episode
 - Returns the in-memory `EvalLog`.
 
 No task re-instantiation; all data comes from persisted files.
@@ -96,8 +96,8 @@ Eight public classes:
 | `JudgeOutput` | Per-episode judge assessment: difficulty, feasibility, failure root cause |
 | `Verifier` | Task verifier reference: GitHub URL + source code |
 | `ExperimentRecord` | Experiment-level record → `experiment_record.json` |
-| `EpisodeRecord` | Episode-level record → line in `eval_log.jsonl` |
-| `EvalLog` | Two-level container: `save(output_dir)` / `load(output_dir)` / `append_episode` |
+| `EpisodeRecord` | Episode-level record → `episodes/<id>/episode_record.json` |
+| `EvalLog` | Two-level container: `save(output_dir)` / `load(output_dir)` / `to_jsonl(path)` |
 
 Key invariants:
 
@@ -114,4 +114,5 @@ Key invariants:
 - `EpisodeRecord.tool_names` — read from `trajectory.metadata["action_schemas"]` at export
   time. Empty list for trajectories produced before this field was added.
 - `BenchmarkSubset` — automatically derived from the benchmark object; no user input required.
-- JSONL format: one JSON object per line, no envelope, no cube-harness dependency to read.
+- Per-trajectory storage: retried episodes overwrite stale records naturally since the new trajectory occupies the same directory.
+- `to_jsonl(path)`: submission helper that assembles a flat JSONL from all per-trajectory records. Output is one JSON object per line, no envelope, no cube-harness dependency to read.

--- a/openspec/changes/atlas-eval-log/deltas.md
+++ b/openspec/changes/atlas-eval-log/deltas.md
@@ -6,9 +6,9 @@ Changes against current specs in `openspec/specs/`.
 
 ## `episode/spec.md`
 
-### MODIFIED — `Episode.run` and `Episode._run_loop`
+### MODIFIED — `Episode.run`
 
-`Episode.run` collects action schemas immediately after the agent is constructed and
+`Episode.run` collects action schemas immediately after the action set is resolved and
 passes them via the `extra_metadata` parameter:
 
 ```python
@@ -23,34 +23,40 @@ return self._run_loop(setup_fn, step_fn, close_fn, agent, extra_metadata=extra_m
 metadata={
     "task_id": task_id,
     "agent_name": agent_name,
-    **(extra_metadata or {}),    # ← injects action_schemas
+    **(extra_metadata or {}),    # injects action_schemas
     **env_output.info,
 },
 ```
 
 **Why:** action schemas are only available at `task.reset()` time. Persisting them in
-metadata lets `export_eval_log()` reconstruct `AgentInfo.tools` post-hoc without
+metadata lets `export_eval_log()` reconstruct `EpisodeRecord.tool_names` post-hoc without
 re-instantiating the task or environment.
 
 ---
 
 ## `experiment/spec.md`
 
-### ADDED — `Experiment.export_eval_log`
+### MODIFIED — `Experiment.export_eval_log`
+
+Signature change: `output_path: Path | None` → `output_dir: Path | None` (now writes
+two files instead of one JSONL file).
 
 ```python
 def export_eval_log(
     self,
-    output_path: Path | None = None,
+    output_dir: Path | None = None,
     git_cwd: str | None = None,
 ) -> EvalLog
 ```
 
+- Builds one `ExperimentRecord` (agent info, benchmark metadata, git provenance).
 - Iterates `storage.list_trajectory_ids()`.
-- Builds one `TaskEvalRecord` per trajectory (reads action schemas from
+- Builds one `EpisodeRecord` per trajectory (reads action schemas from
   `trajectory.metadata["action_schemas"]`).
 - Resolves `task_config` from the episode config index for `task_version_hash` and `seed`.
-- Writes to `output_path` or `<output_dir>/eval_log.jsonl` by default.
+- Writes to `output_dir` or `self.output_dir` by default:
+  - `experiment_record.json` — one JSON object
+  - `eval_log.jsonl` — one JSON line per episode
 - Returns the in-memory `EvalLog`.
 
 No task re-instantiation; all data comes from persisted files.
@@ -59,11 +65,12 @@ No task re-instantiation; all data comes from persisted files.
 
 ## `storage/spec.md`
 
-### ADDED — output file
+### ADDED — output files
 
 ```
 <output_dir>/
-├── eval_log.jsonl    ← ADDED: one JSON line per completed episode
+├── experiment_record.json    ← ADDED: ExperimentRecord (once per experiment)
+├── eval_log.jsonl            ← ADDED: one EpisodeRecord JSON line per completed episode
 ```
 
 Written by `Experiment.export_eval_log()`. Not written automatically during runs;
@@ -75,24 +82,33 @@ must be called explicitly post-experiment.
 
 ### ADDED — `src/cube_harness/eval_log.py`
 
-Five public classes:
+Eight public classes:
 
 | Class | Purpose |
 |---|---|
 | `UsageSummary` | Aggregated LLM token/cost stats across an episode |
-| `AgentInfo` | Agent descriptor: agent_id, config, tools, git provenance, dependency versions |
-| `TaskInfo` | Task descriptor: benchmark metadata, task_id, hash, seed, split, first_observation_text |
-| `TaskEvalRecord` | Complete episode record (task + agent + outcome + usage + declaration) |
-| `EvalLog` | JSONL collection with `save_jsonl` / `load_jsonl` / `append_record` |
+| `AgentInfo` | Agent descriptor: agent_id, config, dependency versions, git provenance |
+| `BenchmarkSubset` | Benchmark subset descriptor for MNAR propensity correction |
+| `JudgeConfig` | Configuration of the LLM judge (optional) |
+| `JudgeOutput` | Per-episode judge assessment: difficulty, feasibility, failure root cause |
+| `Verifier` | Task verifier reference: GitHub URL + source code |
+| `ExperimentRecord` | Experiment-level record → `experiment_record.json` |
+| `EpisodeRecord` | Episode-level record → line in `eval_log.jsonl` |
+| `EvalLog` | Two-level container: `save(output_dir)` / `load(output_dir)` / `append_episode` |
 
 Key invariants:
 
 - `AgentInfo.agent_id` — SHA-256 of sorted serialized agent config JSON. Stable across
   runs with the same config. Primary matrix row key for ATLAS.
-- `TaskInfo.task_version_hash` — SHA-256 of `TaskConfig.model_dump_json()`. Changes when
-  the task config changes, even if `task_id` stays the same. Detects silent benchmark drift.
-- `TaskInfo.first_observation_text` — extracted from the first `EnvironmentOutput` in the
-  trajectory (what the agent actually saw, not the static eval spec).
-- `TaskEvalRecord.declaration` — MNAR bias correction fields. Optional; required for ATLAS
-  community submissions.
+- `AgentInfo` has no `tools` field — tools are episode-specific (same agent gets different
+  action sets on different tasks). See `EpisodeRecord.tool_names`.
+- `ExperimentRecord.experiment_id` — SHA-256(experiment_name + output_dir)[:16]. Stable
+  within a run; unique across different output directories.
+- `EpisodeRecord.experiment_id` — FK linking back to `ExperimentRecord`. Consistent across
+  all episode records in an experiment.
+- `EpisodeRecord.task_version_hash` — SHA-256 of `TaskConfig.model_dump_json()`. Detects
+  silent benchmark drift across submissions.
+- `EpisodeRecord.tool_names` — read from `trajectory.metadata["action_schemas"]` at export
+  time. Empty list for trajectories produced before this field was added.
+- `BenchmarkSubset` — automatically derived from the benchmark object; no user input required.
 - JSONL format: one JSON object per line, no envelope, no cube-harness dependency to read.

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -1,123 +1,133 @@
-# RFC: Atlas EvalLog — Structured Evaluation Records
+# RFC: Atlas EvalLog — Two-Level Structured Evaluation Records
 
 **Status:** DRAFT  
 **PR:** [#297](https://github.com/The-AI-Alliance/cube-harness/pull/297)  
 **Author:** Alexandre Lacoste  
-**Date:** 2026-04-27  
-**Related:** [EEE alignment doc](../../../../atlas/docs/agent_eval_record_proposal.md), PR #315 (episode-status)
+**Date:** 2026-04-28
 
 ---
 
 ## Problem
 
-cube-harness produces trajectories, but has no standard output format for the
-community matrix **M[agent, task] = reward** that the ATLAS project needs.
+cube-harness produces trajectories, but has no standard output format for the community
+matrix **M[agent, task] = reward** that the ATLAS project needs.
 
 Three concrete gaps:
 
 1. **No stable agent identity.** Two runs of the same agent config can't be matched
-   without re-reading the full config. ATLAS needs a stable row key that is cheap to
-   index.
+   without re-reading the full config. ATLAS needs a stable row key that is cheap to index.
 
 2. **Action schemas are ephemeral.** The action set given to the agent at runtime is
    never persisted. Post-hoc analysis (what tools did this agent have on this task?)
    requires re-instantiating the task — expensive and sometimes impossible.
 
 3. **No standardized episode export.** Downstream tools (ATLAS server, leaderboards,
-   other frameworks) each extract reward/cost/metadata differently from our trajectory
-   files. A single JSONL line per episode, readable without cube-harness, solves this.
+   other frameworks) each extract reward/cost/metadata differently from trajectory files.
 
 ---
 
 ## Scope
 
-- New module `eval_log.py` with five public classes: `UsageSummary`, `AgentInfo`,
-  `TaskInfo`, `TaskEvalRecord`, `EvalLog`.
-- `Episode._run_loop` stores `action_schemas` in `trajectory.metadata` so eval records
-  can be built post-hoc without re-instantiating tasks.
-- `Experiment.export_eval_log()` batch-exports one `TaskEvalRecord` per trajectory to
-  `<output_dir>/eval_log.jsonl`.
-- 42 unit tests, no regressions.
-
-Fields are designed to align with EEE's instance-level schema. Pending Elron's review
-of the open questions below, field names may be adjusted directly — no migration needed
-since this PR has never been merged or used in production.
+- New module `eval_log.py` with eight public classes.
+- `Episode.run` persists `action_schemas` in `trajectory.metadata` so per-episode
+  tool lists can be read post-hoc without re-instantiating tasks.
+- `Experiment.export_eval_log()` writes two files per experiment:
+  - `experiment_record.json` — once per experiment (agent, benchmark metadata, git provenance)
+  - `eval_log.jsonl` — one JSON line per episode (outcome, usage, trajectory summary)
+- 48 tests, no regressions.
 
 ---
 
-## Schema (v1)
+## Design: Two-Level Schema
 
-All records are plain JSON, one per line (JSONL). No cube-harness dependency to read.
+The schema mirrors the [Every Eval Ever (EEE)](https://github.com/evaleval/every_eval_ever)
+two-level structure: an aggregate record (experiment-level) and per-instance records
+(episode-level), linked by a stable FK.
 
-### `TaskEvalRecord`
+This split eliminates redundancy: agent description and benchmark metadata appear once per
+experiment rather than once per episode. For a 500-task benchmark, this is a 500× reduction
+in agent config serialization.
+
+### Why two files instead of one envelope JSONL
+
+- `eval_log.jsonl` is streamable: records can be appended immediately after each episode
+  without holding the full experiment in memory.
+- `experiment_record.json` is indexable: ATLAS and leaderboards can read agent/benchmark
+  metadata without scanning all episode lines.
+- Consistent with EEE's two-level schema.
+
+### MNAR correction via `benchmark_subset`
+
+The ATLAS matrix M[agent, task] is Missing Not At Random (MNAR): labs cherry-pick which
+(agent, task) pairs they run, gravitating toward benchmarks where their agent is strong.
+If matrix factorization trains on this biased data naively, recovered difficulty estimates
+reflect selection bias rather than true task difficulty.
+
+Rather than asking submitters to self-report intent (high friction, garbage-prone),
+`BenchmarkSubset` is derived automatically from the benchmark object:
+
+- `name` — `benchmark_metadata.name`, which includes any subset suffix applied via
+  `subset_from_glob` (e.g., `"WorkArena_[level=l1]"`) or `subset_from_list`.
+- `n_tasks` — `len(benchmark.task_metadata)` — the denominator for completion rate.
+  ATLAS can infer which fraction of the benchmark was run without user input.
+
+This gives ATLAS the structural information it needs for propensity scoring (what subset
+was run and how large it was) without requiring submitters to fill in subjective fields.
+
+---
+
+## Schema
+
+### `experiment_record.json`
 
 ```jsonc
 {
-  // ── Task ──────────────────────────────────────────────────────────────────
-  "task": {
-    "benchmark_id": "workarena-l1",          // → EEE evaluation_name (slugified)
-    "benchmark_name": "WorkArena-L1",
-    "benchmark_version": "1.2.0",            // → EEE metadata.benchmark_version
-    "benchmark_description": "...",
-    "benchmark_authors": ["..."],
-    "benchmark_tags": ["gui", "enterprise"],  // → EEE metadata.benchmark_tags
-
-    "task_id": "workarena.create_incident",  // → EEE sample_id
-    "task_version_hash": "9c2f...",          // SHA-256 of TaskConfig JSON → EEE sample_hash
-    "seed": 42,                              // → EEE eval_conditions.seed (Elron's ext)
-    "split": "test",                         // → EEE metadata.split
-
-    "abstract_description": "...",           // broad category description
-    "first_observation_text": "...",         // actual text the agent saw at runtime
-                                             // distinct from EEE input.raw (static spec)
-                                             // primary field for ATLAS task embedding
-    "recommended_max_steps": 15,
-    "extra_info": {}                         // TaskMetadata.extra_info passthrough
-  },
-
-  // ── Agent ─────────────────────────────────────────────────────────────────
+  "experiment_id": "a1b2c3d4e5f6a7b8",        // SHA-256(exp_name + output_dir)[:16]
+  "experiment_name": "workarena_l1_gpt4o",
+  "timestamp": 1745000000.0,
+  "framework_version": "0.4.2",
   "agent": {
-    // Identity
-    "agent_id": "<sha256>",                  // SHA-256(sorted config JSON) — stable row key
-    "config_type": "ReactAgentConfig",       // → EEE agent_system (Elron's ext)
-    "config": {...},                         // full serialized agent config
-    "llm_model": "gpt-4o-2024-11-20",       // → EEE agent_system.models[0].name
-
-    // Capabilities (episode-specific: same agent gets different tools per task)
-    "tools": [...],                          // full schemas in litellm format
-    "tool_names": ["browser_click", ...],    // → EEE agent_system.tools
-
-    // Runtime environment
+    "agent_id": "<sha256>",                    // SHA-256(sorted config JSON)
+    "config_type": "ReactAgentConfig",
+    "config": {...},
+    "llm_model": "gpt-4o-2024-11-20",
     "framework_version": "0.4.2",
-    "dependency_versions": {                 // → EEE agent_system.dependency_versions
-      "cube-harness": "0.4.2",
-      "litellm": "1.65.0"
-    },
-
-    // Git provenance → EEE agent_system.git_*
+    "dependency_versions": {"cube-harness": "0.4.2", "litellm": "1.65.0"},
     "git_commit": "abc123",
     "git_remote_url": "https://github.com/org/repo/tree/abc123",
     "git_is_dirty": false,
-
-    // LLM embedding warm-start (ATLAS cold-start)
-    "description": "ReAct agent, gpt-4o, browser tools, no memory"
+    "description": null                        // optional free-form prose for embedding
   },
-
-  // ── Outcome ───────────────────────────────────────────────────────────────
-  "success": true,                           // reward > 0
-  "reward": 1.0,                             // → EEE evaluation.score (v2 rename)
-  "reward_breakdown": {                      // → EEE evaluation.breakdown (v2 nest)
-    "done": true,
-    "form_submitted": true
+  "benchmark_name": "WorkArena_[level=l1]",
+  "benchmark_version": "1.2.0",
+  "benchmark_subset": {
+    "name": "WorkArena_[level=l1]",
+    "n_tasks": 33,
+    "filter": null                             // glob pattern if subset_from_glob was used
   },
-  "error_type": null,                        // exception class name if any step raised
+  "judge_config": null                         // populated if a post-hoc judge was run
+}
+```
 
-  // ── Trajectory summary ────────────────────────────────────────────────────
-  "n_steps": 25,                             // total steps (agent + env)
-  "n_agent_steps": 12,                       // agent decision turns
-  "n_env_steps": 13,                         // environment executions
+### `eval_log.jsonl` (one line per episode)
+
+```jsonc
+{
+  "experiment_id": "a1b2c3d4e5f6a7b8",        // FK to experiment_record.json
+  "task_id": "workarena.create_incident",
+  "task_version_hash": "9c2f...",             // SHA-256 of TaskConfig JSON
+  "seed": 42,
+  "split": "test",
+  "task_description": "...",                  // TaskMetadata.abstract_description
+  "tool_names": ["browser_click", ...],       // episode-specific; varies per task
+  "success": true,
+  "reward": 1.0,
+  "error_type": null,
+  "n_steps": 25,
+  "n_agent_steps": 12,
+  "n_env_steps": 13,
   "wall_time_s": 47.3,
-  "usage": {                                 // → EEE session_accounting (Elron's ext)
+  "usage": {
     "prompt_tokens": 12400,
     "completion_tokens": 840,
     "total_tokens": 13240,
@@ -126,46 +136,12 @@ All records are plain JSON, one per line (JSONL). No cube-harness dependency to 
     "total_cost_usd": 0.034,
     "n_llm_calls": 12
   },
-
-  // ── Provenance ────────────────────────────────────────────────────────────
-  "run_id": "my_exp_workarena.create_incident_ep0",
   "trajectory_id": "workarena.create_incident_ep0",
-  "timestamp": 1745000000.0,
-  "framework_version": "0.4.2",
-
-  // ── Declaration (ATLAS MNAR correction) ──────────────────────────────────
-  // Required for ATLAS submissions. Feeds a propensity model that downweights
-  // cherry-picked runs in the matrix factorization (Missing Not At Random).
-  "declaration": {
-    "motivation": "capability_probe",        // "capability_probe" | "leaderboard"
-                                             // | "training_data" | "debugging"
-    "task_selection_method": "random",       // "random" | "difficulty_stratified"
-                                             // | "domain_filtered" | "cherry_picked"
-    "compute_budget": "full_benchmark"       // "full_benchmark" | "partial" | "targeted"
-  }
+  "timestamp": 1745000100.0,
+  "verifier": null,                           // optional: ref URL + source code
+  "judge_output": null                        // optional: difficulty, feasible, root cause
 }
 ```
-
-### Why `declaration` exists
-
-The ATLAS matrix M[agent, task] is extremely sparse: labs don't evaluate uniformly at
-random. They cherry-pick strong agents on hard benchmarks, hide results where agents
-fail, and gravitate toward popular benchmarks. If the matrix factorization trains
-naively on this biased data, recovered difficulty estimates reflect *what people chose
-to run*, not true task difficulty (Missing Not At Random / MNAR).
-
-`declaration` fields let submitters self-report their selection intent. ATLAS feeds
-these into a propensity model: `P(observed | agent, task, declaration)`. Observations
-from cherry-picked runs are downweighted via Inverse Propensity Scoring. The anchor
-set (tasks every submitter must run) handles the mandatory portion cleanly; declaration
-corrects the free-choice portion.
-
-### Why no `eval_function_ref`
-
-`input.reference` (EEE) already carries the privileged ground truth. The evaluation
-function pointer is derivable from `benchmark_name + task_id`, goes stale on refactors,
-and is not used by any ATLAS component — the feasibility judge operates from trajectories
-and `input.reference`, not from reading eval source code.
 
 ---
 
@@ -175,47 +151,23 @@ and `input.reference`, not from reading eval source code.
 
 | File | Change |
 |------|--------|
-| `src/cube_harness/eval_log.py` | **NEW** — `UsageSummary`, `AgentInfo`, `TaskInfo`, `TaskEvalRecord`, `EvalLog`; remove `eval_function_ref`; add `declaration` |
-| `src/cube_harness/episode.py` | Store `action_schemas` in `trajectory.metadata` via `extra_metadata` parameter |
-| `src/cube_harness/experiment.py` | Add `export_eval_log(output_path, git_cwd) -> EvalLog` |
-| `tests/test_eval_log.py` | **NEW** — 42 unit tests |
+| `src/cube_harness/eval_log.py` | **NEW** — 8 public classes |
+| `src/cube_harness/episode.py` | Persist `action_schemas` in `trajectory.metadata` |
+| `src/cube_harness/experiment.py` | Replace `export_eval_log` with two-file output |
+| `tests/test_eval_log.py` | **NEW** — 48 unit + integration tests |
 
 ### `episode.py` delta
 
-One addition to `_run_loop`, immediately after `agent = self.config.agent_config.make(action_set)`:
+In `Episode.run`, immediately after the action set is resolved:
 
 ```python
-# Persisted in metadata so eval records can be built post-hoc without
-# re-instantiating the task (action set is only available at task.reset() time).
-action_schemas = [a.as_dict() for a in action_set]
+extra_metadata = {"action_schemas": [a.as_dict() for a in action_set]}
+return self._run_loop(setup_fn, step_fn, close_fn, agent, extra_metadata=extra_metadata)
 ```
 
-And in the `trajectory.metadata` dict:
-
-```python
-metadata={
-    "task_id": task_id,
-    "agent_name": agent_name,
-    "action_schemas": action_schemas,    # ← added
-    **env_output.info,
-},
-```
-
-### `experiment.py` delta
-
-New public method on `Experiment`:
-
-```python
-def export_eval_log(
-    self,
-    output_path: Path | None = None,
-    git_cwd: str | None = None,
-) -> EvalLog
-```
-
-Iterates `storage.list_trajectory_ids()`, builds one `TaskEvalRecord` per trajectory,
-writes `<output_dir>/eval_log.jsonl`. No task re-instantiation; all data comes from
-persisted trajectories and episode configs.
+`_run_loop` merges `extra_metadata` into `trajectory.metadata`. Action schemas are only
+available at `task.reset()` time; persisting them here enables post-hoc reconstruction
+of `EpisodeRecord.tool_names` without re-instantiating the task.
 
 ### Output location
 
@@ -223,7 +175,8 @@ persisted trajectories and episode configs.
 <output_dir>/
 ├── experiment_config.json
 ├── experiment_summary.json
-├── eval_log.jsonl          ← one JSON line per episode
+├── experiment_record.json      ← NEW: one JSON object, written by export_eval_log()
+├── eval_log.jsonl              ← NEW: one JSON line per episode
 └── episodes/
     └── <trajectory_id>/
         ├── episode_config.json
@@ -232,30 +185,5 @@ persisted trajectories and episode configs.
 
 ### Interaction with upcoming PRs
 
-- **PR #315 (episode-status):** status files live inside `episodes/<id>/`. No conflict.
-  `export_eval_log` reads status indirectly via `list_trajectory_ids()` — if #315 lands
-  first, we can filter on `COMPLETED` status instead of scanning trajectories.
+- **PR #315 (episode-status):** no conflict; status files live inside `episodes/<id>/`.
 - **PR #314 (env-cube credentials):** no overlap.
-
----
-
-## Open Questions (deferred to Elron)
-
-1. **`sample_id` semantics.** EEE often uses a numeric row index (`gsm8k_0001`).
-   CUBE tasks use semantic names (`workarena.create_incident`). Should `sample_id`
-   carry the semantic name, or should we add a separate `task_id` and keep `sample_id`
-   numeric?
-
-2. **`sample_hash` scope.** EEE defines it as `hash(input.raw + input.reference)`.
-   ATLAS wants to detect any drift in the task config (env setup, reward function, not
-   just the prompt). Proposal: keep `sample_hash` as EEE defines it; ATLAS submits a
-   separate `task_version_hash` inside `metadata` or as an extension.
-
-3. **`metadata` string constraint.** The EEE escape hatch is `string → string`, which
-   forces `seed` into a string. Worth proposing EEE relax `metadata` to `string → any`
-   for agentic use cases?
-
-4. **`agent_system` at instance vs aggregate level.** Elron's PR adds `agent_system` to
-   `evaluation_results[]` in the aggregate schema. For ATLAS, per-episode records must
-   be self-contained — the agent description needs to be at the instance level. Separate
-   EEE PR needed?

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -39,8 +39,9 @@ Three concrete gaps:
   `<output_dir>/eval_log.jsonl`.
 - 42 unit tests, no regressions.
 
-Fields are named to mirror EEE destinations (see forward-compatibility map) so adapting
-to Elron's schema review is a small rename-and-nest, not a redesign.
+Fields are designed to align with EEE's instance-level schema. Pending Elron's review
+of the open questions below, field names may be adjusted directly — no migration needed
+since this PR has never been merged or used in production.
 
 ---
 
@@ -235,24 +236,6 @@ persisted trajectories and episode configs.
   `export_eval_log` reads status indirectly via `list_trajectory_ids()` — if #315 lands
   first, we can filter on `COMPLETED` status instead of scanning trajectories.
 - **PR #314 (env-cube credentials):** no overlap.
-
----
-
-## EEE Forward-Compatibility Map
-
-| v1 field | v2 EEE destination | Notes |
-|---|---|---|
-| `task.benchmark_id` / `task.benchmark_name` | `evaluation_name` | slugified name |
-| `task.task_id` | `sample_id` | open question: semantic vs numeric key |
-| `task.task_version_hash` | `sample_hash` | scope difference (full config vs input hash) |
-| `task.seed` | `eval_conditions.seed` (Elron's ext) | |
-| `task.split` / `task.benchmark_version` / `task.benchmark_tags` | `metadata` (string escape hatch) | |
-| `task.first_observation_text` | new top-level field | needs EEE schema extension |
-| `agent.*` | `agent_system.*` (Elron's ext) | nested + renamed |
-| `reward` | `evaluation.score` | rename |
-| `reward_breakdown` | `evaluation.breakdown` | nest inside `evaluation` |
-| `usage.*` | `session_accounting.*` (Elron's ext) | renamed fields |
-| `declaration` | new top-level field | needs EEE schema extension |
 
 ---
 

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -1,0 +1,278 @@
+# RFC: Atlas EvalLog — Structured Evaluation Records
+
+**Status:** DRAFT  
+**PR:** [#297](https://github.com/The-AI-Alliance/cube-harness/pull/297)  
+**Author:** Alexandre Lacoste  
+**Date:** 2026-04-27  
+**Related:** [EEE alignment doc](../../../../atlas/docs/agent_eval_record_proposal.md), PR #315 (episode-status)
+
+---
+
+## Problem
+
+cube-harness produces trajectories, but has no standard output format for the
+community matrix **M[agent, task] = reward** that the ATLAS project needs.
+
+Three concrete gaps:
+
+1. **No stable agent identity.** Two runs of the same agent config can't be matched
+   without re-reading the full config. ATLAS needs a stable row key that is cheap to
+   index.
+
+2. **Action schemas are ephemeral.** The action set given to the agent at runtime is
+   never persisted. Post-hoc analysis (what tools did this agent have on this task?)
+   requires re-instantiating the task — expensive and sometimes impossible.
+
+3. **No standardized episode export.** Downstream tools (ATLAS server, leaderboards,
+   other frameworks) each extract reward/cost/metadata differently from our trajectory
+   files. A single JSONL line per episode, readable without cube-harness, solves this.
+
+---
+
+## Scope
+
+- New module `eval_log.py` with five public classes: `UsageSummary`, `AgentInfo`,
+  `TaskInfo`, `TaskEvalRecord`, `EvalLog`.
+- `Episode._run_loop` stores `action_schemas` in `trajectory.metadata` so eval records
+  can be built post-hoc without re-instantiating tasks.
+- `Experiment.export_eval_log()` batch-exports one `TaskEvalRecord` per trajectory to
+  `<output_dir>/eval_log.jsonl`.
+- 40 unit tests, no regressions.
+
+Fields are named to mirror EEE destinations (see forward-compatibility map) so adapting
+to Elron's schema review is a small rename-and-nest, not a redesign.
+
+---
+
+## Schema (v1)
+
+All records are plain JSON, one per line (JSONL). No cube-harness dependency to read.
+
+### `TaskEvalRecord`
+
+```jsonc
+{
+  // ── Task ──────────────────────────────────────────────────────────────────
+  "task": {
+    "benchmark_id": "workarena-l1",          // → EEE evaluation_name (slugified)
+    "benchmark_name": "WorkArena-L1",
+    "benchmark_version": "1.2.0",            // → EEE metadata.benchmark_version
+    "benchmark_description": "...",
+    "benchmark_authors": ["..."],
+    "benchmark_tags": ["gui", "enterprise"],  // → EEE metadata.benchmark_tags
+
+    "task_id": "workarena.create_incident",  // → EEE sample_id
+    "task_version_hash": "9c2f...",          // SHA-256 of TaskConfig JSON → EEE sample_hash
+    "seed": 42,                              // → EEE eval_conditions.seed (Elron's ext)
+    "split": "test",                         // → EEE metadata.split
+
+    "abstract_description": "...",           // broad category description
+    "first_observation_text": "...",         // actual text the agent saw at runtime
+                                             // distinct from EEE input.raw (static spec)
+                                             // primary field for ATLAS task embedding
+    "recommended_max_steps": 15,
+    "extra_info": {}                         // TaskMetadata.extra_info passthrough
+  },
+
+  // ── Agent ─────────────────────────────────────────────────────────────────
+  "agent": {
+    // Identity
+    "agent_id": "<sha256>",                  // SHA-256(sorted config JSON) — stable row key
+    "config_type": "ReactAgentConfig",       // → EEE agent_system (Elron's ext)
+    "config": {...},                         // full serialized agent config
+    "llm_model": "gpt-4o-2024-11-20",       // → EEE agent_system.models[0].name
+
+    // Capabilities (episode-specific: same agent gets different tools per task)
+    "tools": [...],                          // full schemas in litellm format
+    "tool_names": ["browser_click", ...],    // → EEE agent_system.tools
+
+    // Runtime environment
+    "framework_version": "0.4.2",
+    "dependency_versions": {                 // → EEE agent_system.dependency_versions
+      "cube-harness": "0.4.2",
+      "litellm": "1.65.0"
+    },
+
+    // Git provenance → EEE agent_system.git_*
+    "git_commit": "abc123",
+    "git_remote_url": "https://github.com/org/repo/tree/abc123",
+    "git_is_dirty": false,
+
+    // LLM embedding warm-start (ATLAS cold-start)
+    "description": "ReAct agent, gpt-4o, browser tools, no memory"
+  },
+
+  // ── Outcome ───────────────────────────────────────────────────────────────
+  "success": true,                           // reward > 0
+  "reward": 1.0,                             // → EEE evaluation.score (v2 rename)
+  "reward_breakdown": {                      // → EEE evaluation.breakdown (v2 nest)
+    "done": true,
+    "form_submitted": true
+  },
+  "error_type": null,                        // exception class name if any step raised
+
+  // ── Trajectory summary ────────────────────────────────────────────────────
+  "n_steps": 25,                             // total steps (agent + env)
+  "n_agent_steps": 12,                       // agent decision turns
+  "n_env_steps": 13,                         // environment executions
+  "wall_time_s": 47.3,
+  "usage": {                                 // → EEE session_accounting (Elron's ext)
+    "prompt_tokens": 12400,
+    "completion_tokens": 840,
+    "total_tokens": 13240,
+    "cached_tokens": 9800,
+    "cache_creation_tokens": 0,
+    "total_cost_usd": 0.034,
+    "n_llm_calls": 12
+  },
+
+  // ── Provenance ────────────────────────────────────────────────────────────
+  "run_id": "my_exp_workarena.create_incident_ep0",
+  "trajectory_id": "workarena.create_incident_ep0",
+  "timestamp": 1745000000.0,
+  "framework_version": "0.4.2",
+
+  // ── Declaration (ATLAS MNAR correction) ──────────────────────────────────
+  // Required for ATLAS submissions. Feeds a propensity model that downweights
+  // cherry-picked runs in the matrix factorization (Missing Not At Random).
+  "declaration": {
+    "motivation": "capability_probe",        // "capability_probe" | "leaderboard"
+                                             // | "training_data" | "debugging"
+    "task_selection_method": "random",       // "random" | "difficulty_stratified"
+                                             // | "domain_filtered" | "cherry_picked"
+    "compute_budget": "full_benchmark"       // "full_benchmark" | "partial" | "targeted"
+  }
+}
+```
+
+### Why `declaration` exists
+
+The ATLAS matrix M[agent, task] is extremely sparse: labs don't evaluate uniformly at
+random. They cherry-pick strong agents on hard benchmarks, hide results where agents
+fail, and gravitate toward popular benchmarks. If the matrix factorization trains
+naively on this biased data, recovered difficulty estimates reflect *what people chose
+to run*, not true task difficulty (Missing Not At Random / MNAR).
+
+`declaration` fields let submitters self-report their selection intent. ATLAS feeds
+these into a propensity model: `P(observed | agent, task, declaration)`. Observations
+from cherry-picked runs are downweighted via Inverse Propensity Scoring. The anchor
+set (tasks every submitter must run) handles the mandatory portion cleanly; declaration
+corrects the free-choice portion.
+
+### Why no `eval_function_ref`
+
+`input.reference` (EEE) already carries the privileged ground truth. The evaluation
+function pointer is derivable from `benchmark_name + task_id`, goes stale on refactors,
+and is not used by any ATLAS component — the feasibility judge operates from trajectories
+and `input.reference`, not from reading eval source code.
+
+---
+
+## Implementation
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/cube_harness/eval_log.py` | **NEW** — `UsageSummary`, `AgentInfo`, `TaskInfo`, `TaskEvalRecord`, `EvalLog` |
+| `src/cube_harness/episode.py` | Store `action_schemas` in `trajectory.metadata` at episode start |
+| `src/cube_harness/experiment.py` | Add `export_eval_log(output_path, git_cwd) -> EvalLog` |
+| `tests/test_eval_log.py` | **NEW** — 40 unit tests |
+
+### `episode.py` delta
+
+One addition to `_run_loop`, immediately after `agent = self.config.agent_config.make(action_set)`:
+
+```python
+# Persisted in metadata so eval records can be built post-hoc without
+# re-instantiating the task (action set is only available at task.reset() time).
+action_schemas = [a.as_dict() for a in action_set]
+```
+
+And in the `trajectory.metadata` dict:
+
+```python
+metadata={
+    "task_id": task_id,
+    "agent_name": agent_name,
+    "action_schemas": action_schemas,    # ← added
+    **env_output.info,
+},
+```
+
+### `experiment.py` delta
+
+New public method on `Experiment`:
+
+```python
+def export_eval_log(
+    self,
+    output_path: Path | None = None,
+    git_cwd: str | None = None,
+) -> EvalLog
+```
+
+Iterates `storage.list_trajectory_ids()`, builds one `TaskEvalRecord` per trajectory,
+writes `<output_dir>/eval_log.jsonl`. No task re-instantiation; all data comes from
+persisted trajectories and episode configs.
+
+### Output location
+
+```
+<output_dir>/
+├── experiment_config.json
+├── experiment_summary.json
+├── eval_log.jsonl          ← one JSON line per episode
+└── episodes/
+    └── <trajectory_id>/
+        ├── episode_config.json
+        └── ...
+```
+
+### Interaction with upcoming PRs
+
+- **PR #315 (episode-status):** status files live inside `episodes/<id>/`. No conflict.
+  `export_eval_log` reads status indirectly via `list_trajectory_ids()` — if #315 lands
+  first, we can filter on `COMPLETED` status instead of scanning trajectories.
+- **PR #314 (env-cube credentials):** no overlap.
+
+---
+
+## EEE Forward-Compatibility Map
+
+| v1 field | v2 EEE destination | Notes |
+|---|---|---|
+| `task.benchmark_id` / `task.benchmark_name` | `evaluation_name` | slugified name |
+| `task.task_id` | `sample_id` | open question: semantic vs numeric key |
+| `task.task_version_hash` | `sample_hash` | scope difference (full config vs input hash) |
+| `task.seed` | `eval_conditions.seed` (Elron's ext) | |
+| `task.split` / `task.benchmark_version` / `task.benchmark_tags` | `metadata` (string escape hatch) | |
+| `task.first_observation_text` | new top-level field | needs EEE schema extension |
+| `agent.*` | `agent_system.*` (Elron's ext) | nested + renamed |
+| `reward` | `evaluation.score` | rename |
+| `reward_breakdown` | `evaluation.breakdown` | nest inside `evaluation` |
+| `usage.*` | `session_accounting.*` (Elron's ext) | renamed fields |
+| `declaration` | new top-level field | needs EEE schema extension |
+
+---
+
+## Open Questions (deferred to Elron)
+
+1. **`sample_id` semantics.** EEE often uses a numeric row index (`gsm8k_0001`).
+   CUBE tasks use semantic names (`workarena.create_incident`). Should `sample_id`
+   carry the semantic name, or should we add a separate `task_id` and keep `sample_id`
+   numeric?
+
+2. **`sample_hash` scope.** EEE defines it as `hash(input.raw + input.reference)`.
+   ATLAS wants to detect any drift in the task config (env setup, reward function, not
+   just the prompt). Proposal: keep `sample_hash` as EEE defines it; ATLAS submits a
+   separate `task_version_hash` inside `metadata` or as an extension.
+
+3. **`metadata` string constraint.** The EEE escape hatch is `string → string`, which
+   forces `seed` into a string. Worth proposing EEE relax `metadata` to `string → any`
+   for agentic use cases?
+
+4. **`agent_system` at instance vs aggregate level.** Elron's PR adds `agent_system` to
+   `evaluation_results[]` in the aggregate schema. For ATLAS, per-episode records must
+   be self-contained — the agent description needs to be at the instance level. Separate
+   EEE PR needed?

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -31,9 +31,10 @@ Three concrete gaps:
 - New module `eval_log.py` with eight public classes.
 - `Episode.run` persists `action_schemas` in `trajectory.metadata` so per-episode
   tool lists can be read post-hoc without re-instantiating tasks.
-- `Experiment.export_eval_log()` writes two files per experiment:
+- `Experiment.export_eval_log()` writes structured records:
   - `experiment_record.json` — once per experiment (agent, benchmark metadata, git provenance)
-  - `eval_log.jsonl` — one JSON line per episode (outcome, usage, trajectory summary)
+  - `episodes/<trajectory_id>/episode_record.json` — one JSON file per episode (outcome, usage, trajectory summary)
+- `EvalLog.to_jsonl(path)` — submission helper that aggregates per-trajectory records into a flat JSONL for ATLAS upload
 - 48 tests, no regressions.
 
 ---
@@ -48,12 +49,15 @@ This split eliminates redundancy: agent description and benchmark metadata appea
 experiment rather than once per episode. For a 500-task benchmark, this is a 500× reduction
 in agent config serialization.
 
-### Why two files instead of one envelope JSONL
+### Why per-trajectory records instead of a flat JSONL
 
-- `eval_log.jsonl` is streamable: records can be appended immediately after each episode
-  without holding the full experiment in memory.
-- `experiment_record.json` is indexable: ATLAS and leaderboards can read agent/benchmark
-  metadata without scanning all episode lines.
+- **Retried episodes overwrite naturally.** A failed episode gets a new trajectory in
+  `episodes/<id>/`; the new `episode_record.json` replaces the old one without any
+  filtering logic at submission time.
+- **`experiment_record.json` is indexable.** ATLAS and leaderboards can read
+  agent/benchmark metadata without scanning episode files.
+- **`to_jsonl()` is an explicit submission step.** Callers produce the flat JSONL on
+  demand rather than maintaining an append-only file that may contain stale entries.
 - Consistent with EEE's two-level schema.
 
 ### MNAR correction via `benchmark_subset`
@@ -109,7 +113,7 @@ was run and how large it was) without requiring submitters to fill in subjective
 }
 ```
 
-### `eval_log.jsonl` (one line per episode)
+### `episodes/<trajectory_id>/episode_record.json` (one file per episode)
 
 ```jsonc
 {
@@ -175,17 +179,17 @@ of `EpisodeRecord.tool_names` without re-instantiating the task.
 <output_dir>/
 ├── experiment_config.json
 ├── experiment_summary.json
-├── experiment_record.json          ← NEW: written by export_eval_log()
+├── experiment_record.json      ← NEW: one JSON object, written by export_eval_log()
 └── episodes/
     └── <trajectory_id>/
         ├── episode_config.json
-        ├── episode_record.json     ← NEW: one per episode, co-located with trajectory
+        ├── episode_record.json ← NEW: one per episode, written by export_eval_log()
         └── ...
 ```
 
-For ATLAS submission, call `eval_log.to_jsonl(path)` to aggregate all episode records
-into a single flat JSONL. This is a separate step so the submission artifact stays
-distinct from the working experiment files.
+For ATLAS submission, call `eval_log.to_jsonl(path)` to assemble a flat JSONL from
+all per-trajectory records. This is a separate step so the submission artifact is
+distinct from the experiment's working files.
 
 ### Interaction with upcoming PRs
 

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -37,7 +37,7 @@ Three concrete gaps:
   can be built post-hoc without re-instantiating tasks.
 - `Experiment.export_eval_log()` batch-exports one `TaskEvalRecord` per trajectory to
   `<output_dir>/eval_log.jsonl`.
-- 40 unit tests, no regressions.
+- 42 unit tests, no regressions.
 
 Fields are named to mirror EEE destinations (see forward-compatibility map) so adapting
 to Elron's schema review is a small rename-and-nest, not a redesign.
@@ -174,10 +174,10 @@ and `input.reference`, not from reading eval source code.
 
 | File | Change |
 |------|--------|
-| `src/cube_harness/eval_log.py` | **NEW** — `UsageSummary`, `AgentInfo`, `TaskInfo`, `TaskEvalRecord`, `EvalLog` |
-| `src/cube_harness/episode.py` | Store `action_schemas` in `trajectory.metadata` at episode start |
+| `src/cube_harness/eval_log.py` | **NEW** — `UsageSummary`, `AgentInfo`, `TaskInfo`, `TaskEvalRecord`, `EvalLog`; remove `eval_function_ref`; add `declaration` |
+| `src/cube_harness/episode.py` | Store `action_schemas` in `trajectory.metadata` via `extra_metadata` parameter |
 | `src/cube_harness/experiment.py` | Add `export_eval_log(output_path, git_cwd) -> EvalLog` |
-| `tests/test_eval_log.py` | **NEW** — 40 unit tests |
+| `tests/test_eval_log.py` | **NEW** — 42 unit tests |
 
 ### `episode.py` delta
 

--- a/openspec/changes/atlas-eval-log/proposal.md
+++ b/openspec/changes/atlas-eval-log/proposal.md
@@ -175,13 +175,17 @@ of `EpisodeRecord.tool_names` without re-instantiating the task.
 <output_dir>/
 ├── experiment_config.json
 ├── experiment_summary.json
-├── experiment_record.json      ← NEW: one JSON object, written by export_eval_log()
-├── eval_log.jsonl              ← NEW: one JSON line per episode
+├── experiment_record.json          ← NEW: written by export_eval_log()
 └── episodes/
     └── <trajectory_id>/
         ├── episode_config.json
+        ├── episode_record.json     ← NEW: one per episode, co-located with trajectory
         └── ...
 ```
+
+For ATLAS submission, call `eval_log.to_jsonl(path)` to aggregate all episode records
+into a single flat JSONL. This is a separate step so the submission artifact stays
+distinct from the working experiment files.
 
 ### Interaction with upcoming PRs
 

--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -8,9 +8,12 @@ Exports two structured files per experiment, together forming the Atlas EvalLog:
 
 - **`experiment_record.json`** — one JSON object, written once per experiment. Holds
   agent description, benchmark metadata, and git provenance. Does not repeat per episode.
-- **`eval_log.jsonl`** — one JSON line per completed episode. Holds outcome, usage,
-  trajectory summary, and optional judge output. Links to `experiment_record.json` via
-  `experiment_id` FK.
+- **`episodes/<trajectory_id>/episode_record.json`** — one JSON file per completed
+  episode, co-located with trajectory data. Holds outcome, usage, trajectory summary,
+  and optional judge output. Links to `experiment_record.json` via `experiment_id` FK.
+  Retried episodes overwrite stale records naturally.
+- **`to_jsonl(path)`** — submission helper on `EvalLog` that assembles all per-trajectory
+  records into a flat JSONL for ATLAS upload. Call explicitly after `export_eval_log()`.
 
 Both files are plain JSON, readable without any cube-harness dependency.
 
@@ -241,7 +244,7 @@ class EpisodeRecord(TypedBaseModel):
     ) -> "EpisodeRecord"
 ```
 
-One line per episode in `eval_log.jsonl`. Links to `ExperimentRecord` via `experiment_id`.
+One file per episode at `episodes/<trajectory_id>/episode_record.json`. Links to `ExperimentRecord` via `experiment_id`. Retried episodes overwrite stale records since the new trajectory occupies the same directory.
 
 **`task_version_hash`** is the SHA-256 of `TaskConfig.model_dump_json(serialize_as_any=True)`.
 It changes whenever the task config changes, even if `task_id` is unchanged. ATLAS uses it
@@ -356,16 +359,15 @@ distinct from the experiment's working files.
 3. `task_version_hash` covers the full `TaskConfig` JSON, not just the prompt. A task
    whose environment setup changes produces a new hash even if the written instructions
    are identical.
-4. All `EpisodeRecord` rows in a file share the same `experiment_id`, matching the
+4. All `EpisodeRecord` files in an experiment share the same `experiment_id`, matching
    `ExperimentRecord.experiment_id` in the companion `experiment_record.json`.
-5. JSONL lines in `eval_log.jsonl` are self-contained. Appending records to an existing
-   file is safe; the file remains valid JSONL after partial writes.
+5. Lines in the JSONL produced by `to_jsonl()` are self-contained. Each line is a
+   complete `EpisodeRecord`; no cube-harness dependency is required to read the file.
 
 ## Gotchas
 
 - `export_eval_log()` loads all trajectories into memory. For experiments with thousands
-  of episodes, this can be slow. Use `EvalLog.append_episode()` directly inside a custom
-  runner for streaming writes.
+  of episodes, this can be slow.
 - Old trajectories (before the `action_schemas` metadata field was added) yield
   `EpisodeRecord.tool_names = []`. Records are still valid for reward/cost stats.
 - `git_is_dirty = True` means the eval may not reproduce exactly from `git_commit` alone.

--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -4,19 +4,24 @@
 
 ## Purpose
 
-Exports one structured evaluation record per completed episode. Records are appended
-to `<output_dir>/eval_log.jsonl` — a plain JSONL file readable without any
-cube-harness dependency.
+Exports two structured files per experiment, together forming the Atlas EvalLog:
+
+- **`experiment_record.json`** — one JSON object, written once per experiment. Holds
+  agent description, benchmark metadata, and git provenance. Does not repeat per episode.
+- **`eval_log.jsonl`** — one JSON line per completed episode. Holds outcome, usage,
+  trajectory summary, and optional judge output. Links to `experiment_record.json` via
+  `experiment_id` FK.
+
+Both files are plain JSON, readable without any cube-harness dependency.
 
 The primary consumer is **Project ATLAS** (Agent-Task Latent Analysis System), which
 builds the community matrix **M[agent, task] = reward** from these records via sparse
 matrix factorization and IRT. Secondary consumers include leaderboards, cost trackers,
 and any framework that wants a stable per-episode data contract.
 
-EEE compatibility target: fields are named and structured to map cleanly to the
-[Every Eval Ever](https://github.com/evaleval/every_eval_ever) instance-level schema.
-When the EEE agentic extension (Elron's PR #70) is finalized, a small rename-and-nest
-migration produces a valid EEE record. See the [EEE compatibility map](#eee-compatibility-map).
+Fields are structured to map cleanly to the two-level
+[Every Eval Ever (EEE)](https://github.com/evaleval/every_eval_ever) schema:
+`ExperimentRecord` ≈ EEE aggregate record, `EpisodeRecord` ≈ EEE instance-level record.
 
 ---
 
@@ -53,10 +58,6 @@ class AgentInfo(TypedBaseModel):
     config: dict                         # full serialized agent config
     llm_model: str | None                # extracted from config
 
-    # Capabilities (episode-specific)
-    tools: list[dict]                    # litellm function-call format
-    tool_names: list[str]                # names only, derived from tools
-
     # Runtime environment
     framework_version: str               # cube-harness version
     dependency_versions: dict[str, str]  # 9 tracked packages
@@ -73,125 +74,184 @@ class AgentInfo(TypedBaseModel):
     def from_agent_config(
         cls,
         agent_config: AgentConfig,
-        action_schemas: list[dict] | None = None,
         git_cwd: str | None = None,
     ) -> "AgentInfo"
-
-    def with_action_schemas(self, action_schemas: list[dict]) -> "AgentInfo"
-    # Returns a copy with tools + tool_names replaced. Used by export_eval_log()
-    # to inject per-episode action schemas without re-running from_agent_config().
 ```
 
-**`agent_id`** is the primary stable row key for the ATLAS matrix. It is the
-SHA-256 of the agent config serialized to JSON with sorted keys. Two runs of the
-same config produce the same `agent_id`, regardless of wall time or machine.
+**`agent_id`** is the primary stable row key for the ATLAS matrix. It is the SHA-256 of
+the agent config serialized to JSON with sorted keys. Two runs of the same config produce
+the same `agent_id`, regardless of wall time or machine.
 
-**`tools` / `tool_names`** are episode-specific: the same agent receives different
-action schemas on different tasks. These fields capture the actual action set available
-during this episode, read from `trajectory.metadata["action_schemas"]` (written by
-`Episode._run_loop`). They are NOT derived from the agent config alone.
+**No `tools` field.** Tools vary per episode (the same agent gets different action schemas
+on different tasks due to task-level action filtering). Tools are captured at the episode
+level in `EpisodeRecord.tool_names`.
 
-**`description`** is optional free-form prose intended for ATLAS's LLM warm-start
-embedding (cold-start for new agents with zero observed scores). May be human-authored
-or synthesized from the structured fields above.
+**`description`** is optional free-form prose intended for ATLAS's LLM warm-start embedding
+(cold-start for new agents with zero observed scores). May be human-authored or synthesized
+from the structured fields above. Never auto-populated by `from_agent_config()`.
 
 Tracked packages: `cube-harness`, `cube`, `litellm`, `anthropic`, `openai`,
 `browsergym-core`, `playwright`, `pydantic`, `ray`.
 
 ---
 
-### `TaskInfo`
+### `BenchmarkSubset`
 
 ```python
-class TaskInfo(TypedBaseModel):
-    # Benchmark identity
-    benchmark_id: str                    # slugified lowercase name
-    benchmark_name: str
-    benchmark_version: str | None
-    benchmark_description: str | None
-    benchmark_authors: list[str]
-    benchmark_tags: list[str]
-
-    # Task identity
-    task_id: str
-    task_version_hash: str | None        # SHA-256 of TaskConfig JSON
-    seed: int | None
-    split: str | None                    # "train" | "val" | "test"
-
-    # Task description (layered)
-    abstract_description: str | None     # broad category — not the agent's goal
-    first_observation_text: str | None   # actual text the agent saw at runtime
-    recommended_max_steps: int | None
-    extra_info: dict[str, Any]           # TaskMetadata.extra_info passthrough
+class BenchmarkSubset(TypedBaseModel):
+    name: str           # benchmark_metadata.name (includes subset suffix like "[level=l1]")
+    n_tasks: int        # len(benchmark.task_metadata) — denominator for completion rate
+    filter: str | None  # glob expression if subset_from_glob was used
 
     @classmethod
-    def from_trajectory_and_metadata(
-        cls,
-        trajectory: Trajectory,
-        benchmark_metadata: BenchmarkMetadata | None = None,
-        task_metadata: TaskMetadata | None = None,
-        task_config: TaskConfig | None = None,
-    ) -> "TaskInfo"
+    def from_benchmark(cls, benchmark: Any) -> "BenchmarkSubset"
 ```
 
-**`task_version_hash`** is the SHA-256 of `TaskConfig.model_dump_json(serialize_as_any=True)`.
-It changes whenever the task config changes, even if `task_id` is unchanged. ATLAS uses
-it to detect silent benchmark drift: if the same `task_id` has two different hashes across
-submissions, the records cannot be naively merged in the matrix.
+Automatically derived from the benchmark object. Used by ATLAS for MNAR propensity
+correction: `n_tasks` tells ATLAS what fraction of the benchmark was run without requiring
+submitters to fill in subjective fields.
 
-**`first_observation_text`** is extracted from the first `EnvironmentOutput` in the
-trajectory — the actual text the agent received at runtime. This is distinct from
-`input.raw` in EEE (the static eval spec): for GUI/web tasks the first observation
-includes live UI state (AXTree, HTML) that differs from the benchmark's written description.
-This is the primary field for ATLAS task embedding.
+**`name`** captures any subset suffix applied via `subset_from_glob` (e.g.,
+`"WorkArena_[level=l1]"`) or `subset_from_list`. It is `benchmark_metadata.name` verbatim.
 
-**`abstract_description`** comes from `TaskMetadata.abstract_description`. It is
-broad and not task-instance-specific — used for searching and filtering, not embedding.
+**`filter`** is `None` unless manually populated — there is currently no standard way to
+extract the glob pattern from a benchmark object automatically.
 
 ---
 
-### `TaskEvalRecord`
+### `JudgeConfig`
 
 ```python
-class TaskEvalRecord(TypedBaseModel):
-    # Descriptors
-    task: TaskInfo
+class JudgeConfig(TypedBaseModel):
+    model: str           # e.g. "claude-opus-4-7"
+    prompt_version: str  # version or hash of the judge prompt template
+    judged_at: str | None  # ISO-8601 timestamp
+```
+
+Configuration of the LLM judge used for post-hoc episode assessment. Stored in
+`ExperimentRecord.judge_config`; `None` if no judge was run.
+
+---
+
+### `JudgeOutput`
+
+```python
+class JudgeOutput(TypedBaseModel):
+    difficulty: str | None         # estimated task difficulty (free-form or enum)
+    feasible: bool | None          # whether the task was deemed completable
+    failure_root_cause: str | None # short description of why the agent failed
+```
+
+Per-episode LLM judge assessment. Stored in `EpisodeRecord.judge_output`; `None` if no
+judge was run. Populated in a post-processing step, not during the episode run.
+
+---
+
+### `Verifier`
+
+```python
+class Verifier(TypedBaseModel):
+    ref: str | None     # permanent GitHub URL to the verifier function at the exact commit
+    source: str | None  # verifier source code at eval time
+```
+
+Task verifier reference for reproducibility and post-hoc inspection. Stored in
+`EpisodeRecord.verifier`; `None` if not populated.
+
+---
+
+### `ExperimentRecord`
+
+```python
+class ExperimentRecord(TypedBaseModel):
+    experiment_id: str              # SHA-256(experiment_name + output_dir)[:16]
+    experiment_name: str
+    timestamp: float                # export time, Unix
+    framework_version: str
     agent: AgentInfo
+    benchmark_name: str             # benchmark_metadata.name
+    benchmark_version: str | None
+    benchmark_subset: BenchmarkSubset
+    judge_config: JudgeConfig | None = None
+
+    @classmethod
+    def from_experiment(
+        cls,
+        exp_name: str,
+        output_dir: Path,
+        agent_config: Any,
+        benchmark: Any,
+        git_cwd: str | None = None,
+    ) -> "ExperimentRecord"
+```
+
+Written once per experiment to `experiment_record.json`. Contains all fields shared
+across every episode: agent description, benchmark metadata, git provenance.
+
+**`experiment_id`** links every `EpisodeRecord` back to this record. It is
+SHA-256(experiment_name + str(output_dir))[:16] — stable for the same run (output_dir is
+unique per experiment), deterministic across repeated calls.
+
+---
+
+### `EpisodeRecord`
+
+```python
+class EpisodeRecord(TypedBaseModel):
+    # FK
+    experiment_id: str
+
+    # Task identity
+    task_id: str
+    task_version_hash: str | None   # SHA-256 of TaskConfig JSON
+    seed: int | None
+    split: str | None               # "train" | "val" | "test"
+    task_description: str | None    # TaskMetadata.abstract_description
+
+    # Episode-specific tools
+    tool_names: list[str]           # from trajectory.metadata["action_schemas"]
 
     # Outcome
-    success: bool                        # reward > 0
-    reward: float                        # scalar final reward
-    reward_breakdown: dict               # full reward_info (sub-goals, done flag, etc.)
-    error_type: str | None               # exception class name if any step errored
+    success: bool                   # reward > 0
+    reward: float
+    error_type: str | None          # exception class name if any step errored
 
     # Trajectory summary
-    n_steps: int                         # total steps (agent + env)
-    n_agent_steps: int                   # agent decision turns
-    n_env_steps: int                     # env executions
+    n_steps: int
+    n_agent_steps: int
+    n_env_steps: int
     wall_time_s: float | None
     usage: UsageSummary
 
     # Provenance
-    run_id: str                          # "{exp_name}_{trajectory_id}"
     trajectory_id: str
-    timestamp: float                     # episode start, Unix
-    framework_version: str
+    timestamp: float                # episode start, Unix
 
-    # MNAR bias correction
-    declaration: dict                    # see Declaration contract below
+    # Optional post-hoc fields
+    verifier: Verifier | None = None
+    judge_output: JudgeOutput | None = None
 
     @classmethod
     def from_trajectory(
         cls,
         trajectory: Trajectory,
-        agent_info: AgentInfo,
-        task_info: TaskInfo,
-        exp_name: str = "",
-    ) -> "TaskEvalRecord"
+        experiment_id: str,
+        task_metadata: Any | None = None,
+        task_config: Any | None = None,
+    ) -> "EpisodeRecord"
 ```
 
-The **`declaration`** field carries MNAR (Missing Not At Random) correction metadata
-required for ATLAS submissions. See [Declaration contract](#declaration-contract) below.
+One line per episode in `eval_log.jsonl`. Links to `ExperimentRecord` via `experiment_id`.
+
+**`task_version_hash`** is the SHA-256 of `TaskConfig.model_dump_json(serialize_as_any=True)`.
+It changes whenever the task config changes, even if `task_id` is unchanged. ATLAS uses it
+to detect silent benchmark drift: if the same `task_id` has two different hashes across
+submissions, the records cannot be naively merged in the matrix.
+
+**`tool_names`** is read from `trajectory.metadata["action_schemas"]` at export time.
+Returns `[]` for trajectories produced before the `action_schemas` field was added to
+metadata. The list is episode-specific — the same agent gets different tools on different
+tasks due to task-level action filtering.
 
 **`error_type`** is the exception class name (e.g. `"TimeoutError"`) of the first
 `StepError` found in the trajectory. It is `None` for clean episodes that simply scored
@@ -203,110 +263,61 @@ zero — a zero-reward, no-error episode is a valid failure, not a crash.
 
 ```python
 class EvalLog(TypedBaseModel):
-    records: list[TaskEvalRecord] = []
+    experiment: ExperimentRecord
+    episodes: list[EpisodeRecord] = []
 
-    def save_jsonl(self, path: Path) -> None
-    # Writes all records to JSONL (one JSON object per line).
+    def save(self, output_dir: Path) -> None
+    # Writes experiment_record.json and eval_log.jsonl to output_dir.
 
     @classmethod
-    def load_jsonl(cls, path: Path) -> "EvalLog"
-    # Loads all records from JSONL.
+    def load(cls, output_dir: Path) -> "EvalLog"
+    # Loads both files from output_dir.
 
     @staticmethod
-    def append_record(record: TaskEvalRecord, path: Path) -> None
-    # Appends a single record (streaming mode). Safe for one writer;
-    # not safe for concurrent multi-process writes without external file locking.
+    def append_episode(record: EpisodeRecord, path: Path) -> None
+    # Appends a single EpisodeRecord to a JSONL file (streaming mode).
+    # Not safe for concurrent multi-process writes without external file locking.
 ```
 
-The JSONL format is the canonical wire format. Each line is a self-contained
-`TaskEvalRecord` — no schema header, no envelope, no cube-harness dependency to read.
-
----
-
-## Declaration Contract
-
-`TaskEvalRecord.declaration` is a `dict` with three optional fields:
-
-```jsonc
-{
-  "motivation": "capability_probe",       // why this run was submitted
-  "task_selection_method": "random",      // how tasks were chosen
-  "compute_budget": "full_benchmark"      // how much was run
-}
-```
-
-**Allowed values:**
-
-| Field | Values |
-|---|---|
-| `motivation` | `"capability_probe"` · `"leaderboard"` · `"training_data"` · `"debugging"` |
-| `task_selection_method` | `"random"` · `"difficulty_stratified"` · `"domain_filtered"` · `"cherry_picked"` |
-| `compute_budget` | `"full_benchmark"` · `"partial"` · `"targeted"` |
-
-**Why it exists.** The ATLAS matrix is extremely sparse and Missing Not At Random (MNAR):
-labs cherry-pick which (agent, task) pairs they run, gravitating toward benchmarks where
-their agent is strong and avoiding embarrassing failures. If the matrix factorization
-trains on this biased data naively, recovered latent difficulty vectors reflect selection
-bias, not true task difficulty.
-
-Declaration fields feed a propensity model `P(observed | agent, task, declaration)`.
-Observations from cherry-picked runs are downweighted via Inverse Propensity Scoring;
-random-selection runs carry full weight. The anchor set (a fixed task subset every ATLAS
-submitter must evaluate) handles the mandatory portion cleanly; declaration corrects the
-free-choice portion.
-
-For non-ATLAS use the field can be omitted (`{}`). ATLAS community submissions must
-populate all three fields.
+Two-level container. `save()` creates two files; `load()` reads both.
+`append_episode()` is for streaming use cases where records should be written immediately
+after each episode without holding the full log in memory.
 
 ---
 
 ## Integration Points
 
-### `Episode._run_loop` → `trajectory.metadata["action_schemas"]`
+### `Episode.run` → `trajectory.metadata["action_schemas"]`
 
-Immediately after `agent = self.config.agent_config.make(action_set)`:
-
-```python
-action_schemas = [a.as_dict() for a in action_set]
-```
-
-Added to `trajectory.metadata`:
+In `Episode.run`, immediately after the action set is resolved:
 
 ```python
-metadata={
-    "task_id": task_id,
-    "agent_name": agent_name,
-    "action_schemas": action_schemas,
-    **env_output.info,
-}
+extra_metadata = {"action_schemas": [a.as_dict() for a in action_set]}
+return self._run_loop(setup_fn, step_fn, close_fn, agent, extra_metadata=extra_metadata)
 ```
 
-This is the only change to the episode loop. Action schemas are captured once at
-task reset time and persisted so `export_eval_log()` can reconstruct `AgentInfo.tools`
-without re-instantiating tasks.
+`_run_loop` merges `extra_metadata` into `trajectory.metadata`. This is the only change
+to the episode loop. Action schemas are captured once at task reset time and persisted so
+`export_eval_log()` can reconstruct `EpisodeRecord.tool_names` without re-instantiating tasks.
 
 ### `Experiment.export_eval_log`
 
 ```python
 def export_eval_log(
     self,
-    output_path: Path | None = None,
+    output_dir: Path | None = None,
     git_cwd: str | None = None,
 ) -> EvalLog
 ```
 
-Called after `run_sequentially()` or `run_with_ray()` completes. Iterates
-`storage.list_trajectory_ids()`, builds one `TaskEvalRecord` per trajectory, writes
-`<output_dir>/eval_log.jsonl` (or `output_path` if provided). Returns the in-memory
-`EvalLog`.
+Called after `run_sequentially()` or `run_with_ray()` completes. Reads all data from
+persisted files — no task or benchmark re-instantiation required.
 
-Reads all data from persisted files. No task or benchmark re-instantiation required.
+Resolution order for `EpisodeRecord.tool_names`:
+`trajectory.metadata["action_schemas"]` → `[]` if absent.
 
-**Resolution order for `AgentInfo.tools`:**
-`trajectory.metadata["action_schemas"]` → `[]` if absent (old trajectory without the field).
-
-**Resolution order for `TaskInfo` fields:**
-`benchmark.benchmark_metadata` → trajectory metadata fallback → `"unknown"`.
+Resolution order for `task_metadata` fields:
+`benchmark.task_metadata[task_id]` → `None` values (split, description) if absent.
 
 ---
 
@@ -316,6 +327,7 @@ Reads all data from persisted files. No task or benchmark re-instantiation requi
 <output_dir>/
 ├── experiment_config.json
 ├── experiment_summary.json
+├── experiment_record.json      ← one JSON object; written by export_eval_log()
 ├── eval_log.jsonl              ← one JSON line per completed episode
 └── episodes/
     └── <trajectory_id>/
@@ -323,35 +335,8 @@ Reads all data from persisted files. No task or benchmark re-instantiation requi
         └── ...
 ```
 
-`eval_log.jsonl` is written by `export_eval_log()` after the experiment completes.
-It is not written incrementally during the run; call `EvalLog.append_record()` directly
-for streaming use cases.
-
----
-
-## EEE Compatibility Map
-
-Fields are named to make migration to the
-[EEE instance-level schema](https://github.com/evaleval/every_eval_ever) a
-rename-and-nest. No field needs to be dropped or recomputed.
-
-| EvalLog field | EEE destination | Notes |
-|---|---|---|
-| `task.benchmark_name` | `evaluation_name` | |
-| `task.task_id` | `sample_id` | open: semantic name vs numeric key |
-| `task.task_version_hash` | `sample_hash` | EEE scope = input hash; ATLAS scope = full config hash |
-| `task.seed` | `eval_conditions.seed` | Elron's agentic ext |
-| `task.split` | `metadata.split` | string escape hatch |
-| `task.benchmark_version` | `metadata.benchmark_version` | string escape hatch |
-| `task.benchmark_tags` | `metadata.benchmark_tags` | comma-joined string |
-| `task.first_observation_text` | new top-level field | needs EEE schema ext |
-| `agent.*` | inside `agent_system.*` | Elron's agentic ext; rename fields |
-| `reward` | `evaluation.score` | rename |
-| `reward_breakdown` | `evaluation.breakdown` | nest inside `evaluation` |
-| `usage.*` | `session_accounting.*` | Elron's agentic ext; rename fields |
-| `declaration` | new top-level field | needs EEE schema ext |
-
-Open questions pending Elron's response: see [proposal.md](../../changes/atlas-eval-log/proposal.md).
+Both files are written atomically by `EvalLog.save()`. They are not written incrementally
+during the run; call `EvalLog.append_episode()` directly for streaming use cases.
 
 ---
 
@@ -359,26 +344,25 @@ Open questions pending Elron's response: see [proposal.md](../../changes/atlas-e
 
 1. `agent_id` is deterministic: same `AgentConfig` → same hash, regardless of run time,
    machine, or framework version. Never include timestamps or random values in the config.
-2. `task_version_hash` covers the full `TaskConfig` JSON, not just the prompt. A task
-   whose environment setup changes (e.g. a Docker image bump) produces a new hash even
-   if the written instructions are identical.
-3. `first_observation_text` is extracted from the trajectory, not from the task spec.
-   It reflects what the agent actually received, including any dynamic environment state
-   injected at runtime.
-4. JSONL lines are self-contained. Appending records to an existing file is safe; the
-   file remains valid JSONL after partial writes.
-5. `declaration` defaults to `{}`. ATLAS server rejects submissions with empty
-   `declaration`; cube-harness does not enforce this locally.
+2. `experiment_id` is stable for the same (experiment_name, output_dir) pair. Different
+   output directories produce different IDs even for experiments with the same name.
+3. `task_version_hash` covers the full `TaskConfig` JSON, not just the prompt. A task
+   whose environment setup changes produces a new hash even if the written instructions
+   are identical.
+4. All `EpisodeRecord` rows in a file share the same `experiment_id`, matching the
+   `ExperimentRecord.experiment_id` in the companion `experiment_record.json`.
+5. JSONL lines in `eval_log.jsonl` are self-contained. Appending records to an existing
+   file is safe; the file remains valid JSONL after partial writes.
 
 ## Gotchas
 
-- `export_eval_log()` loads all trajectories into memory to build `AgentInfo` and
-  `TaskInfo`. For experiments with thousands of episodes, this can be slow. Use
-  `EvalLog.append_record()` directly inside a custom runner for streaming writes.
+- `export_eval_log()` loads all trajectories into memory. For experiments with thousands
+  of episodes, this can be slow. Use `EvalLog.append_episode()` directly inside a custom
+  runner for streaming writes.
 - Old trajectories (before the `action_schemas` metadata field was added) yield
-  `AgentInfo.tools = []` and `AgentInfo.tool_names = []`. This is valid — records are
-  still useful for reward/cost stats, just not for tool-level analysis.
-- `git_is_dirty = True` means the eval may not reproduce exactly from `git_commit`
-  alone. ATLAS should flag these records accordingly (lower confidence in provenance).
+  `EpisodeRecord.tool_names = []`. Records are still valid for reward/cost stats.
+- `git_is_dirty = True` means the eval may not reproduce exactly from `git_commit` alone.
 - `AgentInfo.description` is never auto-populated by `from_agent_config()`. Set it
-  manually or via a post-processing step when preparing ATLAS submissions.
+  manually when preparing ATLAS submissions.
+- `BenchmarkSubset.filter` is `None` unless manually populated after calling
+  `BenchmarkSubset.from_benchmark()`.

--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -267,21 +267,22 @@ class EvalLog(TypedBaseModel):
     episodes: list[EpisodeRecord] = []
 
     def save(self, output_dir: Path) -> None
-    # Writes experiment_record.json and eval_log.jsonl to output_dir.
+    # Writes experiment_record.json and episodes/<trajectory_id>/episode_record.json.
 
     @classmethod
     def load(cls, output_dir: Path) -> "EvalLog"
-    # Loads both files from output_dir.
+    # Reads experiment_record.json and all episodes/*/episode_record.json.
 
-    @staticmethod
-    def append_episode(record: EpisodeRecord, path: Path) -> None
-    # Appends a single EpisodeRecord to a JSONL file (streaming mode).
-    # Not safe for concurrent multi-process writes without external file locking.
+    def to_jsonl(self, path: Path) -> None
+    # Aggregates all episode records into a flat JSONL file for ATLAS submission.
+    # Each line is a self-contained EpisodeRecord; no cube-harness dependency to read.
 ```
 
-Two-level container. `save()` creates two files; `load()` reads both.
-`append_episode()` is for streaming use cases where records should be written immediately
-after each episode without holding the full log in memory.
+Two-level container. Episode records are co-located with trajectory data in
+`episodes/<trajectory_id>/` — retried episodes naturally overwrite stale records
+since the new trajectory occupies the same directory. `to_jsonl()` is the submission
+helper: call it after `export_eval_log()` or after loading an existing eval log to
+produce a flat file for ATLAS upload.
 
 ---
 
@@ -327,16 +328,22 @@ Resolution order for `task_metadata` fields:
 <output_dir>/
 ├── experiment_config.json
 ├── experiment_summary.json
-├── experiment_record.json      ← one JSON object; written by export_eval_log()
-├── eval_log.jsonl              ← one JSON line per completed episode
+├── experiment_record.json          ← written by export_eval_log()
 └── episodes/
     └── <trajectory_id>/
         ├── episode_config.json
+        ├── episode_record.json     ← written by export_eval_log(), one per episode
         └── ...
 ```
 
-Both files are written atomically by `EvalLog.save()`. They are not written incrementally
-during the run; call `EvalLog.append_episode()` directly for streaming use cases.
+`EvalLog.save(output_dir)` writes `experiment_record.json` at the top level and
+`episode_record.json` inside each trajectory directory. Episode records are co-located
+with trajectory data: if an episode is retried, the new trajectory's record naturally
+replaces the old one without leaving stale flat-file entries.
+
+For ATLAS submission, call `eval_log.to_jsonl(path)` to assemble a single flat JSONL
+from the per-trajectory records. This is a separate step to keep the submission artifact
+distinct from the experiment's working files.
 
 ---
 

--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -1,0 +1,384 @@
+# EvalLog
+
+**Module:** `cube_harness.eval_log`
+
+## Purpose
+
+Exports one structured evaluation record per completed episode. Records are appended
+to `<output_dir>/eval_log.jsonl` — a plain JSONL file readable without any
+cube-harness dependency.
+
+The primary consumer is **Project ATLAS** (Agent-Task Latent Analysis System), which
+builds the community matrix **M[agent, task] = reward** from these records via sparse
+matrix factorization and IRT. Secondary consumers include leaderboards, cost trackers,
+and any framework that wants a stable per-episode data contract.
+
+EEE compatibility target: fields are named and structured to map cleanly to the
+[Every Eval Ever](https://github.com/evaleval/every_eval_ever) instance-level schema.
+When the EEE agentic extension (Elron's PR #70) is finalized, a small rename-and-nest
+migration produces a valid EEE record. See the [EEE compatibility map](#eee-compatibility-map).
+
+---
+
+## Public API
+
+### `UsageSummary`
+
+```python
+class UsageSummary(TypedBaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_cost_usd: float = 0.0
+    n_llm_calls: int = 0
+
+    @classmethod
+    def from_summary_stats(cls, stats: dict | None) -> "UsageSummary"
+```
+
+Aggregated LLM token usage and cost across a complete episode. Built from
+`Trajectory.summary_stats` — no re-scanning of steps required.
+
+---
+
+### `AgentInfo`
+
+```python
+class AgentInfo(TypedBaseModel):
+    # Identity
+    agent_id: str                        # SHA-256(sorted config JSON)
+    config_type: str                     # AgentConfig._type discriminator
+    config: dict                         # full serialized agent config
+    llm_model: str | None                # extracted from config
+
+    # Capabilities (episode-specific)
+    tools: list[dict]                    # litellm function-call format
+    tool_names: list[str]                # names only, derived from tools
+
+    # Runtime environment
+    framework_version: str               # cube-harness version
+    dependency_versions: dict[str, str]  # 9 tracked packages
+
+    # Git provenance
+    git_commit: str | None
+    git_remote_url: str | None           # permanent GitHub permalink
+    git_is_dirty: bool | None
+
+    # LLM warm-start embedding (ATLAS cold-start)
+    description: str | None
+
+    @classmethod
+    def from_agent_config(
+        cls,
+        agent_config: AgentConfig,
+        action_schemas: list[dict] | None = None,
+        git_cwd: str | None = None,
+    ) -> "AgentInfo"
+
+    def with_action_schemas(self, action_schemas: list[dict]) -> "AgentInfo"
+    # Returns a copy with tools + tool_names replaced. Used by export_eval_log()
+    # to inject per-episode action schemas without re-running from_agent_config().
+```
+
+**`agent_id`** is the primary stable row key for the ATLAS matrix. It is the
+SHA-256 of the agent config serialized to JSON with sorted keys. Two runs of the
+same config produce the same `agent_id`, regardless of wall time or machine.
+
+**`tools` / `tool_names`** are episode-specific: the same agent receives different
+action schemas on different tasks. These fields capture the actual action set available
+during this episode, read from `trajectory.metadata["action_schemas"]` (written by
+`Episode._run_loop`). They are NOT derived from the agent config alone.
+
+**`description`** is optional free-form prose intended for ATLAS's LLM warm-start
+embedding (cold-start for new agents with zero observed scores). May be human-authored
+or synthesized from the structured fields above.
+
+Tracked packages: `cube-harness`, `cube`, `litellm`, `anthropic`, `openai`,
+`browsergym-core`, `playwright`, `pydantic`, `ray`.
+
+---
+
+### `TaskInfo`
+
+```python
+class TaskInfo(TypedBaseModel):
+    # Benchmark identity
+    benchmark_id: str                    # slugified lowercase name
+    benchmark_name: str
+    benchmark_version: str | None
+    benchmark_description: str | None
+    benchmark_authors: list[str]
+    benchmark_tags: list[str]
+
+    # Task identity
+    task_id: str
+    task_version_hash: str | None        # SHA-256 of TaskConfig JSON
+    seed: int | None
+    split: str | None                    # "train" | "val" | "test"
+
+    # Task description (layered)
+    abstract_description: str | None     # broad category — not the agent's goal
+    first_observation_text: str | None   # actual text the agent saw at runtime
+    recommended_max_steps: int | None
+    extra_info: dict[str, Any]           # TaskMetadata.extra_info passthrough
+
+    @classmethod
+    def from_trajectory_and_metadata(
+        cls,
+        trajectory: Trajectory,
+        benchmark_metadata: BenchmarkMetadata | None = None,
+        task_metadata: TaskMetadata | None = None,
+        task_config: TaskConfig | None = None,
+    ) -> "TaskInfo"
+```
+
+**`task_version_hash`** is the SHA-256 of `TaskConfig.model_dump_json(serialize_as_any=True)`.
+It changes whenever the task config changes, even if `task_id` is unchanged. ATLAS uses
+it to detect silent benchmark drift: if the same `task_id` has two different hashes across
+submissions, the records cannot be naively merged in the matrix.
+
+**`first_observation_text`** is extracted from the first `EnvironmentOutput` in the
+trajectory — the actual text the agent received at runtime. This is distinct from
+`input.raw` in EEE (the static eval spec): for GUI/web tasks the first observation
+includes live UI state (AXTree, HTML) that differs from the benchmark's written description.
+This is the primary field for ATLAS task embedding.
+
+**`abstract_description`** comes from `TaskMetadata.abstract_description`. It is
+broad and not task-instance-specific — used for searching and filtering, not embedding.
+
+---
+
+### `TaskEvalRecord`
+
+```python
+class TaskEvalRecord(TypedBaseModel):
+    # Descriptors
+    task: TaskInfo
+    agent: AgentInfo
+
+    # Outcome
+    success: bool                        # reward > 0
+    reward: float                        # scalar final reward
+    reward_breakdown: dict               # full reward_info (sub-goals, done flag, etc.)
+    error_type: str | None               # exception class name if any step errored
+
+    # Trajectory summary
+    n_steps: int                         # total steps (agent + env)
+    n_agent_steps: int                   # agent decision turns
+    n_env_steps: int                     # env executions
+    wall_time_s: float | None
+    usage: UsageSummary
+
+    # Provenance
+    run_id: str                          # "{exp_name}_{trajectory_id}"
+    trajectory_id: str
+    timestamp: float                     # episode start, Unix
+    framework_version: str
+
+    # MNAR bias correction
+    declaration: dict                    # see Declaration contract below
+
+    @classmethod
+    def from_trajectory(
+        cls,
+        trajectory: Trajectory,
+        agent_info: AgentInfo,
+        task_info: TaskInfo,
+        exp_name: str = "",
+    ) -> "TaskEvalRecord"
+```
+
+The **`declaration`** field carries MNAR (Missing Not At Random) correction metadata
+required for ATLAS submissions. See [Declaration contract](#declaration-contract) below.
+
+**`error_type`** is the exception class name (e.g. `"TimeoutError"`) of the first
+`StepError` found in the trajectory. It is `None` for clean episodes that simply scored
+zero — a zero-reward, no-error episode is a valid failure, not a crash.
+
+---
+
+### `EvalLog`
+
+```python
+class EvalLog(TypedBaseModel):
+    records: list[TaskEvalRecord] = []
+
+    def save_jsonl(self, path: Path) -> None
+    # Writes all records to JSONL (one JSON object per line).
+
+    @classmethod
+    def load_jsonl(cls, path: Path) -> "EvalLog"
+    # Loads all records from JSONL.
+
+    @staticmethod
+    def append_record(record: TaskEvalRecord, path: Path) -> None
+    # Appends a single record (streaming mode). Safe for one writer;
+    # not safe for concurrent multi-process writes without external file locking.
+```
+
+The JSONL format is the canonical wire format. Each line is a self-contained
+`TaskEvalRecord` — no schema header, no envelope, no cube-harness dependency to read.
+
+---
+
+## Declaration Contract
+
+`TaskEvalRecord.declaration` is a `dict` with three optional fields:
+
+```jsonc
+{
+  "motivation": "capability_probe",       // why this run was submitted
+  "task_selection_method": "random",      // how tasks were chosen
+  "compute_budget": "full_benchmark"      // how much was run
+}
+```
+
+**Allowed values:**
+
+| Field | Values |
+|---|---|
+| `motivation` | `"capability_probe"` · `"leaderboard"` · `"training_data"` · `"debugging"` |
+| `task_selection_method` | `"random"` · `"difficulty_stratified"` · `"domain_filtered"` · `"cherry_picked"` |
+| `compute_budget` | `"full_benchmark"` · `"partial"` · `"targeted"` |
+
+**Why it exists.** The ATLAS matrix is extremely sparse and Missing Not At Random (MNAR):
+labs cherry-pick which (agent, task) pairs they run, gravitating toward benchmarks where
+their agent is strong and avoiding embarrassing failures. If the matrix factorization
+trains on this biased data naively, recovered latent difficulty vectors reflect selection
+bias, not true task difficulty.
+
+Declaration fields feed a propensity model `P(observed | agent, task, declaration)`.
+Observations from cherry-picked runs are downweighted via Inverse Propensity Scoring;
+random-selection runs carry full weight. The anchor set (a fixed task subset every ATLAS
+submitter must evaluate) handles the mandatory portion cleanly; declaration corrects the
+free-choice portion.
+
+For non-ATLAS use the field can be omitted (`{}`). ATLAS community submissions must
+populate all three fields.
+
+---
+
+## Integration Points
+
+### `Episode._run_loop` → `trajectory.metadata["action_schemas"]`
+
+Immediately after `agent = self.config.agent_config.make(action_set)`:
+
+```python
+action_schemas = [a.as_dict() for a in action_set]
+```
+
+Added to `trajectory.metadata`:
+
+```python
+metadata={
+    "task_id": task_id,
+    "agent_name": agent_name,
+    "action_schemas": action_schemas,
+    **env_output.info,
+}
+```
+
+This is the only change to the episode loop. Action schemas are captured once at
+task reset time and persisted so `export_eval_log()` can reconstruct `AgentInfo.tools`
+without re-instantiating tasks.
+
+### `Experiment.export_eval_log`
+
+```python
+def export_eval_log(
+    self,
+    output_path: Path | None = None,
+    git_cwd: str | None = None,
+) -> EvalLog
+```
+
+Called after `run_sequentially()` or `run_with_ray()` completes. Iterates
+`storage.list_trajectory_ids()`, builds one `TaskEvalRecord` per trajectory, writes
+`<output_dir>/eval_log.jsonl` (or `output_path` if provided). Returns the in-memory
+`EvalLog`.
+
+Reads all data from persisted files. No task or benchmark re-instantiation required.
+
+**Resolution order for `AgentInfo.tools`:**
+`trajectory.metadata["action_schemas"]` → `[]` if absent (old trajectory without the field).
+
+**Resolution order for `TaskInfo` fields:**
+`benchmark.benchmark_metadata` → trajectory metadata fallback → `"unknown"`.
+
+---
+
+## On-disk output
+
+```
+<output_dir>/
+├── experiment_config.json
+├── experiment_summary.json
+├── eval_log.jsonl              ← one JSON line per completed episode
+└── episodes/
+    └── <trajectory_id>/
+        ├── episode_config.json
+        └── ...
+```
+
+`eval_log.jsonl` is written by `export_eval_log()` after the experiment completes.
+It is not written incrementally during the run; call `EvalLog.append_record()` directly
+for streaming use cases.
+
+---
+
+## EEE Compatibility Map
+
+Fields are named to make migration to the
+[EEE instance-level schema](https://github.com/evaleval/every_eval_ever) a
+rename-and-nest. No field needs to be dropped or recomputed.
+
+| EvalLog field | EEE destination | Notes |
+|---|---|---|
+| `task.benchmark_name` | `evaluation_name` | |
+| `task.task_id` | `sample_id` | open: semantic name vs numeric key |
+| `task.task_version_hash` | `sample_hash` | EEE scope = input hash; ATLAS scope = full config hash |
+| `task.seed` | `eval_conditions.seed` | Elron's agentic ext |
+| `task.split` | `metadata.split` | string escape hatch |
+| `task.benchmark_version` | `metadata.benchmark_version` | string escape hatch |
+| `task.benchmark_tags` | `metadata.benchmark_tags` | comma-joined string |
+| `task.first_observation_text` | new top-level field | needs EEE schema ext |
+| `agent.*` | inside `agent_system.*` | Elron's agentic ext; rename fields |
+| `reward` | `evaluation.score` | rename |
+| `reward_breakdown` | `evaluation.breakdown` | nest inside `evaluation` |
+| `usage.*` | `session_accounting.*` | Elron's agentic ext; rename fields |
+| `declaration` | new top-level field | needs EEE schema ext |
+
+Open questions pending Elron's response: see [proposal.md](../../changes/atlas-eval-log/proposal.md).
+
+---
+
+## Invariants
+
+1. `agent_id` is deterministic: same `AgentConfig` → same hash, regardless of run time,
+   machine, or framework version. Never include timestamps or random values in the config.
+2. `task_version_hash` covers the full `TaskConfig` JSON, not just the prompt. A task
+   whose environment setup changes (e.g. a Docker image bump) produces a new hash even
+   if the written instructions are identical.
+3. `first_observation_text` is extracted from the trajectory, not from the task spec.
+   It reflects what the agent actually received, including any dynamic environment state
+   injected at runtime.
+4. JSONL lines are self-contained. Appending records to an existing file is safe; the
+   file remains valid JSONL after partial writes.
+5. `declaration` defaults to `{}`. ATLAS server rejects submissions with empty
+   `declaration`; cube-harness does not enforce this locally.
+
+## Gotchas
+
+- `export_eval_log()` loads all trajectories into memory to build `AgentInfo` and
+  `TaskInfo`. For experiments with thousands of episodes, this can be slow. Use
+  `EvalLog.append_record()` directly inside a custom runner for streaming writes.
+- Old trajectories (before the `action_schemas` metadata field was added) yield
+  `AgentInfo.tools = []` and `AgentInfo.tool_names = []`. This is valid — records are
+  still useful for reward/cost stats, just not for tool-level analysis.
+- `git_is_dirty = True` means the eval may not reproduce exactly from `git_commit`
+  alone. ATLAS should flag these records accordingly (lower confidence in provenance).
+- `AgentInfo.description` is never auto-populated by `from_agent_config()`. Set it
+  manually or via a post-processing step when preparing ATLAS submissions.

--- a/src/cube_harness/__init__.py
+++ b/src/cube_harness/__init__.py
@@ -2,6 +2,7 @@ import os
 import time
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from uuid import uuid4
 
 try:
     __version__ = version("cube-harness")
@@ -39,6 +40,7 @@ def make_experiment_output_dir(
         parts.append(llm_name)
     if tag:
         parts.append(tag)
+    parts.append(uuid4().hex[:8])
     dir_name = "_".join(parts)
     path = EXP_DIR / dir_name
     path.mkdir(parents=True, exist_ok=True)

--- a/src/cube_harness/__init__.py
+++ b/src/cube_harness/__init__.py
@@ -1,50 +1,10 @@
-import os
-import time
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
-from uuid import uuid4
+
+from cube_harness.experiment import EXP_DIR, make_experiment_output_dir
 
 try:
     __version__ = version("cube-harness")
 except PackageNotFoundError:
     __version__ = "unknown"
-
-# Standard experiment output root; override with CH_EXP_DIR (default: ~/cube_harness_results)
-_EXP_DIR_RAW = os.environ.get("CH_EXP_DIR", "~/cube_harness_results")
-EXP_DIR = Path(_EXP_DIR_RAW).expanduser().resolve()
-
-
-def make_experiment_output_dir(
-    agent_name: str,
-    benchmark_name: str,
-    llm_name: str | None = None,
-    tag: str | None = None,
-) -> Path:
-    """Create and return a new experiment output directory under EXP_DIR.
-
-    Directory name is: {date}_{agent_name}_{benchmark_name}[_{llm_name}][_{tag}].
-    The directory is created if it does not exist.
-
-    Args:
-        agent_name: Agent identifier (e.g. 'react').
-        benchmark_name: Benchmark identifier (e.g. 'miniwob', 'workarena').
-        llm_name: Optional LLM/model identifier (e.g. 'gpt-4.1-nano').
-        tag: Optional extra tag (e.g. 'resumption_demo', 'l1').
-
-    Returns:
-        Path to the created directory.
-    """
-    now = time.strftime("%Y%m%d_%H%M%S")
-    parts = [now, agent_name, benchmark_name]
-    if llm_name:
-        parts.append(llm_name)
-    if tag:
-        parts.append(tag)
-    parts.append(uuid4().hex[:8])
-    dir_name = "_".join(parts)
-    path = EXP_DIR / dir_name
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
 
 __all__ = ["EXP_DIR", "__version__", "make_experiment_output_dir"]

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -14,6 +14,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
+from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id, write_episode_record
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -286,6 +287,16 @@ class Episode:
                 trajectory.summary_stats = _compute_summary_stats(trajectory)
                 self.storage.save_trajectory(trajectory)
                 summary_proc.on_episode_complete(trajectory, self.storage)
+                try:
+                    evaluation_id = compute_evaluation_id(self.config.exp_name, self.config.output_dir)
+                    ep_record = EpisodeRecord.from_trajectory(
+                        trajectory,
+                        evaluation_id=evaluation_id,
+                        task_config=self.config.task_config,
+                    )
+                    write_episode_record(self.config.output_dir, ep_record)
+                except Exception:
+                    logger.warning("Failed to write episode record", exc_info=True)
                 logger.info(colored(f"Episode completed in {turns} turns, reward: {env_output.reward}", "blue"))
                 final_reward = trajectory.last_env_step().reward
                 ep_status.reward = final_reward

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 from pathlib import Path
@@ -15,7 +14,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.eval_log import EXPERIMENT_RECORD_FILENAME, EpisodeRecord
+from cube_harness.eval_log import EpisodeRecord
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -289,11 +288,9 @@ class Episode:
                 self.storage.save_trajectory(trajectory)
                 summary_proc.on_episode_complete(trajectory, self.storage)
                 try:
-                    exp_record_path = self.config.output_dir / EXPERIMENT_RECORD_FILENAME
-                    evaluation_id = json.loads(exp_record_path.read_text())["evaluation_id"]
                     ep_record = EpisodeRecord.from_trajectory(
                         trajectory,
-                        evaluation_id=evaluation_id,
+                        evaluation_id=self.config.output_dir.name,
                         task_config=self.config.task_config,
                     )
                     ep_record.write(self.config.output_dir)

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -14,7 +14,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id, write_episode_record
+from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -294,7 +294,7 @@ class Episode:
                         evaluation_id=evaluation_id,
                         task_config=self.config.task_config,
                     )
-                    write_episode_record(self.config.output_dir, ep_record)
+                    ep_record.write(self.config.output_dir)
                 except Exception:
                     logger.warning("Failed to write episode record", exc_info=True)
                 logger.info(colored(f"Episode completed in {turns} turns, reward: {env_output.reward}", "blue"))

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from pathlib import Path
@@ -14,7 +15,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id
+from cube_harness.eval_log import EXPERIMENT_RECORD_FILENAME, EpisodeRecord
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -288,7 +289,8 @@ class Episode:
                 self.storage.save_trajectory(trajectory)
                 summary_proc.on_episode_complete(trajectory, self.storage)
                 try:
-                    evaluation_id = compute_evaluation_id(self.config.exp_name, self.config.output_dir)
+                    exp_record_path = self.config.output_dir / EXPERIMENT_RECORD_FILENAME
+                    evaluation_id = json.loads(exp_record_path.read_text())["evaluation_id"]
                     ep_record = EpisodeRecord.from_trajectory(
                         trajectory,
                         evaluation_id=evaluation_id,

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -1,0 +1,570 @@
+"""Atlas EvalLog: structured evaluation records for community-scale agent benchmarking.
+
+Implements the TaskEvalRecord schema required by Project ATLAS for populating the
+Community EvalLog. Records are emitted after each episode and exported as JSONL,
+making them compatible with any framework that can parse JSON.
+
+The Pydantic models are for internal convenience; the on-disk format is plain JSON,
+so downstream frameworks (non-Python, non-cube) can consume it without any dependency
+on cube-harness.
+
+Classes:
+    UsageSummary   — aggregated LLM token usage and cost across an episode
+    AgentInfo      — full agent descriptor: config, capabilities, dependencies, git provenance
+    TaskInfo       — full task descriptor: benchmark metadata, task metadata, content hash
+    TaskEvalRecord — complete evaluation record ready for Atlas ingestion
+    EvalLog        — collection of records with JSONL save/load and streaming append
+"""
+
+import hashlib
+import importlib.metadata
+import json
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from cube.core import EnvironmentOutput, TypedBaseModel
+from pydantic import Field
+
+from cube_harness.core import Trajectory
+
+logger = logging.getLogger(__name__)
+
+# Key packages whose installed versions are captured for reproducibility.
+_TRACKED_PACKAGES: list[str] = [
+    "cube-harness",
+    "cube",
+    "litellm",
+    "anthropic",
+    "openai",
+    "browsergym-core",
+    "playwright",
+    "pydantic",
+    "ray",
+]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _collect_dependency_versions() -> dict[str, str]:
+    """Return installed versions for all tracked packages that are present."""
+    return {pkg: v for pkg in _TRACKED_PACKAGES if (v := _get_package_version(pkg)) is not None}
+
+
+def _to_github_url(remote_url: str, commit: str) -> str | None:
+    """Convert a git remote URL (HTTPS or SSH) to a permanent GitHub commit URL."""
+    ssh = re.match(r"git@github\.com:(.+?)(?:\.git)?$", remote_url)
+    if ssh:
+        return f"https://github.com/{ssh.group(1)}/tree/{commit}"
+    https = re.match(r"https://github\.com/(.+?)(?:\.git)?$", remote_url)
+    if https:
+        return f"https://github.com/{https.group(1)}/tree/{commit}"
+    return None
+
+
+def _get_git_info(cwd: str | None = None) -> tuple[str | None, str | None, bool | None]:
+    """Return (commit_sha, github_permalink, is_dirty) for the repo at cwd.
+
+    All three values are None when git is unavailable or cwd is not inside a repo.
+    is_dirty is True when uncommitted changes exist (result may not reproduce exactly
+    from git_commit alone).
+    """
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL
+        ).decode().strip()
+    except Exception:
+        return None, None, None
+
+    try:
+        remote = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"], cwd=cwd, stderr=subprocess.DEVNULL
+        ).decode().strip()
+        github_url = _to_github_url(remote, commit)
+    except Exception:
+        github_url = None
+
+    try:
+        is_dirty = subprocess.call(
+            ["git", "diff", "--quiet", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL
+        ) != 0
+    except Exception:
+        is_dirty = None
+
+    return commit, github_url, is_dirty
+
+
+def _extract_llm_model(config_dict: dict) -> str | None:
+    """Walk a serialized agent config dict looking for a model name field."""
+    for key in ("model_name", "model", "llm_model"):
+        if key in config_dict and isinstance(config_dict[key], str):
+            return config_dict[key]
+    for nested_key in ("llm_config", "llm"):
+        nested = config_dict.get(nested_key)
+        if isinstance(nested, dict):
+            for key in ("model_name", "model"):
+                if key in nested and isinstance(nested[key], str):
+                    return nested[key]
+    return None
+
+
+def _extract_tool_names(tools: list[dict]) -> list[str]:
+    """Extract action names from serialized action schemas.
+
+    Handles both litellm format ({"type": "function", "function": {"name": ...}})
+    and flat format ({"name": ...}).
+    """
+    names = []
+    for tool in tools:
+        fn = tool.get("function", {})
+        if isinstance(fn, dict) and "name" in fn:
+            names.append(fn["name"])
+        elif "name" in tool:
+            names.append(tool["name"])
+    return names
+
+
+def _extract_error_type(trajectory: Trajectory) -> str | None:
+    """Return the error_type of the first StepError in the trajectory, or None."""
+    for step in trajectory.steps:
+        if hasattr(step.output, "error") and step.output.error is not None:
+            return step.output.error.error_type
+    return None
+
+
+def _extract_first_observation_text(trajectory: Trajectory) -> str | None:
+    """Extract text content from the first EnvironmentOutput in the trajectory.
+
+    This is the actual task instruction as the agent received it.
+    """
+    for step in trajectory.steps:
+        if isinstance(step.output, EnvironmentOutput):
+            texts = [
+                content.data
+                for content in step.output.obs.contents
+                if isinstance(getattr(content, "data", None), str)
+            ]
+            return "\n".join(texts) if texts else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public models
+# ---------------------------------------------------------------------------
+
+
+class UsageSummary(TypedBaseModel):
+    """Aggregated LLM token usage and cost across a complete episode."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_cost_usd: float = 0.0
+    n_llm_calls: int = 0
+
+    @classmethod
+    def from_summary_stats(cls, stats: dict | None) -> "UsageSummary":
+        """Build from the summary_stats dict stored on a Trajectory."""
+        if not stats:
+            return cls()
+        prompt = stats.get("prompt_tokens", 0)
+        completion = stats.get("completion_tokens", 0)
+        return cls(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+            cached_tokens=stats.get("cached_tokens", 0),
+            cache_creation_tokens=stats.get("cache_creation_tokens", 0),
+            total_cost_usd=stats.get("cost", 0.0),
+            n_llm_calls=stats.get("total_llm_calls", 0),
+        )
+
+
+class AgentInfo(TypedBaseModel):
+    """Complete agent descriptor for Atlas embedding and reproducibility.
+
+    Designed for maximum downstream utility: includes structured fields (config, tools,
+    versions) that can be queried or used to synthesize a prose description for LLM
+    embedding, without requiring access to the agent's source code.
+    """
+
+    # Identity
+    agent_id: str = Field(
+        description="SHA-256 of the serialized agent config — stable unique identifier across runs."
+    )
+
+    # Config (structured, queryable)
+    config_type: str = Field(description="Agent config class name (from _type discriminator field).")
+    config: dict = Field(description="Full serialized agent config (model_dump with serialize_as_any=True).")
+    llm_model: str | None = Field(default=None, description="LLM model name extracted from config.")
+
+    # Capabilities — populated per-episode from the action set given to this agent.
+    # The same agent gets different tools on different tasks; these reflect THIS episode.
+    tools: list[dict] = Field(
+        default_factory=list,
+        description="Full action schemas in litellm function-call format (type, function.name, description, parameters).",
+    )
+    tool_names: list[str] = Field(
+        default_factory=list,
+        description="Action names for quick lookup — derived from tools.",
+    )
+
+    # Runtime environment
+    framework_version: str = Field(description="cube-harness version at eval time.")
+    dependency_versions: dict[str, str] = Field(
+        default_factory=dict,
+        description="Installed versions of key packages (cube-harness, litellm, anthropic, openai, ...).",
+    )
+
+    # Code provenance — enables Atlas to link records to an exact, auditable code state.
+    git_commit: str | None = Field(default=None, description="Git SHA-1 of the repo HEAD at eval time.")
+    git_remote_url: str | None = Field(
+        default=None,
+        description="Permanent GitHub URL pointing to the exact commit (tree view). None if not on GitHub.",
+    )
+    git_is_dirty: bool | None = Field(
+        default=None,
+        description=(
+            "True when uncommitted changes exist at eval time — result may not reproduce exactly "
+            "from git_commit alone. None when git info is unavailable."
+        ),
+    )
+
+    # Optional prose — intended for Atlas LLM embedding warm-start.
+    # Can be human-authored or synthesized from the structured fields above.
+    description: str | None = Field(
+        default=None,
+        description=(
+            "Free-form prose description of the agent (e.g. 'ReAct agent using gpt-4o, "
+            "browser tools, no memory, 16k context window'). "
+            "Used by Atlas to embed the agent in latent space via a frontier LLM."
+        ),
+    )
+
+    @classmethod
+    def from_agent_config(
+        cls,
+        agent_config: Any,
+        action_schemas: list[dict] | None = None,
+        git_cwd: str | None = None,
+    ) -> "AgentInfo":
+        """Build AgentInfo from a serialized agent config.
+
+        Args:
+            agent_config: Any AgentConfig (TypedBaseModel subclass).
+            action_schemas: Pre-serialized action schemas in litellm format, as stored
+                            in trajectory.metadata["action_schemas"]. If provided, no
+                            task instantiation is needed to capture capabilities.
+            git_cwd: Working directory for git commands. Defaults to CWD.
+        """
+        harness_version = _get_package_version("cube-harness") or "unknown"
+        config_dict = json.loads(agent_config.model_dump_json(serialize_as_any=True))
+        agent_id = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
+        config_type = config_dict.get("_type", type(agent_config).__name__)
+        llm_model = _extract_llm_model(config_dict)
+        tools = action_schemas or []
+        tool_names = _extract_tool_names(tools)
+        git_commit, git_remote_url, git_is_dirty = _get_git_info(cwd=git_cwd)
+
+        return cls(
+            agent_id=agent_id,
+            config_type=config_type,
+            config=config_dict,
+            llm_model=llm_model,
+            tools=tools,
+            tool_names=tool_names,
+            framework_version=harness_version,
+            dependency_versions=_collect_dependency_versions(),
+            git_commit=git_commit,
+            git_remote_url=git_remote_url,
+            git_is_dirty=git_is_dirty,
+        )
+
+    def with_action_schemas(self, action_schemas: list[dict]) -> "AgentInfo":
+        """Return a copy of this AgentInfo with the given action schemas applied."""
+        return self.model_copy(update={"tools": action_schemas, "tool_names": _extract_tool_names(action_schemas)})
+
+
+class TaskInfo(TypedBaseModel):
+    """Complete task descriptor for Atlas embedding and reproducibility.
+
+    Covers both the benchmark-level context (name, version, authors) and the specific
+    task instance (id, seed, split, description). The first_observation_text field
+    carries the actual instruction the agent saw — crucial for Atlas task embedding.
+    """
+
+    # Benchmark identity
+    benchmark_id: str = Field(description="Stable machine-readable benchmark identifier (lowercased name).")
+    benchmark_name: str = Field(description="Human-readable benchmark name (from BenchmarkMetadata).")
+    benchmark_version: str | None = Field(default=None, description="Benchmark version string.")
+    benchmark_description: str | None = Field(default=None, description="Benchmark description.")
+    benchmark_authors: list[str] = Field(default_factory=list, description="Benchmark author names.")
+    benchmark_tags: list[str] = Field(
+        default_factory=list, description="Benchmark tags (domain, modality, difficulty, etc.)."
+    )
+
+    # Task identity
+    task_id: str = Field(description="Unique task identifier within the benchmark.")
+    task_version_hash: str | None = Field(
+        default=None,
+        description=(
+            "SHA-256 of the serialized TaskConfig JSON. Detects task drift: if a benchmark update "
+            "silently changes a task, the hash changes and Atlas can flag the record as stale."
+        ),
+    )
+    seed: int | None = Field(default=None, description="Random seed for this task instance.")
+    split: str | None = Field(default=None, description="Dataset split: 'train', 'val', or 'test'.")
+
+    # Task description (layered, as Atlas specifies)
+    abstract_description: str | None = Field(
+        default=None,
+        description=(
+            "Broad task description from TaskMetadata.abstract_description — for searching and "
+            "filtering only. Not the specific goal shown to the agent."
+        ),
+    )
+    first_observation_text: str | None = Field(
+        default=None,
+        description=(
+            "Text content of the first observation as the agent received it — the actual task "
+            "instruction. This is the primary field for Atlas task embedding."
+        ),
+    )
+    recommended_max_steps: int | None = Field(
+        default=None, description="Benchmark-recommended step budget for this task."
+    )
+    extra_info: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional task metadata from TaskMetadata.extra_info (difficulty, domain, etc.).",
+    )
+
+    # Privileged — not shown to the agent during evaluation.
+    eval_function_ref: str | None = Field(
+        default=None,
+        description=(
+            "Qualified reference to the evaluation function. "
+            "Privileged: the agent never sees this; the EvalLog does. "
+            "Format: 'module.TaskConfigClass.make() → Task.evaluate'."
+        ),
+    )
+
+    @classmethod
+    def from_trajectory_and_metadata(
+        cls,
+        trajectory: Trajectory,
+        benchmark_metadata: Any | None = None,
+        task_metadata: Any | None = None,
+        task_config: Any | None = None,
+    ) -> "TaskInfo":
+        """Build TaskInfo from a completed trajectory and optional rich metadata.
+
+        Args:
+            trajectory: Completed episode trajectory (provides task_id, first obs text).
+            benchmark_metadata: cube.benchmark.BenchmarkMetadata (provides name, version, ...).
+            task_metadata: cube.task.TaskMetadata for this task (provides split, description, ...).
+            task_config: cube.task.TaskConfig for this episode (provides seed, content hash).
+        """
+        task_id: str = trajectory.metadata.get("task_id", "")
+
+        if benchmark_metadata is not None:
+            bm_name: str = benchmark_metadata.name
+            bm_id: str = bm_name.lower().replace(" ", "-").replace("+", "plus")
+            bm_version: str | None = benchmark_metadata.version
+            bm_description: str | None = benchmark_metadata.description
+            bm_authors: list[str] = list(benchmark_metadata.authors)
+            bm_tags: list[str] = list(benchmark_metadata.tags)
+        else:
+            bm_name = trajectory.metadata.get("benchmark_name", "unknown")
+            bm_id = bm_name.lower().replace(" ", "-")
+            bm_version = None
+            bm_description = None
+            bm_authors = []
+            bm_tags = []
+
+        split: str | None = None
+        abstract_description: str | None = None
+        recommended_max_steps: int | None = None
+        extra_info: dict[str, Any] = {}
+        if task_metadata is not None:
+            split = task_metadata.split
+            abstract_description = task_metadata.abstract_description or None
+            recommended_max_steps = task_metadata.recommended_max_steps
+            extra_info = dict(task_metadata.extra_info)
+
+        task_version_hash: str | None = None
+        seed: int | None = None
+        eval_function_ref: str | None = None
+        if task_config is not None:
+            task_version_hash = hashlib.sha256(
+                task_config.model_dump_json(serialize_as_any=True).encode()
+            ).hexdigest()
+            seed = task_config.seed
+            tc_module = type(task_config).__module__
+            tc_name = type(task_config).__name__
+            eval_function_ref = f"{tc_module}.{tc_name}.make() → Task.evaluate"
+
+        return cls(
+            benchmark_id=bm_id,
+            benchmark_name=bm_name,
+            benchmark_version=bm_version,
+            benchmark_description=bm_description,
+            benchmark_authors=bm_authors,
+            benchmark_tags=bm_tags,
+            task_id=task_id,
+            task_version_hash=task_version_hash,
+            seed=seed,
+            split=split,
+            abstract_description=abstract_description,
+            first_observation_text=_extract_first_observation_text(trajectory),
+            recommended_max_steps=recommended_max_steps,
+            extra_info=extra_info,
+            eval_function_ref=eval_function_ref,
+        )
+
+
+class TaskEvalRecord(TypedBaseModel):
+    """Complete evaluation record for one agent-task episode.
+
+    Compatible with Project ATLAS TaskEvalRecord schema. The on-disk format is plain
+    JSON (JSONL), consumable by any framework without a cube-harness dependency.
+
+    Field groups follow the ATLAS design:
+        task        — what was evaluated
+        agent       — who evaluated it
+        outcome     — how it went (reward, errors)
+        trajectory  — execution summary (steps, tokens, time)
+        provenance  — when, where, with what framework version
+    """
+
+    # Nested descriptors
+    task: TaskInfo
+    agent: AgentInfo
+
+    # Outcome
+    success: bool = Field(description="True when final reward > 0.")
+    reward: float = Field(description="Final reward from the last EnvironmentOutput.")
+    reward_breakdown: dict = Field(
+        default_factory=dict,
+        description="Full reward_info dict from the trajectory (may include sub-goal scores, done flag, etc.).",
+    )
+    error_type: str | None = Field(
+        default=None,
+        description=(
+            "Exception class name if any step raised an error (e.g. 'TimeoutError', 'ValueError'). "
+            "None for clean episodes (even if reward=0)."
+        ),
+    )
+
+    # Trajectory summary
+    n_steps: int = Field(description="Total trajectory steps (agent + env combined).")
+    n_agent_steps: int = Field(description="Agent steps (LLM decision turns).")
+    n_env_steps: int = Field(description="Environment steps (tool executions).")
+    wall_time_s: float | None = Field(default=None, description="Episode wall-clock duration in seconds.")
+    usage: UsageSummary = Field(
+        default_factory=UsageSummary,
+        description="Aggregated LLM token usage and cost for the episode.",
+    )
+
+    # Provenance
+    run_id: str = Field(description="Unique run identifier: '{exp_name}_{trajectory_id}'.")
+    trajectory_id: str = Field(description="Trajectory ID as stored on disk.")
+    timestamp: float = Field(description="Episode start time as Unix timestamp.")
+    framework_version: str = Field(description="cube-harness version.")
+
+    @classmethod
+    def from_trajectory(
+        cls,
+        trajectory: Trajectory,
+        agent_info: AgentInfo,
+        task_info: TaskInfo,
+        exp_name: str = "",
+    ) -> "TaskEvalRecord":
+        """Assemble a TaskEvalRecord from a completed trajectory and pre-built info objects."""
+        harness_version = _get_package_version("cube-harness") or "unknown"
+        last_env = trajectory.last_env_step()
+        reward = last_env.reward
+        stats = trajectory.summary_stats or {}
+
+        wall_time_s: float | None = None
+        if trajectory.start_time is not None and trajectory.end_time is not None:
+            wall_time_s = trajectory.end_time - trajectory.start_time
+
+        return cls(
+            task=task_info,
+            agent=agent_info,
+            success=reward > 0,
+            reward=reward,
+            reward_breakdown=dict(trajectory.reward_info),
+            error_type=_extract_error_type(trajectory),
+            n_steps=len(trajectory.steps),
+            n_agent_steps=stats.get("n_agent_steps", trajectory.n_agent_steps),
+            n_env_steps=stats.get("n_env_steps", trajectory.n_env_steps),
+            wall_time_s=wall_time_s,
+            usage=UsageSummary.from_summary_stats(stats),
+            run_id=f"{exp_name}_{trajectory.id}" if exp_name else trajectory.id,
+            trajectory_id=trajectory.id,
+            timestamp=trajectory.start_time or 0.0,
+            framework_version=harness_version,
+        )
+
+
+class EvalLog(TypedBaseModel):
+    """Collection of TaskEvalRecords with JSONL serialization.
+
+    The JSONL format (one JSON object per line) is the Atlas-compatible wire format.
+    Each line is a self-contained TaskEvalRecord — no schema header, no envelope.
+    Other frameworks read/write the same format without any cube-harness dependency.
+
+    For large experiments, prefer append_record() (streaming) over save_jsonl()
+    (in-memory) to avoid materializing all records at once.
+    """
+
+    records: list[TaskEvalRecord] = Field(default_factory=list)
+
+    def save_jsonl(self, path: Path) -> None:
+        """Write all records to a JSONL file (one JSON object per line)."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            for record in self.records:
+                f.write(record.model_dump_json() + "\n")
+        logger.info(f"Saved {len(self.records)} eval records to {path}")
+
+    @classmethod
+    def load_jsonl(cls, path: Path) -> "EvalLog":
+        """Load all records from a JSONL file."""
+        path = Path(path)
+        records = []
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    records.append(TaskEvalRecord.model_validate_json(line))
+        return cls(records=records)
+
+    @staticmethod
+    def append_record(record: TaskEvalRecord, path: Path) -> None:
+        """Append a single record to a JSONL file (streaming mode).
+
+        Suitable for writing records immediately after each episode without holding
+        the full log in memory. Not safe for concurrent multi-process writes without
+        external file locking.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as f:
+            f.write(record.model_dump_json() + "\n")

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -358,6 +358,14 @@ class ExperimentRecord(TypedBaseModel):
             benchmark_subset=BenchmarkSubset.from_benchmark(benchmark),
         )
 
+    def write(self, output_dir: Path) -> None:
+        """Write experiment_record.json to output_dir."""
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / EXPERIMENT_RECORD_FILENAME
+        path.write_text(self.model_dump_json(indent=2))
+        logger.info(f"Saved experiment record to {path}")
+
 
 class EpisodeRecord(TypedBaseModel):
     """Episode-level record. Written to episodes/<trajectory_id>/episode_record.json after each episode.
@@ -465,26 +473,16 @@ class EpisodeRecord(TypedBaseModel):
             timestamp=trajectory.start_time or 0.0,
         )
 
+    def write(self, output_dir: Path) -> None:
+        """Write episode_record.json to episodes/<trajectory_id>/ inside output_dir."""
+        ep_dir = Path(output_dir) / _EPISODES_DIR / self.trajectory_id
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        (ep_dir / EPISODE_RECORD_FILENAME).write_text(self.model_dump_json(indent=2))
+
 
 EPISODE_RECORD_FILENAME = "episode_record.json"
 EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
 _EPISODES_DIR = "episodes"
-
-
-def write_experiment_record(output_dir: Path, record: ExperimentRecord) -> None:
-    """Write experiment_record.json to output_dir."""
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    path = output_dir / EXPERIMENT_RECORD_FILENAME
-    path.write_text(record.model_dump_json(indent=2))
-    logger.info(f"Saved experiment record to {path}")
-
-
-def write_episode_record(output_dir: Path, record: EpisodeRecord) -> None:
-    """Write episode_record.json to episodes/<trajectory_id>/ inside output_dir."""
-    ep_dir = Path(output_dir) / _EPISODES_DIR / record.trajectory_id
-    ep_dir.mkdir(parents=True, exist_ok=True)
-    (ep_dir / EPISODE_RECORD_FILENAME).write_text(record.model_dump_json(indent=2))
 
 
 class EvalLog(TypedBaseModel):
@@ -506,9 +504,9 @@ class EvalLog(TypedBaseModel):
     def save(self, output_dir: Path) -> None:
         """Write experiment_record.json and per-trajectory episode_record.json files."""
         output_dir = Path(output_dir)
-        write_experiment_record(output_dir, self.experiment)
+        self.experiment.write(output_dir)
         for record in self.episodes:
-            write_episode_record(output_dir, record)
+            record.write(output_dir)
         logger.info(f"Saved {len(self.episodes)} episode records under {output_dir / _EPISODES_DIR}")
 
     @classmethod

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -89,24 +89,24 @@ def _get_git_info(cwd: str | None = None) -> tuple[str | None, str | None, bool 
     from git_commit alone).
     """
     try:
-        commit = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL
-        ).decode().strip()
+        commit = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL).decode().strip()
+        )
     except Exception:
         return None, None, None
 
     try:
-        remote = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"], cwd=cwd, stderr=subprocess.DEVNULL
-        ).decode().strip()
+        remote = (
+            subprocess.check_output(["git", "remote", "get-url", "origin"], cwd=cwd, stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
         github_url = _to_github_url(remote, commit)
     except Exception:
         github_url = None
 
     try:
-        is_dirty = subprocess.call(
-            ["git", "diff", "--quiet", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL
-        ) != 0
+        is_dirty = subprocess.call(["git", "diff", "--quiet", "HEAD"], cwd=cwd, stderr=subprocess.DEVNULL) != 0
     except Exception:
         is_dirty = None
 
@@ -317,7 +317,9 @@ class ExperimentRecord(TypedBaseModel):
     metadata, git provenance. EpisodeRecord links to this via evaluation_id.
     """
 
-    evaluation_id: str = Field(description="output_dir.name — unique per run (includes UUID suffix from make_experiment_output_dir).")
+    evaluation_id: str = Field(
+        description="output_dir.name — unique per run (includes UUID suffix from make_experiment_output_dir)."
+    )
     experiment_name: str = Field(description="Experiment name as set in Experiment.name.")
     evaluation_timestamp: float = Field(description="Experiment start time as Unix timestamp.")
     eval_library: EvalLibrary = Field(description="Library that produced the evaluation.")
@@ -441,9 +443,7 @@ class EpisodeRecord(TypedBaseModel):
         sample_hash: str | None = None
         seed: int | None = None
         if task_config is not None:
-            sample_hash = hashlib.sha256(
-                task_config.model_dump_json(serialize_as_any=True).encode()
-            ).hexdigest()
+            sample_hash = hashlib.sha256(task_config.model_dump_json(serialize_as_any=True).encode()).hexdigest()
             seed = getattr(task_config, "seed", None)
 
         split: str | None = None
@@ -507,9 +507,7 @@ class EvalLog(TypedBaseModel):
     def load(cls, output_dir: Path) -> "EvalLog":
         """Load experiment_record.json and all per-trajectory episode_record.json files."""
         output_dir = Path(output_dir)
-        experiment = ExperimentRecord.model_validate_json(
-            (output_dir / EXPERIMENT_RECORD_FILENAME).read_text()
-        )
+        experiment = ExperimentRecord.model_validate_json((output_dir / EXPERIMENT_RECORD_FILENAME).read_text())
         episodes: list[EpisodeRecord] = []
         episodes_dir = output_dir / _EPISODES_DIR
         if episodes_dir.exists():

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -352,16 +352,6 @@ class TaskInfo(TypedBaseModel):
         description="Additional task metadata from TaskMetadata.extra_info (difficulty, domain, etc.).",
     )
 
-    # Privileged — not shown to the agent during evaluation.
-    eval_function_ref: str | None = Field(
-        default=None,
-        description=(
-            "Qualified reference to the evaluation function. "
-            "Privileged: the agent never sees this; the EvalLog does. "
-            "Format: 'module.TaskConfigClass.make() → Task.evaluate'."
-        ),
-    )
-
     @classmethod
     def from_trajectory_and_metadata(
         cls,
@@ -407,15 +397,11 @@ class TaskInfo(TypedBaseModel):
 
         task_version_hash: str | None = None
         seed: int | None = None
-        eval_function_ref: str | None = None
         if task_config is not None:
             task_version_hash = hashlib.sha256(
                 task_config.model_dump_json(serialize_as_any=True).encode()
             ).hexdigest()
             seed = task_config.seed
-            tc_module = type(task_config).__module__
-            tc_name = type(task_config).__name__
-            eval_function_ref = f"{tc_module}.{tc_name}.make() → Task.evaluate"
 
         return cls(
             benchmark_id=bm_id,
@@ -432,7 +418,6 @@ class TaskInfo(TypedBaseModel):
             first_observation_text=_extract_first_observation_text(trajectory),
             recommended_max_steps=recommended_max_steps,
             extra_info=extra_info,
-            eval_function_ref=eval_function_ref,
         )
 
 
@@ -484,6 +469,18 @@ class TaskEvalRecord(TypedBaseModel):
     trajectory_id: str = Field(description="Trajectory ID as stored on disk.")
     timestamp: float = Field(description="Episode start time as Unix timestamp.")
     framework_version: str = Field(description="cube-harness version.")
+
+    # MNAR bias correction — required for ATLAS community submissions.
+    # motivation: why this run was submitted ("capability_probe"|"leaderboard"|"training_data"|"debugging")
+    # task_selection_method: how tasks were chosen ("random"|"difficulty_stratified"|"domain_filtered"|"cherry_picked")
+    # compute_budget: how much was run ("full_benchmark"|"partial"|"targeted")
+    declaration: dict = Field(
+        default_factory=dict,
+        description=(
+            "Self-reported selection intent for MNAR bias correction. "
+            "Required for ATLAS community submissions; omit for local use."
+        ),
+    )
 
     @classmethod
     def from_trajectory(

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -1,19 +1,21 @@
-"""Atlas EvalLog: structured evaluation records for community-scale agent benchmarking.
+"""Atlas EvalLog: two-level structured evaluation records for community-scale agent benchmarking.
 
-Implements the TaskEvalRecord schema required by Project ATLAS for populating the
-Community EvalLog. Records are emitted after each episode and exported as JSONL,
-making them compatible with any framework that can parse JSON.
+Two files per experiment:
+    experiment_record.json  — ExperimentRecord (once per experiment): agent, benchmark, git provenance
+    eval_log.jsonl          — EpisodeRecord per line: outcome, usage, trajectory summary
 
-The Pydantic models are for internal convenience; the on-disk format is plain JSON,
-so downstream frameworks (non-Python, non-cube) can consume it without any dependency
-on cube-harness.
+Records are plain JSON, no cube-harness dependency to read.
 
 Classes:
-    UsageSummary   — aggregated LLM token usage and cost across an episode
-    AgentInfo      — full agent descriptor: config, capabilities, dependencies, git provenance
-    TaskInfo       — full task descriptor: benchmark metadata, task metadata, content hash
-    TaskEvalRecord — complete evaluation record ready for Atlas ingestion
-    EvalLog        — collection of records with JSONL save/load and streaming append
+    UsageSummary      — aggregated LLM token/cost stats across an episode
+    AgentInfo         — agent descriptor: config, dependency versions, git provenance
+    BenchmarkSubset   — benchmark subset descriptor for MNAR propensity correction
+    JudgeConfig       — configuration of the judge LLM (optional)
+    JudgeOutput       — per-episode judge assessment (optional)
+    Verifier          — task verifier reference (optional)
+    ExperimentRecord  — experiment-level record written to experiment_record.json
+    EpisodeRecord     — episode-level record appended to eval_log.jsonl
+    EvalLog           — two-level container with save/load
 """
 
 import hashlib
@@ -22,17 +24,17 @@ import json
 import logging
 import re
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
-from cube.core import EnvironmentOutput, TypedBaseModel
+from cube.core import TypedBaseModel
 from pydantic import Field
 
 from cube_harness.core import Trajectory
 
 logger = logging.getLogger(__name__)
 
-# Key packages whose installed versions are captured for reproducibility.
 _TRACKED_PACKAGES: list[str] = [
     "cube-harness",
     "cube",
@@ -144,22 +146,6 @@ def _extract_error_type(trajectory: Trajectory) -> str | None:
     return None
 
 
-def _extract_first_observation_text(trajectory: Trajectory) -> str | None:
-    """Extract text content from the first EnvironmentOutput in the trajectory.
-
-    This is the actual task instruction as the agent received it.
-    """
-    for step in trajectory.steps:
-        if isinstance(step.output, EnvironmentOutput):
-            texts = [
-                content.data
-                for content in step.output.obs.contents
-                if isinstance(getattr(content, "data", None), str)
-            ]
-            return "\n".join(texts) if texts else None
-    return None
-
-
 # ---------------------------------------------------------------------------
 # Public models
 # ---------------------------------------------------------------------------
@@ -195,42 +181,21 @@ class UsageSummary(TypedBaseModel):
 
 
 class AgentInfo(TypedBaseModel):
-    """Complete agent descriptor for Atlas embedding and reproducibility.
+    """Agent descriptor for Atlas embedding and reproducibility.
 
-    Designed for maximum downstream utility: includes structured fields (config, tools,
-    versions) that can be queried or used to synthesize a prose description for LLM
-    embedding, without requiring access to the agent's source code.
+    Tools are NOT included here — they vary per episode due to task-level action filtering.
+    See EpisodeRecord.tool_names for the per-episode tool list.
     """
 
-    # Identity
-    agent_id: str = Field(
-        description="SHA-256 of the serialized agent config — stable unique identifier across runs."
-    )
-
-    # Config (structured, queryable)
+    agent_id: str = Field(description="SHA-256 of the serialized agent config — stable unique identifier across runs.")
     config_type: str = Field(description="Agent config class name (from _type discriminator field).")
     config: dict = Field(description="Full serialized agent config (model_dump with serialize_as_any=True).")
     llm_model: str | None = Field(default=None, description="LLM model name extracted from config.")
-
-    # Capabilities — populated per-episode from the action set given to this agent.
-    # The same agent gets different tools on different tasks; these reflect THIS episode.
-    tools: list[dict] = Field(
-        default_factory=list,
-        description="Full action schemas in litellm function-call format (type, function.name, description, parameters).",
-    )
-    tool_names: list[str] = Field(
-        default_factory=list,
-        description="Action names for quick lookup — derived from tools.",
-    )
-
-    # Runtime environment
     framework_version: str = Field(description="cube-harness version at eval time.")
     dependency_versions: dict[str, str] = Field(
         default_factory=dict,
-        description="Installed versions of key packages (cube-harness, litellm, anthropic, openai, ...).",
+        description="Installed versions of tracked packages (cube-harness, litellm, anthropic, openai, ...).",
     )
-
-    # Code provenance — enables Atlas to link records to an exact, auditable code state.
     git_commit: str | None = Field(default=None, description="Git SHA-1 of the repo HEAD at eval time.")
     git_remote_url: str | None = Field(
         default=None,
@@ -243,32 +208,21 @@ class AgentInfo(TypedBaseModel):
             "from git_commit alone. None when git info is unavailable."
         ),
     )
-
-    # Optional prose — intended for Atlas LLM embedding warm-start.
-    # Can be human-authored or synthesized from the structured fields above.
     description: str | None = Field(
         default=None,
-        description=(
-            "Free-form prose description of the agent (e.g. 'ReAct agent using gpt-4o, "
-            "browser tools, no memory, 16k context window'). "
-            "Used by Atlas to embed the agent in latent space via a frontier LLM."
-        ),
+        description="Free-form prose description of the agent for Atlas LLM embedding warm-start.",
     )
 
     @classmethod
     def from_agent_config(
         cls,
         agent_config: Any,
-        action_schemas: list[dict] | None = None,
         git_cwd: str | None = None,
     ) -> "AgentInfo":
-        """Build AgentInfo from a serialized agent config.
+        """Build AgentInfo from an agent config object.
 
         Args:
             agent_config: Any AgentConfig (TypedBaseModel subclass).
-            action_schemas: Pre-serialized action schemas in litellm format, as stored
-                            in trajectory.metadata["action_schemas"]. If provided, no
-                            task instantiation is needed to capture capabilities.
             git_cwd: Working directory for git commands. Defaults to CWD.
         """
         harness_version = _get_package_version("cube-harness") or "unknown"
@@ -276,8 +230,6 @@ class AgentInfo(TypedBaseModel):
         agent_id = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
         config_type = config_dict.get("_type", type(agent_config).__name__)
         llm_model = _extract_llm_model(config_dict)
-        tools = action_schemas or []
-        tool_names = _extract_tool_names(tools)
         git_commit, git_remote_url, git_is_dirty = _get_git_info(cwd=git_cwd)
 
         return cls(
@@ -285,8 +237,6 @@ class AgentInfo(TypedBaseModel):
             config_type=config_type,
             config=config_dict,
             llm_model=llm_model,
-            tools=tools,
-            tool_names=tool_names,
             framework_version=harness_version,
             dependency_versions=_collect_dependency_versions(),
             git_commit=git_commit,
@@ -294,167 +244,141 @@ class AgentInfo(TypedBaseModel):
             git_is_dirty=git_is_dirty,
         )
 
-    def with_action_schemas(self, action_schemas: list[dict]) -> "AgentInfo":
-        """Return a copy of this AgentInfo with the given action schemas applied."""
-        return self.model_copy(update={"tools": action_schemas, "tool_names": _extract_tool_names(action_schemas)})
 
+class BenchmarkSubset(TypedBaseModel):
+    """Benchmark subset descriptor for MNAR propensity correction.
 
-class TaskInfo(TypedBaseModel):
-    """Complete task descriptor for Atlas embedding and reproducibility.
-
-    Covers both the benchmark-level context (name, version, authors) and the specific
-    task instance (id, seed, split, description). The first_observation_text field
-    carries the actual instruction the agent saw — crucial for Atlas task embedding.
+    Automatically derived from the benchmark object. The name field captures any subset
+    suffix applied via subset_from_glob (e.g., "[level=l1]") or subset_from_list.
+    n_tasks is the denominator for computing completion rate without requiring the benchmark.
     """
 
-    # Benchmark identity
-    benchmark_id: str = Field(description="Stable machine-readable benchmark identifier (lowercased name).")
-    benchmark_name: str = Field(description="Human-readable benchmark name (from BenchmarkMetadata).")
-    benchmark_version: str | None = Field(default=None, description="Benchmark version string.")
-    benchmark_description: str | None = Field(default=None, description="Benchmark description.")
-    benchmark_authors: list[str] = Field(default_factory=list, description="Benchmark author names.")
-    benchmark_tags: list[str] = Field(
-        default_factory=list, description="Benchmark tags (domain, modality, difficulty, etc.)."
-    )
-
-    # Task identity
-    task_id: str = Field(description="Unique task identifier within the benchmark.")
-    task_version_hash: str | None = Field(
+    name: str = Field(description="Benchmark name including any subset suffix (benchmark_metadata.name).")
+    n_tasks: int = Field(description="Total tasks in this subset — denominator for completion rate.")
+    filter: str | None = Field(
         default=None,
-        description=(
-            "SHA-256 of the serialized TaskConfig JSON. Detects task drift: if a benchmark update "
-            "silently changes a task, the hash changes and Atlas can flag the record as stale."
-        ),
-    )
-    seed: int | None = Field(default=None, description="Random seed for this task instance.")
-    split: str | None = Field(default=None, description="Dataset split: 'train', 'val', or 'test'.")
-
-    # Task description (layered, as Atlas specifies)
-    abstract_description: str | None = Field(
-        default=None,
-        description=(
-            "Broad task description from TaskMetadata.abstract_description — for searching and "
-            "filtering only. Not the specific goal shown to the agent."
-        ),
-    )
-    first_observation_text: str | None = Field(
-        default=None,
-        description=(
-            "Text content of the first observation as the agent received it — the actual task "
-            "instruction. This is the primary field for Atlas task embedding."
-        ),
-    )
-    recommended_max_steps: int | None = Field(
-        default=None, description="Benchmark-recommended step budget for this task."
-    )
-    extra_info: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional task metadata from TaskMetadata.extra_info (difficulty, domain, etc.).",
+        description="Glob expression if the subset was created via subset_from_glob.",
     )
 
     @classmethod
-    def from_trajectory_and_metadata(
+    def from_benchmark(cls, benchmark: Any) -> "BenchmarkSubset":
+        """Derive BenchmarkSubset from a cube Benchmark object."""
+        bm_metadata = getattr(benchmark, "benchmark_metadata", None)
+        name = bm_metadata.name if bm_metadata else "unknown"
+        n_tasks = len(getattr(benchmark, "task_metadata", {}))
+        return cls(name=name, n_tasks=n_tasks)
+
+
+class JudgeConfig(TypedBaseModel):
+    """Configuration of the LLM judge used for post-hoc episode assessment."""
+
+    model: str = Field(description="Judge model identifier (e.g. 'claude-opus-4-7').")
+    prompt_version: str = Field(description="Version or hash of the judge prompt template.")
+    judged_at: str | None = Field(default=None, description="ISO-8601 timestamp when judging was run.")
+
+
+class JudgeOutput(TypedBaseModel):
+    """Per-episode assessment from a post-hoc LLM judge."""
+
+    difficulty: str | None = Field(default=None, description="Estimated task difficulty (free-form or enum).")
+    feasible: bool | None = Field(default=None, description="Whether the task was deemed completable by the judge.")
+    failure_root_cause: str | None = Field(default=None, description="Short description of why the agent failed.")
+
+
+class Verifier(TypedBaseModel):
+    """Task verifier reference for reproducibility and post-hoc inspection."""
+
+    ref: str | None = Field(
+        default=None,
+        description="Permanent GitHub URL pointing to the verifier function at the exact commit.",
+    )
+    source: str | None = Field(
+        default=None,
+        description="Verifier source code at eval time (for auditing without git access).",
+    )
+
+
+class ExperimentRecord(TypedBaseModel):
+    """Experiment-level record. Written once to experiment_record.json.
+
+    Contains all fields shared across every episode: agent description, benchmark
+    metadata, git provenance. EpisodeRecord links to this via experiment_id.
+    """
+
+    experiment_id: str = Field(description="SHA-256(experiment_name + output_dir)[:16] — stable within a run.")
+    experiment_name: str = Field(description="Experiment name as set in Experiment.name.")
+    timestamp: float = Field(description="Experiment export time as Unix timestamp.")
+    framework_version: str = Field(description="cube-harness version.")
+    agent: AgentInfo = Field(description="Agent descriptor (config, dependency versions, git provenance).")
+    benchmark_name: str = Field(description="Benchmark name from benchmark_metadata.name.")
+    benchmark_version: str | None = Field(default=None, description="Benchmark version string.")
+    benchmark_subset: BenchmarkSubset = Field(description="Subset descriptor for MNAR propensity correction.")
+    judge_config: JudgeConfig | None = Field(
+        default=None,
+        description="Judge configuration if a post-hoc LLM judge was run on these episodes.",
+    )
+
+    @classmethod
+    def from_experiment(
         cls,
-        trajectory: Trajectory,
-        benchmark_metadata: Any | None = None,
-        task_metadata: Any | None = None,
-        task_config: Any | None = None,
-    ) -> "TaskInfo":
-        """Build TaskInfo from a completed trajectory and optional rich metadata.
-
-        Args:
-            trajectory: Completed episode trajectory (provides task_id, first obs text).
-            benchmark_metadata: cube.benchmark.BenchmarkMetadata (provides name, version, ...).
-            task_metadata: cube.task.TaskMetadata for this task (provides split, description, ...).
-            task_config: cube.task.TaskConfig for this episode (provides seed, content hash).
-        """
-        task_id: str = trajectory.metadata.get("task_id", "")
-
-        if benchmark_metadata is not None:
-            bm_name: str = benchmark_metadata.name
-            bm_id: str = bm_name.lower().replace(" ", "-").replace("+", "plus")
-            bm_version: str | None = benchmark_metadata.version
-            bm_description: str | None = benchmark_metadata.description
-            bm_authors: list[str] = list(benchmark_metadata.authors)
-            bm_tags: list[str] = list(benchmark_metadata.tags)
-        else:
-            bm_name = trajectory.metadata.get("benchmark_name", "unknown")
-            bm_id = bm_name.lower().replace(" ", "-")
-            bm_version = None
-            bm_description = None
-            bm_authors = []
-            bm_tags = []
-
-        split: str | None = None
-        abstract_description: str | None = None
-        recommended_max_steps: int | None = None
-        extra_info: dict[str, Any] = {}
-        if task_metadata is not None:
-            split = task_metadata.split
-            abstract_description = task_metadata.abstract_description or None
-            recommended_max_steps = task_metadata.recommended_max_steps
-            extra_info = dict(task_metadata.extra_info)
-
-        task_version_hash: str | None = None
-        seed: int | None = None
-        if task_config is not None:
-            task_version_hash = hashlib.sha256(
-                task_config.model_dump_json(serialize_as_any=True).encode()
-            ).hexdigest()
-            seed = task_config.seed
+        exp_name: str,
+        output_dir: Path,
+        agent_config: Any,
+        benchmark: Any,
+        git_cwd: str | None = None,
+    ) -> "ExperimentRecord":
+        """Build ExperimentRecord from experiment parameters."""
+        experiment_id = hashlib.sha256(f"{exp_name}{output_dir}".encode()).hexdigest()[:16]
+        harness_version = _get_package_version("cube-harness") or "unknown"
+        agent_info = AgentInfo.from_agent_config(agent_config, git_cwd=git_cwd)
+        bm_metadata = getattr(benchmark, "benchmark_metadata", None)
+        bm_name = bm_metadata.name if bm_metadata else "unknown"
+        bm_version = getattr(bm_metadata, "version", None) if bm_metadata else None
 
         return cls(
-            benchmark_id=bm_id,
+            experiment_id=experiment_id,
+            experiment_name=exp_name,
+            timestamp=time.time(),
+            framework_version=harness_version,
+            agent=agent_info,
             benchmark_name=bm_name,
             benchmark_version=bm_version,
-            benchmark_description=bm_description,
-            benchmark_authors=bm_authors,
-            benchmark_tags=bm_tags,
-            task_id=task_id,
-            task_version_hash=task_version_hash,
-            seed=seed,
-            split=split,
-            abstract_description=abstract_description,
-            first_observation_text=_extract_first_observation_text(trajectory),
-            recommended_max_steps=recommended_max_steps,
-            extra_info=extra_info,
+            benchmark_subset=BenchmarkSubset.from_benchmark(benchmark),
         )
 
 
-class TaskEvalRecord(TypedBaseModel):
-    """Complete evaluation record for one agent-task episode.
+class EpisodeRecord(TypedBaseModel):
+    """Episode-level record. One line per episode in eval_log.jsonl.
 
-    Compatible with Project ATLAS TaskEvalRecord schema. The on-disk format is plain
-    JSON (JSONL), consumable by any framework without a cube-harness dependency.
-
-    Field groups follow the ATLAS design:
-        task        — what was evaluated
-        agent       — who evaluated it
-        outcome     — how it went (reward, errors)
-        trajectory  — execution summary (steps, tokens, time)
-        provenance  — when, where, with what framework version
+    Links to ExperimentRecord via experiment_id. Contains all episode-specific fields:
+    task identity, per-episode tool list, outcome, usage, and optional judge output.
     """
 
-    # Nested descriptors
-    task: TaskInfo
-    agent: AgentInfo
-
-    # Outcome
-    success: bool = Field(description="True when final reward > 0.")
-    reward: float = Field(description="Final reward from the last EnvironmentOutput.")
-    reward_breakdown: dict = Field(
-        default_factory=dict,
-        description="Full reward_info dict from the trajectory (may include sub-goal scores, done flag, etc.).",
-    )
-    error_type: str | None = Field(
+    experiment_id: str = Field(description="FK to ExperimentRecord.experiment_id.")
+    task_id: str = Field(description="Unique task identifier within the benchmark.")
+    task_version_hash: str | None = Field(
         default=None,
+        description="SHA-256 of TaskConfig JSON. Detects task drift across benchmark versions.",
+    )
+    seed: int | None = Field(default=None, description="Random seed for this task instance.")
+    split: str | None = Field(default=None, description="Dataset split: 'train', 'val', or 'test'.")
+    task_description: str | None = Field(
+        default=None,
+        description="Abstract task description from TaskMetadata.abstract_description.",
+    )
+    tool_names: list[str] = Field(
+        default_factory=list,
         description=(
-            "Exception class name if any step raised an error (e.g. 'TimeoutError', 'ValueError'). "
-            "None for clean episodes (even if reward=0)."
+            "Action names available during this episode. Episode-specific: same agent gets "
+            "different tools on different tasks due to task-level action filtering."
         ),
     )
-
-    # Trajectory summary
+    success: bool = Field(description="True when final reward > 0.")
+    reward: float = Field(description="Final reward from the last EnvironmentOutput.")
+    error_type: str | None = Field(
+        default=None,
+        description="Exception class name if any step raised an error. None for clean episodes.",
+    )
     n_steps: int = Field(description="Total trajectory steps (agent + env combined).")
     n_agent_steps: int = Field(description="Agent steps (LLM decision turns).")
     n_env_steps: int = Field(description="Environment steps (tool executions).")
@@ -463,35 +387,30 @@ class TaskEvalRecord(TypedBaseModel):
         default_factory=UsageSummary,
         description="Aggregated LLM token usage and cost for the episode.",
     )
-
-    # Provenance
-    run_id: str = Field(description="Unique run identifier: '{exp_name}_{trajectory_id}'.")
     trajectory_id: str = Field(description="Trajectory ID as stored on disk.")
     timestamp: float = Field(description="Episode start time as Unix timestamp.")
-    framework_version: str = Field(description="cube-harness version.")
-
-    # MNAR bias correction — required for ATLAS community submissions.
-    # motivation: why this run was submitted ("capability_probe"|"leaderboard"|"training_data"|"debugging")
-    # task_selection_method: how tasks were chosen ("random"|"difficulty_stratified"|"domain_filtered"|"cherry_picked")
-    # compute_budget: how much was run ("full_benchmark"|"partial"|"targeted")
-    declaration: dict = Field(
-        default_factory=dict,
-        description=(
-            "Self-reported selection intent for MNAR bias correction. "
-            "Required for ATLAS community submissions; omit for local use."
-        ),
+    verifier: Verifier | None = Field(
+        default=None,
+        description="Task verifier reference for reproducibility and post-hoc inspection.",
+    )
+    judge_output: JudgeOutput | None = Field(
+        default=None,
+        description="Per-episode LLM judge assessment (difficulty, feasibility, failure root cause).",
     )
 
     @classmethod
     def from_trajectory(
         cls,
         trajectory: Trajectory,
-        agent_info: AgentInfo,
-        task_info: TaskInfo,
-        exp_name: str = "",
-    ) -> "TaskEvalRecord":
-        """Assemble a TaskEvalRecord from a completed trajectory and pre-built info objects."""
-        harness_version = _get_package_version("cube-harness") or "unknown"
+        experiment_id: str,
+        task_metadata: Any | None = None,
+        task_config: Any | None = None,
+    ) -> "EpisodeRecord":
+        """Assemble an EpisodeRecord from a completed trajectory."""
+        task_id = trajectory.metadata.get("task_id", "")
+        action_schemas: list[dict] = trajectory.metadata.get("action_schemas", [])
+        tool_names = _extract_tool_names(action_schemas)
+
         last_env = trajectory.last_env_step()
         reward = last_env.reward
         stats = trajectory.summary_stats or {}
@@ -500,66 +419,85 @@ class TaskEvalRecord(TypedBaseModel):
         if trajectory.start_time is not None and trajectory.end_time is not None:
             wall_time_s = trajectory.end_time - trajectory.start_time
 
+        task_version_hash: str | None = None
+        seed: int | None = None
+        if task_config is not None:
+            task_version_hash = hashlib.sha256(
+                task_config.model_dump_json(serialize_as_any=True).encode()
+            ).hexdigest()
+            seed = getattr(task_config, "seed", None)
+
+        split: str | None = None
+        task_description: str | None = None
+        if task_metadata is not None:
+            split = getattr(task_metadata, "split", None)
+            task_description = getattr(task_metadata, "abstract_description", None) or None
+
         return cls(
-            task=task_info,
-            agent=agent_info,
+            experiment_id=experiment_id,
+            task_id=task_id,
+            task_version_hash=task_version_hash,
+            seed=seed,
+            split=split,
+            task_description=task_description,
+            tool_names=tool_names,
             success=reward > 0,
             reward=reward,
-            reward_breakdown=dict(trajectory.reward_info),
             error_type=_extract_error_type(trajectory),
             n_steps=len(trajectory.steps),
             n_agent_steps=stats.get("n_agent_steps", trajectory.n_agent_steps),
             n_env_steps=stats.get("n_env_steps", trajectory.n_env_steps),
             wall_time_s=wall_time_s,
             usage=UsageSummary.from_summary_stats(stats),
-            run_id=f"{exp_name}_{trajectory.id}" if exp_name else trajectory.id,
             trajectory_id=trajectory.id,
             timestamp=trajectory.start_time or 0.0,
-            framework_version=harness_version,
         )
 
 
 class EvalLog(TypedBaseModel):
-    """Collection of TaskEvalRecords with JSONL serialization.
+    """Two-level eval log container with JSONL serialization.
 
-    The JSONL format (one JSON object per line) is the Atlas-compatible wire format.
-    Each line is a self-contained TaskEvalRecord — no schema header, no envelope.
-    Other frameworks read/write the same format without any cube-harness dependency.
+    Experiment-level data goes to experiment_record.json (written once).
+    Episode-level data goes to eval_log.jsonl (one JSON object per line).
 
-    For large experiments, prefer append_record() (streaming) over save_jsonl()
-    (in-memory) to avoid materializing all records at once.
+    Both files are plain JSON, readable by any framework without a cube-harness dependency.
     """
 
-    records: list[TaskEvalRecord] = Field(default_factory=list)
+    experiment: ExperimentRecord
+    episodes: list[EpisodeRecord] = Field(default_factory=list)
 
-    def save_jsonl(self, path: Path) -> None:
-        """Write all records to a JSONL file (one JSON object per line)."""
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            for record in self.records:
+    def save(self, output_dir: Path) -> None:
+        """Write experiment_record.json and eval_log.jsonl to output_dir."""
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        exp_path = output_dir / "experiment_record.json"
+        exp_path.write_text(self.experiment.model_dump_json(indent=2))
+        episodes_path = output_dir / "eval_log.jsonl"
+        with open(episodes_path, "w") as f:
+            for record in self.episodes:
                 f.write(record.model_dump_json() + "\n")
-        logger.info(f"Saved {len(self.records)} eval records to {path}")
+        logger.info(f"Saved experiment record to {exp_path}")
+        logger.info(f"Saved {len(self.episodes)} episode records to {episodes_path}")
 
     @classmethod
-    def load_jsonl(cls, path: Path) -> "EvalLog":
-        """Load all records from a JSONL file."""
-        path = Path(path)
-        records = []
-        with open(path) as f:
+    def load(cls, output_dir: Path) -> "EvalLog":
+        """Load experiment_record.json and eval_log.jsonl from output_dir."""
+        output_dir = Path(output_dir)
+        experiment = ExperimentRecord.model_validate_json((output_dir / "experiment_record.json").read_text())
+        episodes: list[EpisodeRecord] = []
+        with open(output_dir / "eval_log.jsonl") as f:
             for line in f:
                 line = line.strip()
                 if line:
-                    records.append(TaskEvalRecord.model_validate_json(line))
-        return cls(records=records)
+                    episodes.append(EpisodeRecord.model_validate_json(line))
+        return cls(experiment=experiment, episodes=episodes)
 
     @staticmethod
-    def append_record(record: TaskEvalRecord, path: Path) -> None:
-        """Append a single record to a JSONL file (streaming mode).
+    def append_episode(record: EpisodeRecord, path: Path) -> None:
+        """Append a single EpisodeRecord to a JSONL file (streaming mode).
 
-        Suitable for writing records immediately after each episode without holding
-        the full log in memory. Not safe for concurrent multi-process writes without
-        external file locking.
+        Suitable for writing records immediately after each episode without holding the full
+        log in memory. Not safe for concurrent multi-process writes without external file locking.
         """
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -28,6 +28,7 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from cube.core import TypedBaseModel
 from pydantic import Field
@@ -145,11 +146,6 @@ def _extract_error_type(trajectory: Trajectory) -> str | None:
         if hasattr(step.output, "error") and step.output.error is not None:
             return step.output.error.error_type
     return None
-
-
-def compute_evaluation_id(exp_name: str, output_dir: Path) -> str:
-    """Return a stable 16-char evaluation_id from experiment name + output dir."""
-    return hashlib.sha256(f"{exp_name}{output_dir}".encode()).hexdigest()[:16]
 
 
 # ---------------------------------------------------------------------------
@@ -348,7 +344,7 @@ class ExperimentRecord(TypedBaseModel):
         bm_version = getattr(bm_metadata, "version", None) if bm_metadata else None
 
         return cls(
-            evaluation_id=compute_evaluation_id(exp_name, output_dir),
+            evaluation_id=f"{exp_name}_{uuid4().hex[:8]}",
             experiment_name=exp_name,
             evaluation_timestamp=time.time(),
             eval_library=EvalLibrary(version=harness_version),

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -33,8 +33,12 @@ from cube.core import TypedBaseModel
 from pydantic import Field
 
 from cube_harness.core import Trajectory
+from cube_harness.storage import EPISODES_DIR as _EPISODES_DIR
 
 logger = logging.getLogger(__name__)
+
+EPISODE_RECORD_FILENAME = "episode_record.json"
+EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
 
 _TRACKED_PACKAGES: list[str] = [
     "cube-harness",
@@ -313,7 +317,7 @@ class ExperimentRecord(TypedBaseModel):
     metadata, git provenance. EpisodeRecord links to this via evaluation_id.
     """
 
-    evaluation_id: str = Field(description="SHA-256(experiment_name + output_dir)[:16] — stable within a run.")
+    evaluation_id: str = Field(description="output_dir.name — unique per run (includes UUID suffix from make_experiment_output_dir).")
     experiment_name: str = Field(description="Experiment name as set in Experiment.name.")
     evaluation_timestamp: float = Field(description="Experiment start time as Unix timestamp.")
     eval_library: EvalLibrary = Field(description="Library that produced the evaluation.")
@@ -473,11 +477,6 @@ class EpisodeRecord(TypedBaseModel):
         ep_dir = Path(output_dir) / _EPISODES_DIR / self.trajectory_id
         ep_dir.mkdir(parents=True, exist_ok=True)
         (ep_dir / EPISODE_RECORD_FILENAME).write_text(self.model_dump_json(indent=2))
-
-
-EPISODE_RECORD_FILENAME = "episode_record.json"
-EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
-_EPISODES_DIR = "episodes"
 
 
 class EvalLog(TypedBaseModel):

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -454,52 +454,65 @@ class EpisodeRecord(TypedBaseModel):
         )
 
 
+EPISODE_RECORD_FILENAME = "episode_record.json"
+EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
+_EPISODES_DIR = "episodes"
+
+
 class EvalLog(TypedBaseModel):
-    """Two-level eval log container with JSONL serialization.
+    """Two-level eval log container.
 
     Experiment-level data goes to experiment_record.json (written once).
-    Episode-level data goes to eval_log.jsonl (one JSON object per line).
+    Episode-level data goes to episodes/<trajectory_id>/episode_record.json
+    (one file per episode, co-located with the trajectory).
 
-    Both files are plain JSON, readable by any framework without a cube-harness dependency.
+    All files are plain JSON, readable without a cube-harness dependency.
+
+    For ATLAS submission, call to_jsonl() to aggregate episode records into a
+    single flat JSONL file.
     """
 
     experiment: ExperimentRecord
     episodes: list[EpisodeRecord] = Field(default_factory=list)
 
     def save(self, output_dir: Path) -> None:
-        """Write experiment_record.json and eval_log.jsonl to output_dir."""
+        """Write experiment_record.json and per-trajectory episode_record.json files."""
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        exp_path = output_dir / "experiment_record.json"
+        exp_path = output_dir / EXPERIMENT_RECORD_FILENAME
         exp_path.write_text(self.experiment.model_dump_json(indent=2))
-        episodes_path = output_dir / "eval_log.jsonl"
-        with open(episodes_path, "w") as f:
-            for record in self.episodes:
-                f.write(record.model_dump_json() + "\n")
+        for record in self.episodes:
+            ep_dir = output_dir / _EPISODES_DIR / record.trajectory_id
+            ep_dir.mkdir(parents=True, exist_ok=True)
+            (ep_dir / EPISODE_RECORD_FILENAME).write_text(record.model_dump_json(indent=2))
         logger.info(f"Saved experiment record to {exp_path}")
-        logger.info(f"Saved {len(self.episodes)} episode records to {episodes_path}")
+        logger.info(f"Saved {len(self.episodes)} episode records under {output_dir / _EPISODES_DIR}")
 
     @classmethod
     def load(cls, output_dir: Path) -> "EvalLog":
-        """Load experiment_record.json and eval_log.jsonl from output_dir."""
+        """Load experiment_record.json and all per-trajectory episode_record.json files."""
         output_dir = Path(output_dir)
-        experiment = ExperimentRecord.model_validate_json((output_dir / "experiment_record.json").read_text())
+        experiment = ExperimentRecord.model_validate_json(
+            (output_dir / EXPERIMENT_RECORD_FILENAME).read_text()
+        )
         episodes: list[EpisodeRecord] = []
-        with open(output_dir / "eval_log.jsonl") as f:
-            for line in f:
-                line = line.strip()
-                if line:
-                    episodes.append(EpisodeRecord.model_validate_json(line))
+        episodes_dir = output_dir / _EPISODES_DIR
+        if episodes_dir.exists():
+            for ep_dir in sorted(episodes_dir.iterdir()):
+                record_path = ep_dir / EPISODE_RECORD_FILENAME
+                if ep_dir.is_dir() and record_path.exists():
+                    episodes.append(EpisodeRecord.model_validate_json(record_path.read_text()))
         return cls(experiment=experiment, episodes=episodes)
 
-    @staticmethod
-    def append_episode(record: EpisodeRecord, path: Path) -> None:
-        """Append a single EpisodeRecord to a JSONL file (streaming mode).
+    def to_jsonl(self, path: Path) -> None:
+        """Write all episode records as a flat JSONL file for ATLAS submission.
 
-        Suitable for writing records immediately after each episode without holding the full
-        log in memory. Not safe for concurrent multi-process writes without external file locking.
+        Each line is a self-contained EpisodeRecord JSON object. No cube-harness
+        dependency required to read the output.
         """
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "a") as f:
-            f.write(record.model_dump_json() + "\n")
+        with open(path, "w") as f:
+            for record in self.episodes:
+                f.write(record.model_dump_json() + "\n")
+        logger.info(f"Exported {len(self.episodes)} episode records to {path}")

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -28,7 +28,6 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 from cube.core import TypedBaseModel
 from pydantic import Field
@@ -344,7 +343,7 @@ class ExperimentRecord(TypedBaseModel):
         bm_version = getattr(bm_metadata, "version", None) if bm_metadata else None
 
         return cls(
-            evaluation_id=f"{exp_name}_{uuid4().hex[:8]}",
+            evaluation_id=Path(output_dir).name,
             experiment_name=exp_name,
             evaluation_timestamp=time.time(),
             eval_library=EvalLibrary(version=harness_version),

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -2,11 +2,12 @@
 
 Two files per experiment:
     experiment_record.json  — ExperimentRecord (once per experiment): agent, benchmark, git provenance
-    eval_log.jsonl          — EpisodeRecord per line: outcome, usage, trajectory summary
+    episodes/<id>/episode_record.json  — one EpisodeRecord per episode, written after each episode
 
 Records are plain JSON, no cube-harness dependency to read.
 
 Classes:
+    EvalLibrary       — library descriptor (name, version)
     UsageSummary      — aggregated LLM token/cost stats across an episode
     AgentInfo         — agent descriptor: config, dependency versions, git provenance
     BenchmarkSubset   — benchmark subset descriptor for MNAR propensity correction
@@ -14,7 +15,7 @@ Classes:
     JudgeOutput       — per-episode judge assessment (optional)
     Verifier          — task verifier reference (optional)
     ExperimentRecord  — experiment-level record written to experiment_record.json
-    EpisodeRecord     — episode-level record appended to eval_log.jsonl
+    EpisodeRecord     — episode-level record written after each episode completes
     EvalLog           — two-level container with save/load
 """
 
@@ -146,19 +147,31 @@ def _extract_error_type(trajectory: Trajectory) -> str | None:
     return None
 
 
+def compute_evaluation_id(exp_name: str, output_dir: Path) -> str:
+    """Return a stable 16-char evaluation_id from experiment name + output dir."""
+    return hashlib.sha256(f"{exp_name}{output_dir}".encode()).hexdigest()[:16]
+
+
 # ---------------------------------------------------------------------------
 # Public models
 # ---------------------------------------------------------------------------
 
 
+class EvalLibrary(TypedBaseModel):
+    """Library that produced the evaluation."""
+
+    name: str = "cube-harness"
+    version: str
+
+
 class UsageSummary(TypedBaseModel):
     """Aggregated LLM token usage and cost across a complete episode."""
 
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
     total_tokens: int = 0
-    cached_tokens: int = 0
-    cache_creation_tokens: int = 0
+    input_tokens_cache_read: int = 0
+    input_tokens_cache_write: int = 0
     total_cost_usd: float = 0.0
     n_llm_calls: int = 0
 
@@ -170,11 +183,11 @@ class UsageSummary(TypedBaseModel):
         prompt = stats.get("prompt_tokens", 0)
         completion = stats.get("completion_tokens", 0)
         return cls(
-            prompt_tokens=prompt,
-            completion_tokens=completion,
+            input_tokens=prompt,
+            output_tokens=completion,
             total_tokens=prompt + completion,
-            cached_tokens=stats.get("cached_tokens", 0),
-            cache_creation_tokens=stats.get("cache_creation_tokens", 0),
+            input_tokens_cache_read=stats.get("cached_tokens", 0),
+            input_tokens_cache_write=stats.get("cache_creation_tokens", 0),
             total_cost_usd=stats.get("cost", 0.0),
             n_llm_calls=stats.get("total_llm_calls", 0),
         )
@@ -299,16 +312,16 @@ class Verifier(TypedBaseModel):
 
 
 class ExperimentRecord(TypedBaseModel):
-    """Experiment-level record. Written once to experiment_record.json.
+    """Experiment-level record. Written once to experiment_record.json at experiment start.
 
     Contains all fields shared across every episode: agent description, benchmark
-    metadata, git provenance. EpisodeRecord links to this via experiment_id.
+    metadata, git provenance. EpisodeRecord links to this via evaluation_id.
     """
 
-    experiment_id: str = Field(description="SHA-256(experiment_name + output_dir)[:16] — stable within a run.")
+    evaluation_id: str = Field(description="SHA-256(experiment_name + output_dir)[:16] — stable within a run.")
     experiment_name: str = Field(description="Experiment name as set in Experiment.name.")
-    timestamp: float = Field(description="Experiment export time as Unix timestamp.")
-    framework_version: str = Field(description="cube-harness version.")
+    evaluation_timestamp: float = Field(description="Experiment start time as Unix timestamp.")
+    eval_library: EvalLibrary = Field(description="Library that produced the evaluation.")
     agent: AgentInfo = Field(description="Agent descriptor (config, dependency versions, git provenance).")
     benchmark_name: str = Field(description="Benchmark name from benchmark_metadata.name.")
     benchmark_version: str | None = Field(default=None, description="Benchmark version string.")
@@ -328,7 +341,6 @@ class ExperimentRecord(TypedBaseModel):
         git_cwd: str | None = None,
     ) -> "ExperimentRecord":
         """Build ExperimentRecord from experiment parameters."""
-        experiment_id = hashlib.sha256(f"{exp_name}{output_dir}".encode()).hexdigest()[:16]
         harness_version = _get_package_version("cube-harness") or "unknown"
         agent_info = AgentInfo.from_agent_config(agent_config, git_cwd=git_cwd)
         bm_metadata = getattr(benchmark, "benchmark_metadata", None)
@@ -336,10 +348,10 @@ class ExperimentRecord(TypedBaseModel):
         bm_version = getattr(bm_metadata, "version", None) if bm_metadata else None
 
         return cls(
-            experiment_id=experiment_id,
+            evaluation_id=compute_evaluation_id(exp_name, output_dir),
             experiment_name=exp_name,
-            timestamp=time.time(),
-            framework_version=harness_version,
+            evaluation_timestamp=time.time(),
+            eval_library=EvalLibrary(version=harness_version),
             agent=agent_info,
             benchmark_name=bm_name,
             benchmark_version=bm_version,
@@ -348,15 +360,15 @@ class ExperimentRecord(TypedBaseModel):
 
 
 class EpisodeRecord(TypedBaseModel):
-    """Episode-level record. One line per episode in eval_log.jsonl.
+    """Episode-level record. Written to episodes/<trajectory_id>/episode_record.json after each episode.
 
-    Links to ExperimentRecord via experiment_id. Contains all episode-specific fields:
+    Links to ExperimentRecord via evaluation_id. Contains all episode-specific fields:
     task identity, per-episode tool list, outcome, usage, and optional judge output.
     """
 
-    experiment_id: str = Field(description="FK to ExperimentRecord.experiment_id.")
-    task_id: str = Field(description="Unique task identifier within the benchmark.")
-    task_version_hash: str | None = Field(
+    evaluation_id: str = Field(description="FK → ExperimentRecord.evaluation_id.")
+    sample_id: str = Field(description="Unique task identifier within the benchmark.")
+    sample_hash: str | None = Field(
         default=None,
         description="SHA-256 of TaskConfig JSON. Detects task drift across benchmark versions.",
     )
@@ -373,13 +385,13 @@ class EpisodeRecord(TypedBaseModel):
             "different tools on different tasks due to task-level action filtering."
         ),
     )
-    success: bool = Field(description="True when final reward > 0.")
-    reward: float = Field(description="Final reward from the last EnvironmentOutput.")
-    error_type: str | None = Field(
+    is_correct: bool = Field(description="True when final score > 0.")
+    score: float = Field(description="Final reward from the last EnvironmentOutput.")
+    error: str | None = Field(
         default=None,
         description="Exception class name if any step raised an error. None for clean episodes.",
     )
-    n_steps: int = Field(description="Total trajectory steps (agent + env combined).")
+    num_turns: int = Field(description="Total trajectory steps (agent + env combined).")
     n_agent_steps: int = Field(description="Agent steps (LLM decision turns).")
     n_env_steps: int = Field(description="Environment steps (tool executions).")
     wall_time_s: float | None = Field(default=None, description="Episode wall-clock duration in seconds.")
@@ -402,27 +414,27 @@ class EpisodeRecord(TypedBaseModel):
     def from_trajectory(
         cls,
         trajectory: Trajectory,
-        experiment_id: str,
+        evaluation_id: str,
         task_metadata: Any | None = None,
         task_config: Any | None = None,
     ) -> "EpisodeRecord":
         """Assemble an EpisodeRecord from a completed trajectory."""
-        task_id = trajectory.metadata.get("task_id", "")
+        sample_id = trajectory.metadata.get("task_id", "")
         action_schemas: list[dict] = trajectory.metadata.get("action_schemas", [])
         tool_names = _extract_tool_names(action_schemas)
 
         last_env = trajectory.last_env_step()
-        reward = last_env.reward
+        score = last_env.reward
         stats = trajectory.summary_stats or {}
 
         wall_time_s: float | None = None
         if trajectory.start_time is not None and trajectory.end_time is not None:
             wall_time_s = trajectory.end_time - trajectory.start_time
 
-        task_version_hash: str | None = None
+        sample_hash: str | None = None
         seed: int | None = None
         if task_config is not None:
-            task_version_hash = hashlib.sha256(
+            sample_hash = hashlib.sha256(
                 task_config.model_dump_json(serialize_as_any=True).encode()
             ).hexdigest()
             seed = getattr(task_config, "seed", None)
@@ -434,17 +446,17 @@ class EpisodeRecord(TypedBaseModel):
             task_description = getattr(task_metadata, "abstract_description", None) or None
 
         return cls(
-            experiment_id=experiment_id,
-            task_id=task_id,
-            task_version_hash=task_version_hash,
+            evaluation_id=evaluation_id,
+            sample_id=sample_id,
+            sample_hash=sample_hash,
             seed=seed,
             split=split,
             task_description=task_description,
             tool_names=tool_names,
-            success=reward > 0,
-            reward=reward,
-            error_type=_extract_error_type(trajectory),
-            n_steps=len(trajectory.steps),
+            is_correct=score > 0,
+            score=score,
+            error=_extract_error_type(trajectory),
+            num_turns=len(trajectory.steps),
             n_agent_steps=stats.get("n_agent_steps", trajectory.n_agent_steps),
             n_env_steps=stats.get("n_env_steps", trajectory.n_env_steps),
             wall_time_s=wall_time_s,
@@ -459,12 +471,28 @@ EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
 _EPISODES_DIR = "episodes"
 
 
+def write_experiment_record(output_dir: Path, record: ExperimentRecord) -> None:
+    """Write experiment_record.json to output_dir."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / EXPERIMENT_RECORD_FILENAME
+    path.write_text(record.model_dump_json(indent=2))
+    logger.info(f"Saved experiment record to {path}")
+
+
+def write_episode_record(output_dir: Path, record: EpisodeRecord) -> None:
+    """Write episode_record.json to episodes/<trajectory_id>/ inside output_dir."""
+    ep_dir = Path(output_dir) / _EPISODES_DIR / record.trajectory_id
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    (ep_dir / EPISODE_RECORD_FILENAME).write_text(record.model_dump_json(indent=2))
+
+
 class EvalLog(TypedBaseModel):
     """Two-level eval log container.
 
-    Experiment-level data goes to experiment_record.json (written once).
+    Experiment-level data goes to experiment_record.json (written once at experiment start).
     Episode-level data goes to episodes/<trajectory_id>/episode_record.json
-    (one file per episode, co-located with the trajectory).
+    (one file per episode, co-located with the trajectory, written after each episode).
 
     All files are plain JSON, readable without a cube-harness dependency.
 
@@ -478,14 +506,9 @@ class EvalLog(TypedBaseModel):
     def save(self, output_dir: Path) -> None:
         """Write experiment_record.json and per-trajectory episode_record.json files."""
         output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        exp_path = output_dir / EXPERIMENT_RECORD_FILENAME
-        exp_path.write_text(self.experiment.model_dump_json(indent=2))
+        write_experiment_record(output_dir, self.experiment)
         for record in self.episodes:
-            ep_dir = output_dir / _EPISODES_DIR / record.trajectory_id
-            ep_dir.mkdir(parents=True, exist_ok=True)
-            (ep_dir / EPISODE_RECORD_FILENAME).write_text(record.model_dump_json(indent=2))
-        logger.info(f"Saved experiment record to {exp_path}")
+            write_episode_record(output_dir, record)
         logger.info(f"Saved {len(self.episodes)} episode records under {output_dir / _EPISODES_DIR}")
 
     @classmethod

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -2,8 +2,6 @@
 
 import logging
 import time
-from pathlib import Path
-from typing import Any
 from uuid import uuid4
 
 import ray
@@ -12,7 +10,6 @@ from cube_harness.core import Trajectory
 from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id, write_episode_record
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage, Storage
@@ -58,23 +55,6 @@ def _pre_claim(storage: Storage, episode: Episode) -> None:
             retry_count=next_retry_count(prior),
         ),
     )
-
-
-def _write_episode_record(
-    output_dir: Path,
-    evaluation_id: str,
-    trajectory: Trajectory,
-    episode: Episode,
-    task_metadata: Any | None = None,
-) -> None:
-    """Build and persist an EpisodeRecord immediately after an episode completes."""
-    record = EpisodeRecord.from_trajectory(
-        trajectory,
-        evaluation_id=evaluation_id,
-        task_metadata=task_metadata,
-        task_config=episode.config.task_config,
-    )
-    write_episode_record(output_dir, record)
 
 
 def run_with_ray(
@@ -193,16 +173,7 @@ def _run_with_ray_impl(
         traj_id = _trajectory_id(episode)
         log_file = get_log_path(output_dir, traj_id)
         with redirect_output_to_log(log_file, append=True, tee=False, log_format=LOG_FORMAT):
-            trajectory = episode.run()
-            # Write the episode record on the worker, co-located with the trajectory write.
-            # task_metadata (split/abstract_description) is not available on the worker —
-            # those optional fields are left None.
-            try:
-                evaluation_id = compute_evaluation_id(episode.config.exp_name, episode.config.output_dir)
-                _write_episode_record(episode.config.output_dir, evaluation_id, trajectory, episode)
-            except Exception:
-                logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
-            return trajectory
+            return episode.run()
 
     if not ray.is_initialized():
         ray.init(
@@ -472,8 +443,6 @@ def _run_sequentially_impl(
             config=exp.config,
             exp_id=f"{exp.name}_{uuid4().hex}",
         )
-        evaluation_id = compute_evaluation_id(exp.name, exp.output_dir)
-        task_metadata_index: dict[str, Any] = getattr(exp.benchmark, "task_metadata", {})
         for episode in episodes:
             traj_id = _trajectory_id(episode)
             log_file = get_log_path(exp.output_dir, traj_id)
@@ -481,17 +450,6 @@ def _run_sequentially_impl(
                 try:
                     trajectory = episode.run()
                     results.trajectories[traj_id] = trajectory
-                    task_id = trajectory.metadata.get("task_id", "")
-                    try:
-                        _write_episode_record(
-                            exp.output_dir,
-                            evaluation_id,
-                            trajectory,
-                            episode,
-                            task_metadata=task_metadata_index.get(task_id),
-                        )
-                    except Exception:
-                        logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
                 except Exception as e:
                     logger.exception(f"Episode {traj_id} failed")
                     results.failures[traj_id] = str(e)

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -2,6 +2,8 @@
 
 import logging
 import time
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import ray
@@ -58,18 +60,21 @@ def _pre_claim(storage: Storage, episode: Episode) -> None:
     )
 
 
-def _write_episode_record(exp: Experiment, trajectory: Trajectory, episode: Episode) -> None:
+def _write_episode_record(
+    output_dir: Path,
+    evaluation_id: str,
+    trajectory: Trajectory,
+    episode: Episode,
+    task_metadata: Any | None = None,
+) -> None:
     """Build and persist an EpisodeRecord immediately after an episode completes."""
-    task_id = trajectory.metadata.get("task_id", "")
-    task_metadata = getattr(exp.benchmark, "task_metadata", {}).get(task_id)
-    evaluation_id = compute_evaluation_id(exp.name, exp.output_dir)
     record = EpisodeRecord.from_trajectory(
         trajectory,
         evaluation_id=evaluation_id,
         task_metadata=task_metadata,
         task_config=episode.config.task_config,
     )
-    write_episode_record(exp.output_dir, record)
+    write_episode_record(output_dir, record)
 
 
 def run_with_ray(
@@ -188,7 +193,16 @@ def _run_with_ray_impl(
         traj_id = _trajectory_id(episode)
         log_file = get_log_path(output_dir, traj_id)
         with redirect_output_to_log(log_file, append=True, tee=False, log_format=LOG_FORMAT):
-            return episode.run()
+            trajectory = episode.run()
+            # Write the episode record on the worker, co-located with the trajectory write.
+            # task_metadata (split/abstract_description) is not available on the worker —
+            # those optional fields are left None.
+            try:
+                evaluation_id = compute_evaluation_id(episode.config.exp_name, episode.config.output_dir)
+                _write_episode_record(episode.config.output_dir, evaluation_id, trajectory, episode)
+            except Exception:
+                logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
+            return trajectory
 
     if not ray.is_initialized():
         ray.init(
@@ -213,16 +227,13 @@ def _run_with_ray_impl(
             _pre_claim(storage, episode)
 
         ref_to_traj_id: dict[ray.ObjectRef, str] = {}
-        ref_to_episode: dict[ray.ObjectRef, Episode] = {}
         for episode in episodes:
             ref = run_episode.remote(episode)
             ref_to_traj_id[ref] = _trajectory_id(episode)
-            ref_to_episode[ref] = episode
         logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
         results = _poll_ray(
             exp,
             ref_to_traj_id,
-            ref_to_episode,
             storage,
             ray_poll_timeout=ray_poll_timeout,
             step_timeout_s=step_timeout_s,
@@ -246,7 +257,6 @@ def _run_with_ray_impl(
 def _poll_ray(
     exp: Experiment,
     ref_to_traj_id: dict[ray.ObjectRef, str],
-    ref_to_episode: dict[ray.ObjectRef, Episode],
     storage: FileStorage,
     *,
     ray_poll_timeout: float,
@@ -278,10 +288,6 @@ def _poll_ray(
                     traj.n_env_steps,
                 )
                 results.trajectories[traj_id] = traj
-                try:
-                    _write_episode_record(exp, traj, ref_to_episode[task_ref])
-                except Exception:
-                    logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
             except Exception as e:
                 logger.exception(f"Run failed with exception: {e}")
                 results.failures[traj_id] = str(e)
@@ -466,6 +472,8 @@ def _run_sequentially_impl(
             config=exp.config,
             exp_id=f"{exp.name}_{uuid4().hex}",
         )
+        evaluation_id = compute_evaluation_id(exp.name, exp.output_dir)
+        task_metadata_index: dict[str, Any] = getattr(exp.benchmark, "task_metadata", {})
         for episode in episodes:
             traj_id = _trajectory_id(episode)
             log_file = get_log_path(exp.output_dir, traj_id)
@@ -473,8 +481,15 @@ def _run_sequentially_impl(
                 try:
                     trajectory = episode.run()
                     results.trajectories[traj_id] = trajectory
+                    task_id = trajectory.metadata.get("task_id", "")
                     try:
-                        _write_episode_record(exp, trajectory, episode)
+                        _write_episode_record(
+                            exp.output_dir,
+                            evaluation_id,
+                            trajectory,
+                            episode,
+                            task_metadata=task_metadata_index.get(task_id),
+                        )
                     except Exception:
                         logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
                 except Exception as e:

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -10,6 +10,7 @@ from cube_harness.core import Trajectory
 from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
+from cube_harness.eval_log import EpisodeRecord, compute_evaluation_id, write_episode_record
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage, Storage
@@ -55,6 +56,20 @@ def _pre_claim(storage: Storage, episode: Episode) -> None:
             retry_count=next_retry_count(prior),
         ),
     )
+
+
+def _write_episode_record(exp: Experiment, trajectory: Trajectory, episode: Episode) -> None:
+    """Build and persist an EpisodeRecord immediately after an episode completes."""
+    task_id = trajectory.metadata.get("task_id", "")
+    task_metadata = getattr(exp.benchmark, "task_metadata", {}).get(task_id)
+    evaluation_id = compute_evaluation_id(exp.name, exp.output_dir)
+    record = EpisodeRecord.from_trajectory(
+        trajectory,
+        evaluation_id=evaluation_id,
+        task_metadata=task_metadata,
+        task_config=episode.config.task_config,
+    )
+    write_episode_record(exp.output_dir, record)
 
 
 def run_with_ray(
@@ -198,13 +213,16 @@ def _run_with_ray_impl(
             _pre_claim(storage, episode)
 
         ref_to_traj_id: dict[ray.ObjectRef, str] = {}
+        ref_to_episode: dict[ray.ObjectRef, Episode] = {}
         for episode in episodes:
             ref = run_episode.remote(episode)
             ref_to_traj_id[ref] = _trajectory_id(episode)
+            ref_to_episode[ref] = episode
         logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
         results = _poll_ray(
             exp,
             ref_to_traj_id,
+            ref_to_episode,
             storage,
             ray_poll_timeout=ray_poll_timeout,
             step_timeout_s=step_timeout_s,
@@ -228,6 +246,7 @@ def _run_with_ray_impl(
 def _poll_ray(
     exp: Experiment,
     ref_to_traj_id: dict[ray.ObjectRef, str],
+    ref_to_episode: dict[ray.ObjectRef, Episode],
     storage: FileStorage,
     *,
     ray_poll_timeout: float,
@@ -259,6 +278,10 @@ def _poll_ray(
                     traj.n_env_steps,
                 )
                 results.trajectories[traj_id] = traj
+                try:
+                    _write_episode_record(exp, traj, ref_to_episode[task_ref])
+                except Exception:
+                    logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
             except Exception as e:
                 logger.exception(f"Run failed with exception: {e}")
                 results.failures[traj_id] = str(e)
@@ -450,6 +473,10 @@ def _run_sequentially_impl(
                 try:
                     trajectory = episode.run()
                     results.trajectories[traj_id] = trajectory
+                    try:
+                        _write_episode_record(exp, trajectory, episode)
+                    except Exception:
+                        logger.warning(f"Failed to write episode record for {traj_id}", exc_info=True)
                 except Exception as e:
                     logger.exception(f"Episode {traj_id} failed")
                     results.failures[traj_id] = str(e)

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -13,7 +13,7 @@ from cube_harness.core import Trajectory
 from cube_harness.episode import MAX_STEPS, Episode
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
-from cube_harness.eval_log import EvalLog, ExperimentRecord, write_experiment_record
+from cube_harness.eval_log import EvalLog, ExperimentRecord
 from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class Experiment(TypedBaseModel):
             benchmark=self.benchmark,
             git_cwd=self.git_cwd,
         )
-        write_experiment_record(output_path, exp_record)
+        exp_record.write(output_path)
 
     @classmethod
     def load_config(cls, path: str) -> Self:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -38,6 +38,10 @@ class Experiment(TypedBaseModel):
     git_cwd: str | None = None
 
     @property
+    def evaluation_id(self) -> str:
+        return self.output_dir.name
+
+    @property
     def config(self) -> dict:
         return self.model_dump(serialize_as_any=True)
 

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -1,12 +1,15 @@
 import json
 import logging
+import os
+import re
 import time
 from pathlib import Path
 from typing import Self
+from uuid import uuid4
 
 from cube.benchmark import Benchmark
 from cube.core import TypedBaseModel
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
@@ -17,6 +20,33 @@ from cube_harness.eval_log import EvalLog, ExperimentRecord
 from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
+
+EXP_DIR = Path(os.environ.get("CH_EXP_DIR", "~/cube_harness_results")).expanduser().resolve()
+_UUID_SUFFIX_RE = re.compile(r"_[0-9a-f]{8}$")
+
+
+def make_experiment_output_dir(
+    agent_name: str,
+    benchmark_name: str,
+    llm_name: str | None = None,
+    tag: str | None = None,
+    base_dir: Path | None = None,
+) -> Path:
+    """Create and return a unique output directory for an experiment run.
+
+    Directory name: {date}_{agent_name}_{benchmark_name}[_{llm_name}][_{tag}]_{uuid8}.
+    The directory is created before returning.
+    """
+    now = time.strftime("%Y%m%d_%H%M%S")
+    parts = [now, agent_name, benchmark_name]
+    if llm_name:
+        parts.append(llm_name)
+    if tag:
+        parts.append(tag)
+    parts.append(uuid4().hex[:8])
+    path = (base_dir or EXP_DIR) / "_".join(parts)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 class ExpResult(TypedBaseModel):
@@ -36,6 +66,12 @@ class Experiment(TypedBaseModel):
     max_steps: int = MAX_STEPS
     max_retries: int = 3
     git_cwd: str | None = None
+
+    @model_validator(mode="after")
+    def _ensure_unique_output_dir(self) -> "Experiment":
+        if not _UUID_SUFFIX_RE.search(self.output_dir.name):
+            self.output_dir = self.output_dir.parent / f"{self.output_dir.name}_{uuid4().hex[:8]}"
+        return self
 
     @property
     def evaluation_id(self) -> str:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -59,7 +59,7 @@ class ExpResult(TypedBaseModel):
 
 class Experiment(TypedBaseModel):
     name: str
-    output_dir: Path
+    output_dir: Path | None = None
     agent_config: AgentConfig
     benchmark: Benchmark
     resume: bool = False
@@ -69,7 +69,13 @@ class Experiment(TypedBaseModel):
 
     @model_validator(mode="after")
     def _ensure_unique_output_dir(self) -> "Experiment":
-        if not _UUID_SUFFIX_RE.search(self.output_dir.name):
+        if self.output_dir is None:
+            self.output_dir = make_experiment_output_dir(
+                agent_name=self.agent_config.agent_name,
+                benchmark_name=self.benchmark.benchmark_metadata.name,
+                tag=self.name,
+            )
+        elif not _UUID_SUFFIX_RE.search(self.output_dir.name):
             self.output_dir = self.output_dir.parent / f"{self.output_dir.name}_{uuid4().hex[:8]}"
         return self
 

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -10,11 +10,11 @@ from pydantic import Field
 
 from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
-from cube_harness.episode import MAX_STEPS, Episode, EpisodeConfig
+from cube_harness.episode import MAX_STEPS, Episode
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
-from cube_harness.eval_log import EpisodeRecord, EvalLog, ExperimentRecord
-from cube_harness.storage import EPISODES_DIR, FileStorage
+from cube_harness.eval_log import EvalLog, ExperimentRecord, write_experiment_record
+from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ class Experiment(TypedBaseModel):
     resume: bool = False
     max_steps: int = MAX_STEPS
     max_retries: int = 3
+    git_cwd: str | None = None
 
     @property
     def config(self) -> dict:
@@ -135,6 +136,14 @@ class Experiment(TypedBaseModel):
         with open(config_path, "w") as f:
             f.write(self.model_dump_json(indent=2, serialize_as_any=True))
         logger.info(f"Saved experiment config to {config_path}")
+        exp_record = ExperimentRecord.from_experiment(
+            exp_name=self.name,
+            output_dir=self.output_dir,
+            agent_config=self.agent_config,
+            benchmark=self.benchmark,
+            git_cwd=self.git_cwd,
+        )
+        write_experiment_record(output_path, exp_record)
 
     @classmethod
     def load_config(cls, path: str) -> Self:
@@ -195,76 +204,21 @@ class Experiment(TypedBaseModel):
         logger.info(f"  Failed tasks: {len(results.failures)}")
         logger.info(f"Saved to: {self.output_dir}")
 
-    def export_eval_log(self, output_dir: Path | None = None, git_cwd: str | None = None) -> EvalLog:
-        """Export evaluation records for all completed trajectories as an Atlas EvalLog.
+    def export_eval_log(self, output_dir: Path | None = None) -> EvalLog:
+        """Load the EvalLog from per-trajectory records written during the run.
 
-        Writes experiment_record.json (once) and episodes/<id>/episode_record.json
-        (one per trajectory). Action schemas are read from trajectory.metadata so no
-        task re-instantiation is required.
+        experiment_record.json is written at experiment start (save_config).
+        episode_record.json files are written by the runner after each episode.
+        This method simply reads those files and packages them.
 
         Args:
-            output_dir: Destination directory. Defaults to self.output_dir.
-            git_cwd: Working directory for git introspection of the agent codebase.
+            output_dir: Directory to read from. Defaults to self.output_dir.
 
         Returns:
-            EvalLog with ExperimentRecord and one EpisodeRecord per completed trajectory.
+            EvalLog with ExperimentRecord and one EpisodeRecord per completed episode.
         """
-        storage = FileStorage(self.output_dir)
         resolved_dir = output_dir if output_dir is not None else self.output_dir
-
-        exp_record = ExperimentRecord.from_experiment(
-            exp_name=self.name,
-            output_dir=self.output_dir,
-            agent_config=self.agent_config,
-            benchmark=self.benchmark,
-            git_cwd=git_cwd,
-        )
-
-        task_metadata_index: dict[str, object] = getattr(self.benchmark, "task_metadata", {})
-        episode_config_index = _load_episode_config_index(storage, self.output_dir)
-
-        episodes: list[EpisodeRecord] = []
-        for trajectory_id in storage.list_trajectory_ids():
-            try:
-                trajectory = storage.load_trajectory(trajectory_id)
-            except Exception as e:
-                logger.warning(f"Skipping trajectory {trajectory_id}: failed to load: {e}")
-                continue
-
-            ep_config = episode_config_index.get(trajectory_id)
-            task_config = ep_config.task_config if ep_config is not None else None
-            task_id = trajectory.metadata.get("task_id", "")
-            task_metadata = task_metadata_index.get(task_id)
-
-            record = EpisodeRecord.from_trajectory(
-                trajectory,
-                experiment_id=exp_record.experiment_id,
-                task_metadata=task_metadata,
-                task_config=task_config,
-            )
-            episodes.append(record)
-
-        eval_log = EvalLog(experiment=exp_record, episodes=episodes)
-        eval_log.save(resolved_dir)
-        return eval_log
-
-
-def _load_episode_config_index(storage: FileStorage, output_dir: Path) -> dict[str, EpisodeConfig]:
-    """Return a trajectory_id → EpisodeConfig mapping from V2 episode directories."""
-    index: dict[str, EpisodeConfig] = {}
-    episodes_dir = output_dir / EPISODES_DIR
-    if not episodes_dir.exists():
-        return index
-    for ep_dir in episodes_dir.iterdir():
-        if not ep_dir.is_dir():
-            continue
-        config_file = ep_dir / "episode_config.json"
-        if config_file.exists():
-            try:
-                index[ep_dir.name] = storage.load_episode_config(config_file)
-            except Exception as e:
-                logger.warning(f"Failed to load episode config {config_file}: {e}")
-    return index
+        return EvalLog.load(resolved_dir)
 
 
 def sweep_stale_statuses(

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -10,10 +10,11 @@ from pydantic import Field
 
 from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
-from cube_harness.episode import MAX_STEPS, Episode
+from cube_harness.episode import MAX_STEPS, Episode, EpisodeConfig
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
-from cube_harness.storage import FileStorage
+from cube_harness.eval_log import EpisodeRecord, EvalLog, ExperimentRecord
+from cube_harness.storage import EPISODES_DIR, FileStorage
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +194,77 @@ class Experiment(TypedBaseModel):
         logger.info(f"  Accuracy (avg. final reward): {accuracy:.4f}")
         logger.info(f"  Failed tasks: {len(results.failures)}")
         logger.info(f"Saved to: {self.output_dir}")
+
+    def export_eval_log(self, output_dir: Path | None = None, git_cwd: str | None = None) -> EvalLog:
+        """Export evaluation records for all completed trajectories as an Atlas EvalLog.
+
+        Writes experiment_record.json (once) and episodes/<id>/episode_record.json
+        (one per trajectory). Action schemas are read from trajectory.metadata so no
+        task re-instantiation is required.
+
+        Args:
+            output_dir: Destination directory. Defaults to self.output_dir.
+            git_cwd: Working directory for git introspection of the agent codebase.
+
+        Returns:
+            EvalLog with ExperimentRecord and one EpisodeRecord per completed trajectory.
+        """
+        storage = FileStorage(self.output_dir)
+        resolved_dir = output_dir if output_dir is not None else self.output_dir
+
+        exp_record = ExperimentRecord.from_experiment(
+            exp_name=self.name,
+            output_dir=self.output_dir,
+            agent_config=self.agent_config,
+            benchmark=self.benchmark,
+            git_cwd=git_cwd,
+        )
+
+        task_metadata_index: dict[str, object] = getattr(self.benchmark, "task_metadata", {})
+        episode_config_index = _load_episode_config_index(storage, self.output_dir)
+
+        episodes: list[EpisodeRecord] = []
+        for trajectory_id in storage.list_trajectory_ids():
+            try:
+                trajectory = storage.load_trajectory(trajectory_id)
+            except Exception as e:
+                logger.warning(f"Skipping trajectory {trajectory_id}: failed to load: {e}")
+                continue
+
+            ep_config = episode_config_index.get(trajectory_id)
+            task_config = ep_config.task_config if ep_config is not None else None
+            task_id = trajectory.metadata.get("task_id", "")
+            task_metadata = task_metadata_index.get(task_id)
+
+            record = EpisodeRecord.from_trajectory(
+                trajectory,
+                experiment_id=exp_record.experiment_id,
+                task_metadata=task_metadata,
+                task_config=task_config,
+            )
+            episodes.append(record)
+
+        eval_log = EvalLog(experiment=exp_record, episodes=episodes)
+        eval_log.save(resolved_dir)
+        return eval_log
+
+
+def _load_episode_config_index(storage: FileStorage, output_dir: Path) -> dict[str, EpisodeConfig]:
+    """Return a trajectory_id → EpisodeConfig mapping from V2 episode directories."""
+    index: dict[str, EpisodeConfig] = {}
+    episodes_dir = output_dir / EPISODES_DIR
+    if not episodes_dir.exists():
+        return index
+    for ep_dir in episodes_dir.iterdir():
+        if not ep_dir.is_dir():
+            continue
+        config_file = ep_dir / "episode_config.json"
+        if config_file.exists():
+            try:
+                index[ep_dir.name] = storage.load_episode_config(config_file)
+            except Exception as e:
+                logger.warning(f"Failed to load episode config {config_file}: {e}")
+    return index
 
 
 def sweep_stale_statuses(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from cube.benchmark import Benchmark as CubeBenchmark
@@ -31,9 +32,15 @@ from cube_harness.tool import ToolWithTelemetry
 
 @pytest.fixture
 def tmp_dir():
-    """Temporary directory fixture for tests that need file I/O."""
+    """Temporary directory fixture for tests that need file I/O.
+
+    Yields a path ending in _{uuid8} so Experiment's uniqueness validator
+    recognises it as already unique and does not mutate the path.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
+        path = Path(tmpdir) / f"exp_{uuid4().hex[:8]}"
+        path.mkdir()
+        yield path
 
 
 @pytest.fixture

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -12,6 +12,7 @@ from cube_harness.eval_log import (
     AgentInfo,
     BenchmarkSubset,
     EpisodeRecord,
+    EvalLibrary,
     EvalLog,
     ExperimentRecord,
     JudgeConfig,
@@ -22,6 +23,7 @@ from cube_harness.eval_log import (
     _extract_llm_model,
     _extract_tool_names,
     _to_github_url,
+    compute_evaluation_id,
 )
 
 # ---------------------------------------------------------------------------
@@ -173,6 +175,40 @@ def test_to_github_url_strips_git_suffix() -> None:
 
 
 # ---------------------------------------------------------------------------
+# compute_evaluation_id
+# ---------------------------------------------------------------------------
+
+
+def test_compute_evaluation_id_stable(tmp_dir: Path) -> None:
+    id1 = compute_evaluation_id("my_exp", tmp_dir)
+    id2 = compute_evaluation_id("my_exp", tmp_dir)
+    assert id1 == id2
+    assert len(id1) == 16
+
+
+def test_compute_evaluation_id_varies_by_name(tmp_dir: Path) -> None:
+    assert compute_evaluation_id("exp_a", tmp_dir) != compute_evaluation_id("exp_b", tmp_dir)
+
+
+# ---------------------------------------------------------------------------
+# EvalLibrary
+# ---------------------------------------------------------------------------
+
+
+def test_eval_library_defaults() -> None:
+    lib = EvalLibrary(version="1.2.3")
+    assert lib.name == "cube-harness"
+    assert lib.version == "1.2.3"
+
+
+def test_eval_library_roundtrip() -> None:
+    lib = EvalLibrary(version="0.5.0")
+    restored = EvalLibrary.model_validate_json(lib.model_dump_json())
+    assert restored.name == "cube-harness"
+    assert restored.version == "0.5.0"
+
+
+# ---------------------------------------------------------------------------
 # UsageSummary
 # ---------------------------------------------------------------------------
 
@@ -187,16 +223,18 @@ def test_usage_summary_from_stats() -> None:
         "total_llm_calls": 3,
     }
     usage = UsageSummary.from_summary_stats(stats)
-    assert usage.prompt_tokens == 500
-    assert usage.completion_tokens == 200
+    assert usage.input_tokens == 500
+    assert usage.output_tokens == 200
     assert usage.total_tokens == 700
+    assert usage.input_tokens_cache_read == 50
+    assert usage.input_tokens_cache_write == 10
     assert usage.total_cost_usd == 0.05
     assert usage.n_llm_calls == 3
 
 
 def test_usage_summary_from_none() -> None:
     usage = UsageSummary.from_summary_stats(None)
-    assert usage.prompt_tokens == 0
+    assert usage.input_tokens == 0
     assert usage.total_cost_usd == 0.0
 
 
@@ -269,11 +307,11 @@ def test_benchmark_subset_unknown_benchmark() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_experiment_record_experiment_id_is_stable(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+def test_experiment_record_evaluation_id_is_stable(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     rec1 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
     rec2 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    assert rec1.experiment_id == rec2.experiment_id
-    assert len(rec1.experiment_id) == 16
+    assert rec1.evaluation_id == rec2.evaluation_id
+    assert len(rec1.evaluation_id) == 16
 
 
 def test_experiment_record_fields(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
@@ -283,14 +321,16 @@ def test_experiment_record_fields(mock_agent_config, mock_cube_benchmark, tmp_di
     assert rec.benchmark_version == "0.1.0"
     assert rec.benchmark_subset.n_tasks == 2
     assert rec.judge_config is None
+    assert rec.eval_library.name == "cube-harness"
 
 
 def test_experiment_record_roundtrip(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     rec = ExperimentRecord.from_experiment("roundtrip_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
     serialized = rec.model_dump_json()
     restored = ExperimentRecord.model_validate_json(serialized)
-    assert restored.experiment_id == rec.experiment_id
+    assert restored.evaluation_id == rec.evaluation_id
     assert restored.benchmark_name == rec.benchmark_name
+    assert restored.eval_library.version == rec.eval_library.version
 
 
 # ---------------------------------------------------------------------------
@@ -300,42 +340,42 @@ def test_experiment_record_roundtrip(mock_agent_config, mock_cube_benchmark, tmp
 
 def test_episode_record_success() -> None:
     traj = _trajectory(reward=1.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
-    assert record.success is True
-    assert record.reward == 1.0
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
+    assert record.is_correct is True
+    assert record.score == 1.0
     assert record.trajectory_id == "t1_ep0"
 
 
 def test_episode_record_failure() -> None:
     traj = _trajectory(reward=0.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
-    assert record.success is False
-    assert record.reward == 0.0
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
+    assert record.is_correct is False
+    assert record.score == 0.0
 
 
 def test_episode_record_wall_time() -> None:
     traj = _trajectory(reward=1.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
     assert record.wall_time_s == pytest.approx(10.0)
 
 
-def test_episode_record_n_steps() -> None:
+def test_episode_record_num_turns() -> None:
     traj = _trajectory(reward=1.0, n_agent_steps=3)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
-    assert record.n_steps == len(traj.steps)
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
+    assert record.num_turns == len(traj.steps)
     assert record.n_agent_steps == 3
 
 
 def test_episode_record_tool_names_from_metadata() -> None:
     traj = _trajectory(reward=1.0)
     traj.metadata["action_schemas"] = [{"type": "function", "function": {"name": "click"}}]
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
     assert record.tool_names == ["click"]
 
 
 def test_episode_record_tool_names_empty_without_metadata() -> None:
     traj = _trajectory(reward=1.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
     assert record.tool_names == []
 
 
@@ -344,7 +384,7 @@ def test_episode_record_with_task_metadata() -> None:
 
     traj = _trajectory(task_id="click-dialog")
     tm = TaskMetadata(id="click-dialog", split="test", abstract_description="Click a dialog button")
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123", task_metadata=tm)
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123", task_metadata=tm)
     assert record.split == "test"
     assert record.task_description == "Click a dialog button"
 
@@ -358,22 +398,22 @@ def test_episode_record_with_task_config(mock_tool_config) -> None:
 
     traj = _trajectory(task_id="t1")
     tc = MockTaskConfig(task_id="t1", seed=42, tool_config=mock_tool_config)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123", task_config=tc)
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123", task_config=tc)
     assert record.seed == 42
-    assert record.task_version_hash is not None
-    assert len(record.task_version_hash) == 64
+    assert record.sample_hash is not None
+    assert len(record.sample_hash) == 64
 
 
 def test_episode_record_judge_output_optional() -> None:
     traj = _trajectory(reward=1.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
     assert record.judge_output is None
     assert record.verifier is None
 
 
 def test_episode_record_with_judge_output() -> None:
     traj = _trajectory(reward=0.0)
-    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
     record = record.model_copy(
         update={
             "judge_output": JudgeOutput(
@@ -395,7 +435,7 @@ def test_episode_record_with_judge_output() -> None:
 def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj = _trajectory(reward=1.0, task_id="task-a")
     exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
+    ep_rec = EpisodeRecord.from_trajectory(traj, evaluation_id=exp_rec.evaluation_id)
     log = EvalLog(experiment=exp_rec, episodes=[ep_rec])
 
     with tempfile.TemporaryDirectory() as out:
@@ -405,7 +445,7 @@ def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir)
         assert (out_dir / "episodes" / "task-a_ep0" / "episode_record.json").exists()
         loaded = EvalLog.load(out_dir)
 
-    assert loaded.experiment.experiment_id == exp_rec.experiment_id
+    assert loaded.experiment.evaluation_id == exp_rec.evaluation_id
     assert len(loaded.episodes) == 1
     assert loaded.episodes[0].trajectory_id == "task-a_ep0"
 
@@ -413,7 +453,7 @@ def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir)
 def test_eval_log_episode_record_is_valid_json(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj = _trajectory(reward=0.5)
     exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
+    ep_rec = EpisodeRecord.from_trajectory(traj, evaluation_id=exp_rec.evaluation_id)
     log = EvalLog(experiment=exp_rec, episodes=[ep_rec])
 
     with tempfile.TemporaryDirectory() as out:
@@ -422,9 +462,9 @@ def test_eval_log_episode_record_is_valid_json(mock_agent_config, mock_cube_benc
         record_path = out_dir / "episodes" / "t1_ep0" / "episode_record.json"
         parsed = json.loads(record_path.read_text())
 
-    assert "experiment_id" in parsed
-    assert "task_id" in parsed
-    assert "reward" in parsed
+    assert "evaluation_id" in parsed
+    assert "sample_id" in parsed
+    assert "score" in parsed
 
 
 def test_eval_log_experiment_record_is_valid_json(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
@@ -435,17 +475,18 @@ def test_eval_log_experiment_record_is_valid_json(mock_agent_config, mock_cube_b
         log.save(Path(out))
         parsed = json.loads((Path(out) / "experiment_record.json").read_text())
 
-    assert "experiment_id" in parsed
+    assert "evaluation_id" in parsed
     assert "agent" in parsed
     assert "benchmark_subset" in parsed
+    assert "eval_library" in parsed
 
 
 def test_eval_log_to_jsonl(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj1 = _trajectory(reward=1.0, task_id="t1")
     traj2 = _trajectory(reward=0.0, task_id="t2")
     exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    rec1 = EpisodeRecord.from_trajectory(traj1, experiment_id=exp_rec.experiment_id)
-    rec2 = EpisodeRecord.from_trajectory(traj2, experiment_id=exp_rec.experiment_id)
+    rec1 = EpisodeRecord.from_trajectory(traj1, evaluation_id=exp_rec.evaluation_id)
+    rec2 = EpisodeRecord.from_trajectory(traj2, evaluation_id=exp_rec.evaluation_id)
     log = EvalLog(experiment=exp_rec, episodes=[rec1, rec2])
 
     with tempfile.TemporaryDirectory() as out:
@@ -454,16 +495,16 @@ def test_eval_log_to_jsonl(mock_agent_config, mock_cube_benchmark, tmp_dir) -> N
         lines = jsonl_path.read_text().strip().splitlines()
 
     assert len(lines) == 2
-    task_ids = {json.loads(line)["task_id"] for line in lines}
-    assert task_ids == {"t1", "t2"}
+    sample_ids = {json.loads(line)["sample_id"] for line in lines}
+    assert sample_ids == {"t1", "t2"}
 
 
-def test_eval_log_experiment_id_fk_consistent(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
-    """EpisodeRecords carry the same experiment_id as ExperimentRecord."""
+def test_eval_log_evaluation_id_fk_consistent(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    """EpisodeRecords carry the same evaluation_id as ExperimentRecord."""
     exp_rec = ExperimentRecord.from_experiment("fk_test", tmp_dir, mock_agent_config, mock_cube_benchmark)
     traj = _trajectory(reward=1.0)
-    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
-    assert ep_rec.experiment_id == exp_rec.experiment_id
+    ep_rec = EpisodeRecord.from_trajectory(traj, evaluation_id=exp_rec.evaluation_id)
+    assert ep_rec.evaluation_id == exp_rec.evaluation_id
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +531,7 @@ def test_verifier_roundtrip() -> None:
 
 
 def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_benchmark) -> None:
-    """Full experiment run → export_eval_log → to_jsonl produces correct two-level output."""
+    """experiment_record.json is written at start; episode_record.json per episode; export_eval_log loads them."""
     from cube_harness.exp_runner import run_sequentially
     from cube_harness.experiment import Experiment
 
@@ -502,33 +543,32 @@ def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_bench
     )
     run_sequentially(exp)
 
-    eval_log = exp.export_eval_log(tmp_dir)
-
-    # experiment_record.json written at top level
+    # experiment_record.json written at experiment start (save_config), not post-hoc
     exp_record_path = tmp_dir / "experiment_record.json"
     assert exp_record_path.exists(), "experiment_record.json was not created"
     exp_data = json.loads(exp_record_path.read_text())
     assert exp_data["experiment_name"] == "integration_test"
     assert "agent" in exp_data
     assert exp_data["benchmark_subset"]["n_tasks"] == 2
+    assert exp_data["eval_library"]["name"] == "cube-harness"
 
-    # episode_record.json written per trajectory directory
+    # episode_record.json written per trajectory directory during the run
     episode_records = list((tmp_dir / "episodes").glob("*/episode_record.json"))
     assert len(episode_records) == 2, f"Expected 2 episode records, got {len(episode_records)}"
 
-    experiment_id = eval_log.experiment.experiment_id
+    evaluation_id = exp_data["evaluation_id"]
     for record_path in episode_records:
         episode = json.loads(record_path.read_text())
-        assert episode["experiment_id"] == experiment_id
-        assert episode["reward"] == pytest.approx(1.0)
-        assert episode["success"] is True
+        assert episode["evaluation_id"] == evaluation_id
+        assert episode["score"] == pytest.approx(1.0)
+        assert episode["is_correct"] is True
 
-    # load() reconstructs from per-trajectory files
-    loaded = EvalLog.load(tmp_dir)
-    assert loaded.experiment.experiment_id == experiment_id
-    assert len(loaded.episodes) == 2
+    # export_eval_log is now a thin reader — no trajectory loading
+    eval_log = exp.export_eval_log(tmp_dir)
+    assert eval_log.experiment.evaluation_id == evaluation_id
+    assert len(eval_log.episodes) == 2
 
-    # to_jsonl() assembles flat submission file
+    # to_jsonl assembles flat submission file
     jsonl_path = tmp_dir / "submission.jsonl"
     eval_log.to_jsonl(jsonl_path)
     lines = jsonl_path.read_text().strip().splitlines()

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -10,12 +10,15 @@ from cube.core import Content, EnvironmentOutput, Observation, StepError
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.eval_log import (
     AgentInfo,
+    BenchmarkSubset,
+    EpisodeRecord,
     EvalLog,
-    TaskEvalRecord,
-    TaskInfo,
+    ExperimentRecord,
+    JudgeConfig,
+    JudgeOutput,
     UsageSummary,
+    Verifier,
     _extract_error_type,
-    _extract_first_observation_text,
     _extract_llm_model,
     _extract_tool_names,
     _to_github_url,
@@ -145,32 +148,6 @@ def test_extract_error_type_returns_first_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _extract_first_observation_text
-# ---------------------------------------------------------------------------
-
-
-def test_extract_first_observation_text_returns_text() -> None:
-    traj = _trajectory(reward=1.0)
-    text = _extract_first_observation_text(traj)
-    assert text == "Task: do it"
-
-
-def test_extract_first_observation_text_empty_trajectory() -> None:
-    traj = Trajectory(id="empty")
-    assert _extract_first_observation_text(traj) is None
-
-
-def test_extract_first_observation_text_joins_multiple_contents() -> None:
-    obs = Observation(contents=[Content.from_data("Goal:"), Content.from_data("Click the button")])
-    env_out = EnvironmentOutput(obs=obs, reward=0.0, done=False, info={})
-    traj = Trajectory(id="t1")
-    traj.steps.append(TrajectoryStep(output=env_out, start_time=0.0, end_time=1.0))
-    text = _extract_first_observation_text(traj)
-    assert "Goal:" in text
-    assert "Click the button" in text
-
-
-# ---------------------------------------------------------------------------
 # _to_github_url
 # ---------------------------------------------------------------------------
 
@@ -243,29 +220,19 @@ def test_agent_info_from_agent_config_basic(mock_agent_config) -> None:
     assert isinstance(info.framework_version, str)
 
 
-def test_agent_info_from_agent_config_with_schemas(mock_agent_config) -> None:
-    schemas = [{"type": "function", "function": {"name": "click"}}]
-    info = AgentInfo.from_agent_config(mock_agent_config, action_schemas=schemas)
-    assert info.tools == schemas
-    assert info.tool_names == ["click"]
-
-
 def test_agent_info_agent_id_is_stable(mock_agent_config) -> None:
     info1 = AgentInfo.from_agent_config(mock_agent_config)
     info2 = AgentInfo.from_agent_config(mock_agent_config)
     assert info1.agent_id == info2.agent_id
 
 
-def test_agent_info_with_action_schemas_returns_copy(mock_agent_config) -> None:
+def test_agent_info_has_no_tools_field(mock_agent_config) -> None:
     info = AgentInfo.from_agent_config(mock_agent_config)
-    schemas = [{"type": "function", "function": {"name": "scroll"}}]
-    enriched = info.with_action_schemas(schemas)
-    assert enriched.tool_names == ["scroll"]
-    assert info.tool_names == []  # original unchanged
+    assert not hasattr(info, "tools")
+    assert not hasattr(info, "tool_names")
 
 
 def test_agent_info_llm_model_extracted() -> None:
-    """AgentConfig with llm_config sub-dict gets llm_model populated."""
     from cube_harness.agent import AgentConfig
 
     class LLMAgentConfig(AgentConfig):
@@ -280,187 +247,283 @@ def test_agent_info_llm_model_extracted() -> None:
 
 
 # ---------------------------------------------------------------------------
-# TaskInfo
+# BenchmarkSubset
 # ---------------------------------------------------------------------------
 
 
-def test_task_info_from_trajectory_minimal() -> None:
-    traj = _trajectory(task_id="task-42")
-    info = TaskInfo.from_trajectory_and_metadata(traj)
-    assert info.task_id == "task-42"
-    assert info.benchmark_name == "unknown"
-    assert info.first_observation_text == "Task: do it"
+def test_benchmark_subset_from_benchmark(mock_cube_benchmark) -> None:
+    subset = BenchmarkSubset.from_benchmark(mock_cube_benchmark)
+    assert subset.name == "mock-cube"
+    assert subset.n_tasks == 2
+    assert subset.filter is None
 
 
-def test_task_info_with_benchmark_metadata() -> None:
-    from cube.benchmark import BenchmarkMetadata
-
-    bm = BenchmarkMetadata(name="MiniWoB", version="1.0", description="Mini browser tasks", authors=["A"], tags=["browser"])
-    traj = _trajectory(task_id="click-dialog")
-    info = TaskInfo.from_trajectory_and_metadata(traj, benchmark_metadata=bm)
-    assert info.benchmark_name == "MiniWoB"
-    assert info.benchmark_id == "miniwob"
-    assert info.benchmark_version == "1.0"
-    assert "A" in info.benchmark_authors
+def test_benchmark_subset_unknown_benchmark() -> None:
+    subset = BenchmarkSubset.from_benchmark(object())
+    assert subset.name == "unknown"
+    assert subset.n_tasks == 0
 
 
-def test_task_info_with_task_metadata() -> None:
+# ---------------------------------------------------------------------------
+# ExperimentRecord
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_record_experiment_id_is_stable(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    rec1 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    rec2 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    assert rec1.experiment_id == rec2.experiment_id
+    assert len(rec1.experiment_id) == 16
+
+
+def test_experiment_record_fields(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    assert rec.experiment_name == "test_exp"
+    assert rec.benchmark_name == "mock-cube"
+    assert rec.benchmark_version == "0.1.0"
+    assert rec.benchmark_subset.n_tasks == 2
+    assert rec.judge_config is None
+
+
+def test_experiment_record_roundtrip(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    rec = ExperimentRecord.from_experiment("roundtrip_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    serialized = rec.model_dump_json()
+    restored = ExperimentRecord.model_validate_json(serialized)
+    assert restored.experiment_id == rec.experiment_id
+    assert restored.benchmark_name == rec.benchmark_name
+
+
+# ---------------------------------------------------------------------------
+# EpisodeRecord
+# ---------------------------------------------------------------------------
+
+
+def test_episode_record_success() -> None:
+    traj = _trajectory(reward=1.0)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.success is True
+    assert record.reward == 1.0
+    assert record.trajectory_id == "t1_ep0"
+
+
+def test_episode_record_failure() -> None:
+    traj = _trajectory(reward=0.0)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.success is False
+    assert record.reward == 0.0
+
+
+def test_episode_record_wall_time() -> None:
+    traj = _trajectory(reward=1.0)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.wall_time_s == pytest.approx(10.0)
+
+
+def test_episode_record_n_steps() -> None:
+    traj = _trajectory(reward=1.0, n_agent_steps=3)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.n_steps == len(traj.steps)
+    assert record.n_agent_steps == 3
+
+
+def test_episode_record_tool_names_from_metadata() -> None:
+    traj = _trajectory(reward=1.0)
+    traj.metadata["action_schemas"] = [{"type": "function", "function": {"name": "click"}}]
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.tool_names == ["click"]
+
+
+def test_episode_record_tool_names_empty_without_metadata() -> None:
+    traj = _trajectory(reward=1.0)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.tool_names == []
+
+
+def test_episode_record_with_task_metadata() -> None:
     from cube.task import TaskMetadata
 
-    tm = TaskMetadata(
-        id="click-dialog",
-        split="test",
-        abstract_description="Click a dialog button",
-        recommended_max_steps=10,
-        extra_info={"difficulty": "easy"},
-    )
     traj = _trajectory(task_id="click-dialog")
-    info = TaskInfo.from_trajectory_and_metadata(traj, task_metadata=tm)
-    assert info.split == "test"
-    assert info.abstract_description == "Click a dialog button"
-    assert info.recommended_max_steps == 10
-    assert info.extra_info["difficulty"] == "easy"
+    tm = TaskMetadata(id="click-dialog", split="test", abstract_description="Click a dialog button")
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123", task_metadata=tm)
+    assert record.split == "test"
+    assert record.task_description == "Click a dialog button"
 
 
-def test_task_info_task_version_hash_from_task_config(mock_tool_config) -> None:
-    from cube.task import TaskConfig, TaskMetadata
+def test_episode_record_with_task_config(mock_tool_config) -> None:
+    from cube.task import TaskConfig
 
     class MockTaskConfig(TaskConfig):
         def make(self, runtime_context=None, container_backend=None):  # type: ignore[override]
             raise NotImplementedError
 
-    tc = MockTaskConfig(task_id="t1", seed=42, tool_config=mock_tool_config)
     traj = _trajectory(task_id="t1")
-    info = TaskInfo.from_trajectory_and_metadata(traj, task_config=tc)
-    assert info.seed == 42
-    assert info.task_version_hash is not None
-    assert len(info.task_version_hash) == 64
+    tc = MockTaskConfig(task_id="t1", seed=42, tool_config=mock_tool_config)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123", task_config=tc)
+    assert record.seed == 42
+    assert record.task_version_hash is not None
+    assert len(record.task_version_hash) == 64
 
 
-# ---------------------------------------------------------------------------
-# TaskEvalRecord
-# ---------------------------------------------------------------------------
-
-
-def test_task_eval_record_success(mock_agent_config) -> None:
+def test_episode_record_judge_output_optional() -> None:
     traj = _trajectory(reward=1.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info, exp_name="exp1")
-    assert record.success is True
-    assert record.reward == 1.0
-    assert record.run_id == "exp1_t1_ep0"
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
+    assert record.judge_output is None
+    assert record.verifier is None
 
 
-def test_task_eval_record_failure(mock_agent_config) -> None:
+def test_episode_record_with_judge_output() -> None:
     traj = _trajectory(reward=0.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
-    assert record.success is False
-    assert record.reward == 0.0
-
-
-def test_task_eval_record_wall_time(mock_agent_config) -> None:
-    traj = _trajectory(reward=1.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
-    assert record.wall_time_s == pytest.approx(10.0)
-
-
-def test_task_eval_record_n_steps(mock_agent_config) -> None:
-    traj = _trajectory(reward=1.0, n_agent_steps=3)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
-    assert record.n_steps == len(traj.steps)
-    assert record.n_agent_steps == 3
-
-
-def test_task_eval_record_declaration_defaults_empty(mock_agent_config) -> None:
-    traj = _trajectory(reward=1.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
-    assert record.declaration == {}
-
-
-def test_task_eval_record_declaration_roundtrip(mock_agent_config) -> None:
-    traj = _trajectory(reward=1.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    record = EpisodeRecord.from_trajectory(traj, experiment_id="abc123")
     record = record.model_copy(
         update={
-            "declaration": {
-                "motivation": "capability_probe",
-                "task_selection_method": "random",
-                "compute_budget": "full_benchmark",
-            }
+            "judge_output": JudgeOutput(
+                difficulty="hard",
+                feasible=True,
+                failure_root_cause="Agent did not find the submit button",
+            )
         }
     )
-    assert record.declaration["motivation"] == "capability_probe"
-    assert record.declaration["task_selection_method"] == "random"
+    assert record.judge_output.difficulty == "hard"
+    assert record.judge_output.feasible is True
 
 
 # ---------------------------------------------------------------------------
-# EvalLog JSONL round-trip
+# EvalLog: two-level round-trip
 # ---------------------------------------------------------------------------
 
 
-def test_eval_log_save_and_load(mock_agent_config) -> None:
-    traj = _trajectory(reward=1.0)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info, exp_name="test_exp")
-    log = EvalLog(records=[record])
+def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    traj = _trajectory(reward=1.0, task_id="task-a")
+    exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
+    log = EvalLog(experiment=exp_rec, episodes=[ep_rec])
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "eval_log.jsonl"
-        log.save_jsonl(path)
-        loaded = EvalLog.load_jsonl(path)
+    with tempfile.TemporaryDirectory() as out:
+        out_dir = Path(out)
+        log.save(out_dir)
+        assert (out_dir / "experiment_record.json").exists()
+        assert (out_dir / "eval_log.jsonl").exists()
+        loaded = EvalLog.load(out_dir)
 
-    assert len(loaded.records) == 1
-    assert loaded.records[0].trajectory_id == record.trajectory_id
-    assert loaded.records[0].success == record.success
-    assert loaded.records[0].reward == record.reward
+    assert loaded.experiment.experiment_id == exp_rec.experiment_id
+    assert len(loaded.episodes) == 1
+    assert loaded.episodes[0].trajectory_id == "task-a_ep0"
 
 
-def test_eval_log_jsonl_is_valid_json_per_line(mock_agent_config) -> None:
+def test_eval_log_episode_jsonl_is_valid_json_per_line(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj = _trajectory(reward=0.5)
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info = TaskInfo.from_trajectory_and_metadata(traj)
-    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
-    log = EvalLog(records=[record])
+    exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
+    log = EvalLog(experiment=exp_rec, episodes=[ep_rec])
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "out.jsonl"
-        log.save_jsonl(path)
-        lines = path.read_text().strip().splitlines()
+    with tempfile.TemporaryDirectory() as out:
+        log.save(Path(out))
+        lines = (Path(out) / "eval_log.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
 
-    assert len(lines) == 1
-    parsed = json.loads(lines[0])
-    assert "task" in parsed
-    assert "agent" in parsed
+    assert "experiment_id" in parsed
+    assert "task_id" in parsed
     assert "reward" in parsed
 
 
-def test_eval_log_append_record(mock_agent_config) -> None:
+def test_eval_log_experiment_record_is_valid_json(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    log = EvalLog(experiment=exp_rec, episodes=[])
+
+    with tempfile.TemporaryDirectory() as out:
+        log.save(Path(out))
+        parsed = json.loads((Path(out) / "experiment_record.json").read_text())
+
+    assert "experiment_id" in parsed
+    assert "agent" in parsed
+    assert "benchmark_subset" in parsed
+
+
+def test_eval_log_append_episode(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj1 = _trajectory(reward=1.0, task_id="t1")
     traj2 = _trajectory(reward=0.0, task_id="t2")
-    agent_info = AgentInfo.from_agent_config(mock_agent_config)
-    task_info1 = TaskInfo.from_trajectory_and_metadata(traj1)
-    task_info2 = TaskInfo.from_trajectory_and_metadata(traj2)
-    rec1 = TaskEvalRecord.from_trajectory(traj1, agent_info, task_info1)
-    rec2 = TaskEvalRecord.from_trajectory(traj2, agent_info, task_info2)
+    exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    rec1 = EpisodeRecord.from_trajectory(traj1, experiment_id=exp_rec.experiment_id)
+    rec2 = EpisodeRecord.from_trajectory(traj2, experiment_id=exp_rec.experiment_id)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "streamed.jsonl"
-        EvalLog.append_record(rec1, path)
-        EvalLog.append_record(rec2, path)
-        loaded = EvalLog.load_jsonl(path)
+    with tempfile.TemporaryDirectory() as out:
+        out_path = Path(out) / "eval_log.jsonl"
+        EvalLog.append_episode(rec1, out_path)
+        EvalLog.append_episode(rec2, out_path)
+        lines = out_path.read_text().strip().splitlines()
 
-    assert len(loaded.records) == 2
-    task_ids = {r.task.task_id for r in loaded.records}
+    assert len(lines) == 2
+    task_ids = {json.loads(line)["task_id"] for line in lines}
     assert task_ids == {"t1", "t2"}
+
+
+def test_eval_log_experiment_id_fk_consistent(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    """EpisodeRecords carry the same experiment_id as ExperimentRecord."""
+    exp_rec = ExperimentRecord.from_experiment("fk_test", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    traj = _trajectory(reward=1.0)
+    ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
+    assert ep_rec.experiment_id == exp_rec.experiment_id
+
+
+# ---------------------------------------------------------------------------
+# Optional models
+# ---------------------------------------------------------------------------
+
+
+def test_judge_config_roundtrip() -> None:
+    cfg = JudgeConfig(model="claude-opus-4-7", prompt_version="v1.2", judged_at="2026-04-28T12:00:00Z")
+    restored = JudgeConfig.model_validate_json(cfg.model_dump_json())
+    assert restored.model == "claude-opus-4-7"
+    assert restored.judged_at == "2026-04-28T12:00:00Z"
+
+
+def test_verifier_roundtrip() -> None:
+    v = Verifier(ref="https://github.com/org/repo/blob/abc123/eval.py", source="def evaluate(): return 1.0")
+    restored = Verifier.model_validate_json(v.model_dump_json())
+    assert "abc123" in restored.ref
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_benchmark) -> None:
+    """Full experiment run followed by export_eval_log produces correct two-level output."""
+    from cube_harness.exp_runner import run_sequentially
+    from cube_harness.experiment import Experiment
+
+    exp = Experiment(
+        name="integration_test",
+        output_dir=tmp_dir,
+        agent_config=mock_agent_config,
+        benchmark=mock_cube_benchmark,
+    )
+    run_sequentially(exp)
+
+    eval_log = exp.export_eval_log(tmp_dir)
+
+    exp_record_path = tmp_dir / "experiment_record.json"
+    eval_log_path = tmp_dir / "eval_log.jsonl"
+    assert exp_record_path.exists(), "experiment_record.json was not created"
+    assert eval_log_path.exists(), "eval_log.jsonl was not created"
+
+    exp_data = json.loads(exp_record_path.read_text())
+    assert exp_data["experiment_name"] == "integration_test"
+    assert "agent" in exp_data
+    assert exp_data["benchmark_subset"]["n_tasks"] == 2
+
+    lines = eval_log_path.read_text().strip().splitlines()
+    assert len(lines) == 2, f"Expected 2 episode records, got {len(lines)}"
+
+    experiment_id = eval_log.experiment.experiment_id
+    for line in lines:
+        episode = json.loads(line)
+        assert episode["experiment_id"] == experiment_id
+        assert episode["reward"] == pytest.approx(1.0)
+        assert episode["success"] is True
+
+    loaded = EvalLog.load(tmp_dir)
+    assert loaded.experiment.experiment_id == experiment_id
+    assert len(loaded.episodes) == 2

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -290,11 +290,9 @@ def test_benchmark_subset_unknown_benchmark() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_experiment_record_evaluation_id_format(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+def test_experiment_record_evaluation_id_is_dir_name(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     rec = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    # format: "{exp_name}_{8 hex chars}"
-    assert rec.evaluation_id.startswith("my_exp_")
-    assert len(rec.evaluation_id) == len("my_exp_") + 8
+    assert rec.evaluation_id == tmp_dir.name
 
 
 def test_experiment_record_fields(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -23,7 +23,6 @@ from cube_harness.eval_log import (
     _extract_llm_model,
     _extract_tool_names,
     _to_github_url,
-    compute_evaluation_id,
 )
 
 # ---------------------------------------------------------------------------
@@ -175,22 +174,6 @@ def test_to_github_url_strips_git_suffix() -> None:
 
 
 # ---------------------------------------------------------------------------
-# compute_evaluation_id
-# ---------------------------------------------------------------------------
-
-
-def test_compute_evaluation_id_stable(tmp_dir: Path) -> None:
-    id1 = compute_evaluation_id("my_exp", tmp_dir)
-    id2 = compute_evaluation_id("my_exp", tmp_dir)
-    assert id1 == id2
-    assert len(id1) == 16
-
-
-def test_compute_evaluation_id_varies_by_name(tmp_dir: Path) -> None:
-    assert compute_evaluation_id("exp_a", tmp_dir) != compute_evaluation_id("exp_b", tmp_dir)
-
-
-# ---------------------------------------------------------------------------
 # EvalLibrary
 # ---------------------------------------------------------------------------
 
@@ -307,11 +290,11 @@ def test_benchmark_subset_unknown_benchmark() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_experiment_record_evaluation_id_is_stable(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
-    rec1 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    rec2 = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
-    assert rec1.evaluation_id == rec2.evaluation_id
-    assert len(rec1.evaluation_id) == 16
+def test_experiment_record_evaluation_id_format(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+    rec = ExperimentRecord.from_experiment("my_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
+    # format: "{exp_name}_{8 hex chars}"
+    assert rec.evaluation_id.startswith("my_exp_")
+    assert len(rec.evaluation_id) == len("my_exp_") + 8
 
 
 def test_experiment_record_fields(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -402,7 +402,7 @@ def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir)
         out_dir = Path(out)
         log.save(out_dir)
         assert (out_dir / "experiment_record.json").exists()
-        assert (out_dir / "eval_log.jsonl").exists()
+        assert (out_dir / "episodes" / "task-a_ep0" / "episode_record.json").exists()
         loaded = EvalLog.load(out_dir)
 
     assert loaded.experiment.experiment_id == exp_rec.experiment_id
@@ -410,17 +410,17 @@ def test_eval_log_save_and_load(mock_agent_config, mock_cube_benchmark, tmp_dir)
     assert loaded.episodes[0].trajectory_id == "task-a_ep0"
 
 
-def test_eval_log_episode_jsonl_is_valid_json_per_line(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+def test_eval_log_episode_record_is_valid_json(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj = _trajectory(reward=0.5)
     exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
     ep_rec = EpisodeRecord.from_trajectory(traj, experiment_id=exp_rec.experiment_id)
     log = EvalLog(experiment=exp_rec, episodes=[ep_rec])
 
     with tempfile.TemporaryDirectory() as out:
-        log.save(Path(out))
-        lines = (Path(out) / "eval_log.jsonl").read_text().strip().splitlines()
-        assert len(lines) == 1
-        parsed = json.loads(lines[0])
+        out_dir = Path(out)
+        log.save(out_dir)
+        record_path = out_dir / "episodes" / "t1_ep0" / "episode_record.json"
+        parsed = json.loads(record_path.read_text())
 
     assert "experiment_id" in parsed
     assert "task_id" in parsed
@@ -440,18 +440,18 @@ def test_eval_log_experiment_record_is_valid_json(mock_agent_config, mock_cube_b
     assert "benchmark_subset" in parsed
 
 
-def test_eval_log_append_episode(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
+def test_eval_log_to_jsonl(mock_agent_config, mock_cube_benchmark, tmp_dir) -> None:
     traj1 = _trajectory(reward=1.0, task_id="t1")
     traj2 = _trajectory(reward=0.0, task_id="t2")
     exp_rec = ExperimentRecord.from_experiment("test_exp", tmp_dir, mock_agent_config, mock_cube_benchmark)
     rec1 = EpisodeRecord.from_trajectory(traj1, experiment_id=exp_rec.experiment_id)
     rec2 = EpisodeRecord.from_trajectory(traj2, experiment_id=exp_rec.experiment_id)
+    log = EvalLog(experiment=exp_rec, episodes=[rec1, rec2])
 
     with tempfile.TemporaryDirectory() as out:
-        out_path = Path(out) / "eval_log.jsonl"
-        EvalLog.append_episode(rec1, out_path)
-        EvalLog.append_episode(rec2, out_path)
-        lines = out_path.read_text().strip().splitlines()
+        jsonl_path = Path(out) / "submission.jsonl"
+        log.to_jsonl(jsonl_path)
+        lines = jsonl_path.read_text().strip().splitlines()
 
     assert len(lines) == 2
     task_ids = {json.loads(line)["task_id"] for line in lines}
@@ -490,7 +490,7 @@ def test_verifier_roundtrip() -> None:
 
 
 def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_benchmark) -> None:
-    """Full experiment run followed by export_eval_log produces correct two-level output."""
+    """Full experiment run → export_eval_log → to_jsonl produces correct two-level output."""
     from cube_harness.exp_runner import run_sequentially
     from cube_harness.experiment import Experiment
 
@@ -504,26 +504,32 @@ def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_bench
 
     eval_log = exp.export_eval_log(tmp_dir)
 
+    # experiment_record.json written at top level
     exp_record_path = tmp_dir / "experiment_record.json"
-    eval_log_path = tmp_dir / "eval_log.jsonl"
     assert exp_record_path.exists(), "experiment_record.json was not created"
-    assert eval_log_path.exists(), "eval_log.jsonl was not created"
-
     exp_data = json.loads(exp_record_path.read_text())
     assert exp_data["experiment_name"] == "integration_test"
     assert "agent" in exp_data
     assert exp_data["benchmark_subset"]["n_tasks"] == 2
 
-    lines = eval_log_path.read_text().strip().splitlines()
-    assert len(lines) == 2, f"Expected 2 episode records, got {len(lines)}"
+    # episode_record.json written per trajectory directory
+    episode_records = list((tmp_dir / "episodes").glob("*/episode_record.json"))
+    assert len(episode_records) == 2, f"Expected 2 episode records, got {len(episode_records)}"
 
     experiment_id = eval_log.experiment.experiment_id
-    for line in lines:
-        episode = json.loads(line)
+    for record_path in episode_records:
+        episode = json.loads(record_path.read_text())
         assert episode["experiment_id"] == experiment_id
         assert episode["reward"] == pytest.approx(1.0)
         assert episode["success"] is True
 
+    # load() reconstructs from per-trajectory files
     loaded = EvalLog.load(tmp_dir)
     assert loaded.experiment.experiment_id == experiment_id
     assert len(loaded.episodes) == 2
+
+    # to_jsonl() assembles flat submission file
+    jsonl_path = tmp_dir / "submission.jsonl"
+    eval_log.to_jsonl(jsonl_path)
+    lines = jsonl_path.read_text().strip().splitlines()
+    assert len(lines) == 2

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -1,0 +1,440 @@
+"""Tests for cube_harness.eval_log — Atlas EvalLog system."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from cube.core import Content, EnvironmentOutput, Observation, StepError
+
+from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
+from cube_harness.eval_log import (
+    AgentInfo,
+    EvalLog,
+    TaskEvalRecord,
+    TaskInfo,
+    UsageSummary,
+    _extract_error_type,
+    _extract_first_observation_text,
+    _extract_llm_model,
+    _extract_tool_names,
+    _to_github_url,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _env_output(reward: float = 0.0, done: bool = True, text: str = "Task: do it") -> EnvironmentOutput:
+    obs = Observation(contents=[Content.from_data(text)])
+    return EnvironmentOutput(obs=obs, reward=reward, done=done, info={})
+
+
+def _trajectory(reward: float = 1.0, task_id: str = "t1", n_agent_steps: int = 1) -> Trajectory:
+    """Build a minimal completed trajectory for testing."""
+    traj = Trajectory(
+        id=f"{task_id}_ep0",
+        metadata={"task_id": task_id},
+        start_time=100.0,
+        end_time=110.0,
+        reward_info={"reward": reward, "done": reward > 0},
+        summary_stats={
+            "n_agent_steps": n_agent_steps,
+            "n_env_steps": n_agent_steps + 1,
+            "total_llm_calls": n_agent_steps,
+            "prompt_tokens": 100 * n_agent_steps,
+            "completion_tokens": 50 * n_agent_steps,
+            "cached_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cost": 0.01 * n_agent_steps,
+        },
+    )
+    traj.steps.append(TrajectoryStep(output=_env_output(reward=0.0, done=False), start_time=100.0, end_time=101.0))
+    for _ in range(n_agent_steps):
+        traj.steps.append(TrajectoryStep(output=AgentOutput(actions=[]), start_time=101.0, end_time=102.0))
+    traj.steps.append(TrajectoryStep(output=_env_output(reward=reward, done=reward > 0), start_time=102.0, end_time=103.0))
+    return traj
+
+
+# ---------------------------------------------------------------------------
+# _extract_llm_model
+# ---------------------------------------------------------------------------
+
+
+def test_extract_llm_model_top_level_model_name() -> None:
+    assert _extract_llm_model({"model_name": "gpt-4o"}) == "gpt-4o"
+
+
+def test_extract_llm_model_top_level_model() -> None:
+    assert _extract_llm_model({"model": "claude-3-5-sonnet"}) == "claude-3-5-sonnet"
+
+
+def test_extract_llm_model_nested_llm_config() -> None:
+    assert _extract_llm_model({"llm_config": {"model_name": "gpt-4o-mini"}}) == "gpt-4o-mini"
+
+
+def test_extract_llm_model_nested_llm() -> None:
+    assert _extract_llm_model({"llm": {"model": "o1"}}) == "o1"
+
+
+def test_extract_llm_model_returns_none_when_absent() -> None:
+    assert _extract_llm_model({"temperature": 0.7}) is None
+
+
+def test_extract_llm_model_ignores_non_string_values() -> None:
+    assert _extract_llm_model({"model_name": 42}) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_names
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tool_names_litellm_format() -> None:
+    tools = [{"type": "function", "function": {"name": "click", "description": "Click"}}]
+    assert _extract_tool_names(tools) == ["click"]
+
+
+def test_extract_tool_names_flat_format() -> None:
+    tools = [{"name": "type_text", "description": "Type"}]
+    assert _extract_tool_names(tools) == ["type_text"]
+
+
+def test_extract_tool_names_mixed_formats() -> None:
+    tools = [
+        {"type": "function", "function": {"name": "click"}},
+        {"name": "scroll"},
+    ]
+    assert _extract_tool_names(tools) == ["click", "scroll"]
+
+
+def test_extract_tool_names_empty_list() -> None:
+    assert _extract_tool_names([]) == []
+
+
+def test_extract_tool_names_skips_tools_without_name() -> None:
+    tools = [{"type": "function", "function": {"description": "No name here"}}]
+    assert _extract_tool_names(tools) == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_error_type
+# ---------------------------------------------------------------------------
+
+
+def test_extract_error_type_clean_trajectory() -> None:
+    traj = _trajectory(reward=1.0)
+    assert _extract_error_type(traj) is None
+
+
+def test_extract_error_type_from_agent_output() -> None:
+    traj = _trajectory(reward=0.0)
+    err = StepError(error_type="ValueError", exception_str="bad value", stack_trace="")
+    traj.steps.insert(1, TrajectoryStep(output=AgentOutput(error=err), start_time=101.0, end_time=101.5))
+    assert _extract_error_type(traj) == "ValueError"
+
+
+def test_extract_error_type_returns_first_error() -> None:
+    traj = _trajectory(reward=0.0)
+    err1 = StepError(error_type="TimeoutError", exception_str="timeout", stack_trace="")
+    err2 = StepError(error_type="ValueError", exception_str="bad", stack_trace="")
+    traj.steps.insert(1, TrajectoryStep(output=AgentOutput(error=err1), start_time=101.0, end_time=101.5))
+    traj.steps.insert(2, TrajectoryStep(output=AgentOutput(error=err2), start_time=101.5, end_time=102.0))
+    assert _extract_error_type(traj) == "TimeoutError"
+
+
+# ---------------------------------------------------------------------------
+# _extract_first_observation_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_first_observation_text_returns_text() -> None:
+    traj = _trajectory(reward=1.0)
+    text = _extract_first_observation_text(traj)
+    assert text == "Task: do it"
+
+
+def test_extract_first_observation_text_empty_trajectory() -> None:
+    traj = Trajectory(id="empty")
+    assert _extract_first_observation_text(traj) is None
+
+
+def test_extract_first_observation_text_joins_multiple_contents() -> None:
+    obs = Observation(contents=[Content.from_data("Goal:"), Content.from_data("Click the button")])
+    env_out = EnvironmentOutput(obs=obs, reward=0.0, done=False, info={})
+    traj = Trajectory(id="t1")
+    traj.steps.append(TrajectoryStep(output=env_out, start_time=0.0, end_time=1.0))
+    text = _extract_first_observation_text(traj)
+    assert "Goal:" in text
+    assert "Click the button" in text
+
+
+# ---------------------------------------------------------------------------
+# _to_github_url
+# ---------------------------------------------------------------------------
+
+
+def test_to_github_url_ssh() -> None:
+    url = _to_github_url("git@github.com:org/repo.git", "abc123")
+    assert url == "https://github.com/org/repo/tree/abc123"
+
+
+def test_to_github_url_https() -> None:
+    url = _to_github_url("https://github.com/org/repo", "abc123")
+    assert url == "https://github.com/org/repo/tree/abc123"
+
+
+def test_to_github_url_non_github_returns_none() -> None:
+    url = _to_github_url("https://gitlab.com/org/repo.git", "abc123")
+    assert url is None
+
+
+def test_to_github_url_strips_git_suffix() -> None:
+    url = _to_github_url("https://github.com/org/repo.git", "sha1")
+    assert url == "https://github.com/org/repo/tree/sha1"
+
+
+# ---------------------------------------------------------------------------
+# UsageSummary
+# ---------------------------------------------------------------------------
+
+
+def test_usage_summary_from_stats() -> None:
+    stats = {
+        "prompt_tokens": 500,
+        "completion_tokens": 200,
+        "cached_tokens": 50,
+        "cache_creation_tokens": 10,
+        "cost": 0.05,
+        "total_llm_calls": 3,
+    }
+    usage = UsageSummary.from_summary_stats(stats)
+    assert usage.prompt_tokens == 500
+    assert usage.completion_tokens == 200
+    assert usage.total_tokens == 700
+    assert usage.total_cost_usd == 0.05
+    assert usage.n_llm_calls == 3
+
+
+def test_usage_summary_from_none() -> None:
+    usage = UsageSummary.from_summary_stats(None)
+    assert usage.prompt_tokens == 0
+    assert usage.total_cost_usd == 0.0
+
+
+def test_usage_summary_total_tokens_is_sum() -> None:
+    stats = {"prompt_tokens": 100, "completion_tokens": 40}
+    usage = UsageSummary.from_summary_stats(stats)
+    assert usage.total_tokens == 140
+
+
+# ---------------------------------------------------------------------------
+# AgentInfo
+# ---------------------------------------------------------------------------
+
+
+def test_agent_info_from_agent_config_basic(mock_agent_config) -> None:
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    assert len(info.agent_id) == 64  # SHA-256 hex
+    assert "MockAgentConfig" in info.config_type
+    assert isinstance(info.config, dict)
+    assert isinstance(info.dependency_versions, dict)
+    assert isinstance(info.framework_version, str)
+
+
+def test_agent_info_from_agent_config_with_schemas(mock_agent_config) -> None:
+    schemas = [{"type": "function", "function": {"name": "click"}}]
+    info = AgentInfo.from_agent_config(mock_agent_config, action_schemas=schemas)
+    assert info.tools == schemas
+    assert info.tool_names == ["click"]
+
+
+def test_agent_info_agent_id_is_stable(mock_agent_config) -> None:
+    info1 = AgentInfo.from_agent_config(mock_agent_config)
+    info2 = AgentInfo.from_agent_config(mock_agent_config)
+    assert info1.agent_id == info2.agent_id
+
+
+def test_agent_info_with_action_schemas_returns_copy(mock_agent_config) -> None:
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    schemas = [{"type": "function", "function": {"name": "scroll"}}]
+    enriched = info.with_action_schemas(schemas)
+    assert enriched.tool_names == ["scroll"]
+    assert info.tool_names == []  # original unchanged
+
+
+def test_agent_info_llm_model_extracted() -> None:
+    """AgentConfig with llm_config sub-dict gets llm_model populated."""
+    from cube_harness.agent import AgentConfig
+
+    class LLMAgentConfig(AgentConfig):
+        llm_config: dict = {"model_name": "gpt-4o"}
+
+        def make(self, action_set=None, **kwargs):  # type: ignore[override]
+            raise NotImplementedError
+
+    cfg = LLMAgentConfig()
+    info = AgentInfo.from_agent_config(cfg)
+    assert info.llm_model == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# TaskInfo
+# ---------------------------------------------------------------------------
+
+
+def test_task_info_from_trajectory_minimal() -> None:
+    traj = _trajectory(task_id="task-42")
+    info = TaskInfo.from_trajectory_and_metadata(traj)
+    assert info.task_id == "task-42"
+    assert info.benchmark_name == "unknown"
+    assert info.first_observation_text == "Task: do it"
+
+
+def test_task_info_with_benchmark_metadata() -> None:
+    from cube.benchmark import BenchmarkMetadata
+
+    bm = BenchmarkMetadata(name="MiniWoB", version="1.0", description="Mini browser tasks", authors=["A"], tags=["browser"])
+    traj = _trajectory(task_id="click-dialog")
+    info = TaskInfo.from_trajectory_and_metadata(traj, benchmark_metadata=bm)
+    assert info.benchmark_name == "MiniWoB"
+    assert info.benchmark_id == "miniwob"
+    assert info.benchmark_version == "1.0"
+    assert "A" in info.benchmark_authors
+
+
+def test_task_info_with_task_metadata() -> None:
+    from cube.task import TaskMetadata
+
+    tm = TaskMetadata(
+        id="click-dialog",
+        split="test",
+        abstract_description="Click a dialog button",
+        recommended_max_steps=10,
+        extra_info={"difficulty": "easy"},
+    )
+    traj = _trajectory(task_id="click-dialog")
+    info = TaskInfo.from_trajectory_and_metadata(traj, task_metadata=tm)
+    assert info.split == "test"
+    assert info.abstract_description == "Click a dialog button"
+    assert info.recommended_max_steps == 10
+    assert info.extra_info["difficulty"] == "easy"
+
+
+def test_task_info_task_version_hash_from_task_config(mock_tool_config) -> None:
+    from cube.task import TaskConfig, TaskMetadata
+
+    class MockTaskConfig(TaskConfig):
+        def make(self, runtime_context=None, container_backend=None):  # type: ignore[override]
+            raise NotImplementedError
+
+    tc = MockTaskConfig(task_id="t1", seed=42, tool_config=mock_tool_config)
+    traj = _trajectory(task_id="t1")
+    info = TaskInfo.from_trajectory_and_metadata(traj, task_config=tc)
+    assert info.seed == 42
+    assert info.task_version_hash is not None
+    assert len(info.task_version_hash) == 64
+
+
+# ---------------------------------------------------------------------------
+# TaskEvalRecord
+# ---------------------------------------------------------------------------
+
+
+def test_task_eval_record_success(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info, exp_name="exp1")
+    assert record.success is True
+    assert record.reward == 1.0
+    assert record.run_id == "exp1_t1_ep0"
+
+
+def test_task_eval_record_failure(mock_agent_config) -> None:
+    traj = _trajectory(reward=0.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    assert record.success is False
+    assert record.reward == 0.0
+
+
+def test_task_eval_record_wall_time(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    assert record.wall_time_s == pytest.approx(10.0)
+
+
+def test_task_eval_record_n_steps(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0, n_agent_steps=3)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    assert record.n_steps == len(traj.steps)
+    assert record.n_agent_steps == 3
+
+
+# ---------------------------------------------------------------------------
+# EvalLog JSONL round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_eval_log_save_and_load(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info, exp_name="test_exp")
+    log = EvalLog(records=[record])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "eval_log.jsonl"
+        log.save_jsonl(path)
+        loaded = EvalLog.load_jsonl(path)
+
+    assert len(loaded.records) == 1
+    assert loaded.records[0].trajectory_id == record.trajectory_id
+    assert loaded.records[0].success == record.success
+    assert loaded.records[0].reward == record.reward
+
+
+def test_eval_log_jsonl_is_valid_json_per_line(mock_agent_config) -> None:
+    traj = _trajectory(reward=0.5)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    log = EvalLog(records=[record])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "out.jsonl"
+        log.save_jsonl(path)
+        lines = path.read_text().strip().splitlines()
+
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert "task" in parsed
+    assert "agent" in parsed
+    assert "reward" in parsed
+
+
+def test_eval_log_append_record(mock_agent_config) -> None:
+    traj1 = _trajectory(reward=1.0, task_id="t1")
+    traj2 = _trajectory(reward=0.0, task_id="t2")
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info1 = TaskInfo.from_trajectory_and_metadata(traj1)
+    task_info2 = TaskInfo.from_trajectory_and_metadata(traj2)
+    rec1 = TaskEvalRecord.from_trajectory(traj1, agent_info, task_info1)
+    rec2 = TaskEvalRecord.from_trajectory(traj2, agent_info, task_info2)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "streamed.jsonl"
+        EvalLog.append_record(rec1, path)
+        EvalLog.append_record(rec2, path)
+        loaded = EvalLog.load_jsonl(path)
+
+    assert len(loaded.records) == 2
+    task_ids = {r.task.task_id for r in loaded.records}
+    assert task_ids == {"t1", "t2"}

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -378,6 +378,32 @@ def test_task_eval_record_n_steps(mock_agent_config) -> None:
     assert record.n_agent_steps == 3
 
 
+def test_task_eval_record_declaration_defaults_empty(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    assert record.declaration == {}
+
+
+def test_task_eval_record_declaration_roundtrip(mock_agent_config) -> None:
+    traj = _trajectory(reward=1.0)
+    agent_info = AgentInfo.from_agent_config(mock_agent_config)
+    task_info = TaskInfo.from_trajectory_and_metadata(traj)
+    record = TaskEvalRecord.from_trajectory(traj, agent_info, task_info)
+    record = record.model_copy(
+        update={
+            "declaration": {
+                "motivation": "capability_probe",
+                "task_selection_method": "random",
+                "compute_budget": "full_benchmark",
+            }
+        }
+    )
+    assert record.declaration["motivation"] == "capability_probe"
+    assert record.declaration["task_selection_method"] == "random"
+
+
 # ---------------------------------------------------------------------------
 # EvalLog JSONL round-trip
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -57,7 +57,9 @@ def _trajectory(reward: float = 1.0, task_id: str = "t1", n_agent_steps: int = 1
     traj.steps.append(TrajectoryStep(output=_env_output(reward=0.0, done=False), start_time=100.0, end_time=101.0))
     for _ in range(n_agent_steps):
         traj.steps.append(TrajectoryStep(output=AgentOutput(actions=[]), start_time=101.0, end_time=102.0))
-    traj.steps.append(TrajectoryStep(output=_env_output(reward=reward, done=reward > 0), start_time=102.0, end_time=103.0))
+    traj.steps.append(
+        TrajectoryStep(output=_env_output(reward=reward, done=reward > 0), start_time=102.0, end_time=103.0)
+    )
     return traj
 
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -233,8 +233,8 @@ class TestExperiment:
 
         exp.save_config()
 
-        assert nested_dir.exists()
-        assert (nested_dir / "experiment_config.json").exists()
+        assert exp.output_dir.exists()
+        assert (exp.output_dir / "experiment_config.json").exists()
 
     def test_experiment_serialization(self, tmp_dir, mock_agent_config, mock_cube_benchmark):
         """Test Experiment JSON serialization."""

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -15,7 +15,7 @@ from cube_harness.core import Trajectory, TrajectoryStep
 from cube_harness.episode import Episode
 from cube_harness.episode_status import EpisodeStatus
 from cube_harness.exp_runner import _kill_stale_workers, run_sequentially
-from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
+from cube_harness.experiment import _UUID_SUFFIX_RE, Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.storage import FileStorage
 from tests.conftest import MockAgentConfig, MockCubeBenchmark, MockCubeTask, MockCubeTaskConfig, MockToolConfig
 
@@ -150,6 +150,20 @@ class TestExperiment:
         assert exp.output_dir == tmp_dir
         assert exp.agent_config == mock_agent_config
         assert exp.benchmark == mock_cube_benchmark
+
+    def test_experiment_auto_output_dir(self, mock_agent_config, mock_cube_benchmark):
+        """output_dir is auto-generated when omitted."""
+        exp = Experiment(
+            name="my_run",
+            agent_config=mock_agent_config,
+            benchmark=mock_cube_benchmark,
+        )
+
+        assert exp.output_dir is not None
+        assert exp.output_dir.exists()
+        assert _UUID_SUFFIX_RE.search(exp.output_dir.name)
+        assert "mock-cube" in exp.output_dir.name
+        assert mock_agent_config.agent_name in exp.output_dir.name
 
     def test_experiment_config_property(self, tmp_dir, mock_agent_config, mock_cube_benchmark):
         """Test Experiment config property."""


### PR DESCRIPTION
## Summary

Implements the **Atlas EvalLog** system — a JSONL-based evaluation record schema for Project ATLAS (Agent-Task Latent Analysis System). ATLAS uses these records to populate a community sparse matrix M[agent, task] = reward, enabling large-scale agent capability analysis across benchmarks.

### New file: `src/cube_harness/eval_log.py`

- **`UsageSummary`** — aggregated LLM token/cost stats per episode
- **`AgentInfo`** — rich agent descriptor capturing: SHA-256 `agent_id` (stable across runs), full serialized config, extracted LLM model name, full action schemas in litellm format, installed dependency versions (9 packages), and git provenance (commit SHA + GitHub permalink). No source code — just enough for Atlas to embed the agent in latent space.
- **`TaskInfo`** — rich task descriptor: benchmark metadata (name, version, authors, tags), task-level metadata (split, abstract description, recommended step budget), SHA-256 `task_version_hash` (detects silent task drift), seed, and `first_observation_text` (the actual task instruction the agent saw — primary Atlas embedding field).
- **`TaskEvalRecord`** — complete episode record (task + agent + outcome + trajectory summary + provenance) ready for Atlas ingestion as a single JSONL line.
- **`EvalLog`** — JSONL collection with `save_jsonl` / `load_jsonl` / `append_record` (streaming, no full materialization).

### Modified: `src/cube_harness/episode.py`

Stores `action_schemas` in `trajectory.metadata` at run time so eval records can be built post-hoc without re-instantiating tasks (no environment setup needed).

### Modified: `src/cube_harness/experiment.py`

Adds `Experiment.export_eval_log(output_path=None, git_cwd=None) -> EvalLog` — batch-exports one `TaskEvalRecord` per completed trajectory. Reads action schemas from trajectory metadata, resolves task/benchmark metadata from the benchmark object.

**Usage:**
```python
exp = Experiment(name="my_exp", output_dir=..., agent_config=..., benchmark=...)
run_sequentially(exp)
eval_log = exp.export_eval_log()  # writes output_dir/eval_log.jsonl
```

### New file: `tests/test_eval_log.py`

40 unit tests covering all private helpers and public classes — 40/40 passing.

## Test plan

- [x] `uv run pytest tests/test_eval_log.py -v` → 40/40 passed
- [x] `uv run pytest tests/ -q` → 614/614 passed (no regressions)
- [x] Constitution compliance: all imports at module level (EX-001), type hints everywhere (CC-001), no global mutable state (EX-002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)