### PR TITLE
docs: link cube-standard's Authoring a CUBE guide from cubes/README

### DIFF
--- a/cubes/README.md
+++ b/cubes/README.md
@@ -2,13 +2,6 @@
 
 This folder contains concrete CUBE implementations — self-contained Python packages that wrap specific benchmarks (e.g., WebArena, SWE-bench, OSWorld) using the `cube` standard library.
 
-Each cube typically provides:
+Each cube implements the `Tool`, `Task`, and `Benchmark` interfaces from `cube-standard` (plus an optional `Container` config for sandboxed environments). Once wrapped, any cube can run in any CUBE-compatible harness.
 
-- **`Tool` subclass** — defines the action space the agent can use (e.g., browser clicks, shell commands), implemented with `@tool_action`-decorated methods
-- **`ToolConfig`** — serializable config that instantiates the tool (optionally connecting to a container)
-- **`Task` subclass** — implements `reset()` (initial observation) and `evaluate()` (scoring), plus optional `finished()` and `filter_actions()`
-- **`TaskConfig`** — serializable config with a `make()` method that instantiates the task, wiring together metadata, tool config, and runtime context
-- **`Benchmark` subclass** — manages the full task collection: declares `benchmark_metadata`, `task_metadata`, `task_config_class`, and implements `_setup()` / `close()` for shared infrastructure
-- **`Container` config** *(optional)* — if the benchmark needs a sandboxed environment (Docker, etc.)
-
-By implementing this interface, any cube can be run by any agent harness that supports the CUBE standard.
+**Building a new cube?** See the **[Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube)** in cube-standard — it covers the five-layer architecture, three starting paths (interactive `/new-cube` skill, copy an example, scaffold from the template), implementation order, and validation.


### PR DESCRIPTION
## Summary

Companion doc PR to cube-standard [#117](https://github.com/The-AI-Alliance/cube-standard/pull/117), which introduces the new **Authoring a CUBE** guide at https://the-ai-alliance.github.io/cube-standard/authoring-a-cube.

Collapses the duplicated 5-layer description in `cubes/README.md` (Tool / ToolConfig / Task / TaskConfig / Benchmark / Container) to a single pointer at the guide. The inline description drifted from the authoritative spec over time; one link keeps the two in sync and gives cube authors a single pedagogical starting point.

## Test plan

- [ ] Link resolves after [cube-standard #117](https://github.com/The-AI-Alliance/cube-standard/pull/117) merges (will work immediately; the guide is already on that branch's Jekyll site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)