### PR TITLE
chore: drop uv.sources git overrides now that cube-standard 0.1.0rc5 is on PyPI

### DIFF
--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -19,9 +19,6 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/miniwob_cube/task_metadata.json"]
 
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
-
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/osworld-cube/pyproject.toml
+++ b/cubes/osworld-cube/pyproject.toml
@@ -78,7 +78,6 @@ markers = [
 override-dependencies = ["protobuf>=6.33.5"]
 
 [tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 cube-computer-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-computer-tool" }
 cube-vm-backend = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-vm-backend" }
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }

--- a/cubes/swebench-verified-cube/pyproject.toml
+++ b/cubes/swebench-verified-cube/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = "SWE-bench Verified — 500 real-world GitHub issues with test-based validation"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc4",
+    "cube-standard>=0.1.0rc5",
     "datasets",
 ]
 
 [project.optional-dependencies]
 debug = [
-    "cube-standard[docker]>=0.1.0rc4",
+    "cube-standard[docker]>=0.1.0rc5",
 ]
 
 [project.entry-points."cube.benchmarks"]
@@ -27,9 +27,6 @@ include = ["src/swebench_verified_cube/task_metadata.json"]
 dev = [
     "pytest>=9.0",
 ]
-
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 
 [tool.ruff]
 fix = true

--- a/cubes/terminalbench-cube/pyproject.toml
+++ b/cubes/terminalbench-cube/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = "Terminal-Bench 2 — real-world terminal tasks with pytest-based validation"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc4",
+    "cube-standard>=0.1.0rc5",
     "datasets",
 ]
 
 [project.optional-dependencies]
 debug = [
-    "cube-standard[docker]>=0.1.0rc4",
+    "cube-standard[docker]>=0.1.0rc5",
 ]
 
 [project.entry-points."cube.benchmarks"]
@@ -27,9 +27,6 @@ include = ["src/terminalbench_cube/task_metadata.json"]
 dev = [
     "pytest>=9.0",
 ]
-
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 
 [tool.ruff]
 fix = true

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "WebArena-Verified benchmark cube — 812 verified web automation tasks"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc4",
+    "cube-standard>=0.1.0rc5",
     "cube-browser-tool>=0.2.0",
     "webarena-verified",
     "Pillow",
@@ -19,9 +19,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/webarena_verified_cube/task_metadata.json"]
-
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 
 [tool.ruff]
 fix = true

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "WorkArena ServiceNow benchmark for cube"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "cube-standard>=0.1.0rc4",
+    "cube-standard>=0.1.0rc5",
     "browsergym-workarena",
     "termcolor",
     "cube-browser-tool>=0.2.0",
@@ -22,9 +22,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/workarena_cube/task_metadata.json"]
-
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 
 [tool.ruff]
 fix = true

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -25,7 +25,6 @@ azure = [
 ]
 
 [tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }  # TODO: remove once 0.1.0rc5 released
 cube-infra-aws = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-aws" }  # TODO: remove once cube-infra-aws released
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }  # TODO: remove once cube-infra-azure released
 osworld-cube = { path = "../cubes/osworld-cube", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc4",
+    "cube-standard>=0.1.0rc5",
     "cube-browser-playwright>=0.2.0",  # added back temporarily for browsergym.py, should be removed once browsergym.py is moved to cube-browser-tool package
     "pydantic~=2.0",
     "litellm~=1.80.8",
@@ -44,9 +44,6 @@ build-backend = "uv_build"
 
 [tool.uv]
 constraint-dependencies = ["pyasn1>=0.6.2", "cryptography>=46.0.5", "protobuf>=6.33.5"]
-
-[tool.uv.sources]
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard"}  # TODO: remove once 0.1.0rc5 released
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
## Summary

- Remove all `[tool.uv.sources]` `cube-standard = { git = ... }` overrides that were pinned with `# TODO: remove once 0.1.0rc5 released`
- Bump `cube-standard` version floor from `>=0.1.0rc4` to `>=0.1.0rc5` where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)