### PR TITLE
feat(dev): make review — frictionless cross-repo PR setup

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Block commits that leave a local path = "..." source in any pyproject.toml.
+# Relative paths break for anyone with a different folder structure.
+# Use Depends-on: in the PR description and `make review PR=<n>` instead.
+if git diff --cached -- '*pyproject.toml' | grep -qE '^\+\s*path\s*=\s*"'; then
+    echo "❌ A pyproject.toml contains a local path = \"...\" source."
+    echo "   Local paths break for reviewers with a different folder structure."
+    echo ""
+    echo "   Instead:"
+    echo "   1. Revert the path = source to the PyPI/git version."
+    echo "   2. Add a Depends-on: line to your PR description:"
+    echo "      Depends-on: cube-standard/<branch-name>"
+    echo "   3. Reviewers run: make review PR=<n>"
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,6 @@ node_modules
 
 # LSF license
 pac.entitlement
+
+# Local cube-standard clone for cross-repo development (see: make review PR=<n>)
+cube-standard/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,34 @@ make test               # full pytest
 make debug              # small end-to-end run
 make xray               # open the trajectory viewer
 make lint
+make review PR=<n>      # check out a PR and wire up any cross-repo cube-standard dependency
 uv run recipes/hello_miniwob.py   # example run
 ```
 
 Environment vars go in `.env` (loaded by pyproject). `OPENAI_API_KEY`
 is the only required one for the baseline recipes; see individual cubes for others.
+
+## Cross-repo PRs (cube-harness ↔ cube-standard)
+
+When a PR depends on an unreleased cube-standard branch, do **not** commit
+`path = "..."` local sources to any `pyproject.toml` (root or under `cubes/`).
+The pre-commit hook (`.githooks/pre-commit`) will block this — local paths break
+for anyone with a different folder structure.
+
+**Authoring a cross-repo PR:**
+
+1. Keep `pyproject.toml` pointing at PyPI (or a git ref) — do **not** commit the local path.
+2. Add `Depends-on: cube-standard/<branch-name>` anywhere in the PR description body.
+
+**Reviewing a cross-repo PR:**
+
+```bash
+make review PR=<n>
+```
+
+This checks out the PR branch, reads `Depends-on:` from the PR description, clones
+`cube-standard` into the repo root (gitignored), checks out the correct branch, and
+installs all workspace packages with `uv pip install -e cube-standard --all-packages --all-extras`.
 
 ## What lives elsewhere
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ for anyone with a different folder structure.
 **Authoring a cross-repo PR:**
 
 1. Keep `pyproject.toml` pointing at PyPI (or a git ref) — do **not** commit the local path.
-2. Add `Depends-on: cube-standard/<branch-name>` anywhere in the PR description body.
+2. Add a line starting with `Depends-on: cube-standard/<branch-name>` to the PR description body. The line must start at column 0 (no leading whitespace, not inside a list or quote block).
 
 **Reviewing a cross-repo PR:**
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
-.PHONY: help install ci-install update format lint test coverage hello debug xray
+.PHONY: help install ci-install update format lint test coverage hello debug xray review
 
 help:
-	@echo "make install    - Install dependencies in editable mode"
-	@echo "make ci-install - Install dependencies with locked versions (for CI)"
-	@echo "make update     - Update dependencies"
-	@echo "make format     - Format code"
-	@echo "make lint       - Lint and auto-fix"
-	@echo "make test       - Run unit tests"
-	@echo "make coverage   - Run tests with coverage report"
-	@echo "make hello      - Run hello_miniwob recipe"
-	@echo "make debug      - Run hello_miniwob recipe in debug mode"
-	@echo "make xray       - Run AL2 XRay viewer in debug mode"
+	@echo "make install       - Install dependencies in editable mode"
+	@echo "make ci-install    - Install dependencies with locked versions (for CI)"
+	@echo "make update        - Update dependencies"
+	@echo "make format        - Format code"
+	@echo "make lint          - Lint and auto-fix"
+	@echo "make test          - Run unit tests"
+	@echo "make coverage      - Run tests with coverage report"
+	@echo "make hello         - Run hello_miniwob recipe"
+	@echo "make debug         - Run hello_miniwob recipe in debug mode"
+	@echo "make xray          - Run AL2 XRay viewer in debug mode"
+	@echo "make review PR=<n> - Check out a PR and set up any cross-repo cube-standard dependency"
 
 hello:
 	@echo "🤖 Running hello_miniwob recipe"
@@ -58,3 +59,29 @@ test: install
 coverage:
 	@echo "📊 Running tests with coverage report"
 	uv run pytest tests/ --cov=cube_harness --cov-report=term-missing
+
+review:
+	@if [ -z "$(PR)" ]; then echo "Usage: make review PR=<number>"; exit 1; fi
+	@echo "🔍 Checking out PR $(PR)"
+	gh pr checkout $(PR) --repo The-AI-Alliance/cube-harness
+	@DEPENDS_ON=$$(gh pr view $(PR) --repo The-AI-Alliance/cube-harness --json body --jq '.body' \
+	    | grep -i '^Depends-on:' | head -1 | sed 's/Depends-on://I' | tr -d ' \r'); \
+	if [ -n "$$DEPENDS_ON" ]; then \
+	    echo "📦 Depends-on: $$DEPENDS_ON"; \
+	    BRANCH=$$(echo "$$DEPENDS_ON" | cut -d/ -f2-); \
+	    if [ -d "cube-standard" ]; then \
+	        echo "⚠️  cube-standard/ already exists — skipping clone/checkout."; \
+	        echo "   To use branch $$BRANCH, manage it manually:"; \
+	        echo "   git -C cube-standard checkout $$BRANCH"; \
+	    else \
+	        echo "Cloning cube-standard branch: $$BRANCH"; \
+	        git clone --branch "$$BRANCH" https://github.com/The-AI-Alliance/cube-standard.git cube-standard; \
+	    fi; \
+	else \
+	    echo "No Depends-on found — using cube-standard from PyPI"; \
+	fi
+	@if [ -d "cube-standard/.git" ]; then \
+	    echo "📦 Installing cube-standard (all workspace packages)..."; \
+	    uv pip install -e cube-standard --all-packages --all-extras; \
+	fi
+	@echo "✅ Ready to review PR $(PR)"

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ coverage:
 
 review:
 	@if [ -z "$(PR)" ]; then echo "Usage: make review PR=<number>"; exit 1; fi
+	@if ! git diff --quiet || ! git diff --cached --quiet; then \
+	    echo "❌ Working tree has uncommitted changes. Stash or commit before running make review."; \
+	    exit 1; \
+	fi
 	@echo "🔍 Checking out PR $(PR)"
 	gh pr checkout $(PR) --repo The-AI-Alliance/cube-harness
 	@DEPENDS_ON=$$(gh pr view $(PR) --repo The-AI-Alliance/cube-harness --json body --jq '.body' \
@@ -70,9 +74,14 @@ review:
 	    echo "📦 Depends-on: $$DEPENDS_ON"; \
 	    BRANCH=$$(echo "$$DEPENDS_ON" | cut -d/ -f2-); \
 	    if [ -d "cube-standard" ]; then \
-	        echo "⚠️  cube-standard/ already exists — skipping clone/checkout."; \
-	        echo "   To use branch $$BRANCH, manage it manually:"; \
-	        echo "   git -C cube-standard checkout $$BRANCH"; \
+	        CURRENT=$$(git -C cube-standard rev-parse --abbrev-ref HEAD); \
+	        if [ "$$CURRENT" != "$$BRANCH" ]; then \
+	            echo "❌ cube-standard/ already exists but is on branch '$$CURRENT' (expected '$$BRANCH')."; \
+	            echo "   Switch it manually: git -C cube-standard checkout $$BRANCH"; \
+	            echo "   Or remove cube-standard/ and re-run make review PR=$(PR)."; \
+	            exit 1; \
+	        fi; \
+	        echo "✅ cube-standard/ already on branch $$BRANCH"; \
 	    else \
 	        echo "Cloning cube-standard branch: $$BRANCH"; \
 	        git clone --branch "$$BRANCH" https://github.com/The-AI-Alliance/cube-standard.git cube-standard; \


### PR DESCRIPTION
## Summary

- Adds `make review PR=<n>` that checks out a PR, reads `Depends-on: cube-standard/<branch>` from the PR description, clones cube-standard on that branch, and installs all workspace packages (`--all-packages --all-extras`)
- Warns instead of overwriting if `cube-standard/` already exists in the working directory
- Adds a pre-commit hook (`.githooks/pre-commit`) that blocks committing local `path = "..."` sources in any `pyproject.toml` (root or `cubes/*`), directing authors to use the `Depends-on:` convention instead
- Adds `cube-standard/` to `.gitignore`
- Documents the full cross-repo workflow in `AGENTS.md`

## Motivation

Cross-repo PRs between cube-harness and cube-standard currently require manual steps to figure out which branch to clone and where. This removes that friction and standardises the convention via a single make command.

## Convention

**Authors** add to their PR description:
```
Depends-on: cube-standard/<branch-name>
```

**Reviewers** run:
```bash
make review PR=<n>
```

## Test plan

- [ ] `make review PR=<n>` on a PR with `Depends-on:` clones and checks out the correct branch
- [ ] `make review PR=<n>` on a PR without `Depends-on:` prints "No Depends-on found" and skips clone
- [ ] Running again with `cube-standard/` already present prints the warning and skips clone
- [ ] Committing a `pyproject.toml` with `path = "..."` is blocked by the pre-commit hook
- [ ] Committing without a local path passes the hook