### PR TITLE
rfc: episode status file for robust resume/retry

### DIFF
--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -61,7 +61,7 @@ directory. No trajectory deserialization in the retry decision path.
 Controls how many times a failed episode is retried. Episodes at `retry_count >= max_retries`
 are reported as permanently failed and excluded from future runs.
 
-### ADDED — `max_retry_rounds: int = 1` parameter on `run_with_ray` and `run_sequentially`
+### ADDED — `max_retry_rounds: int = 3` parameter on `run_with_ray` and `run_sequentially`
 
 After the main run completes, the runner checks for retriable episodes. If any exist
 and `retry_rounds < max_retry_rounds`, it runs again with `retry_failed=True` on the

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -128,11 +128,6 @@ Run at:
 - The start of `get_episodes_to_run()` when `resume=True`
 - After `ray.shutdown()` in `_run_with_ray_impl`
 
-### ADDED — `is_retriable(status, max_retries) -> bool` (in `experiment.py`)
-
-Standalone helper; `True` if status is `None` or in `RETRIABLE_STATUSES` with
-`retry_count < max_retries`.
-
 ### ADDED — `max_retries: int = 3` field on `Experiment`
 
 Controls how many times a failed episode is retried. Episodes at `retry_count >= max_retries`
@@ -160,6 +155,9 @@ def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> Non
 
 def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
     # Returns None if status.json does not exist or is corrupt
+
+def archive_episode(self, trajectory_id: str) -> None: ...
+    # Renames the episode directory to <id>.archived_<ts>/ preserving per-attempt history
 ```
 
 ### ADDED — `FileStorage` implementation
@@ -183,8 +181,9 @@ Status files live at `episodes/{trajectory_id}/status.json`.
 Before submitting episodes to Ray, the driver calls `_pre_claim(storage, episode)`:
 
 - Reads any prior `status.json`.
-- If prior is terminal, archives the episode directory (preserving per-attempt history).
+- If prior is terminal, calls `storage.archive_episode(traj_id)` (public `Storage` Protocol method) to preserve per-attempt history.
 - Writes `status=QUEUED` with `last_heartbeat_at=None` and `retry_count` from `next_retry_count(prior)`.
+- Only called for episodes that will actually run — in `debug_limit` mode, episodes beyond the limit are not pre-claimed.
 
 A concurrent runner sees `QUEUED` / `RUNNING` and skips those episodes.
 

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -12,7 +12,7 @@ Applies to: `openspec/specs/episode/spec.md`, `openspec/specs/experiment/spec.md
 ```python
 @dataclass
 class EpisodeStatus:
-    status: Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED"]
+    status: Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE"]
     task_id: str
     episode_id: int
     started_at: float
@@ -52,8 +52,8 @@ of the retry decision path.
 | `resume` | `retry_failed` | Episodes returned |
 |----------|----------------|-------------------|
 | False    | False          | All episodes from scratch |
-| True     | False          | Episodes with no `status.json` or `status != COMPLETED` with `status == RUNNING` and stale heartbeat — i.e. unstarted |
-| False    | True           | Episodes with `status IN (FAILED, CANCELLED)` or stale RUNNING, AND `retry_count < max_retries` |
+| True     | False          | Episodes with no `status.json` or `status == STALE` — i.e. unstarted or abandoned |
+| False    | True           | Episodes with `status IN (FAILED, CANCELLED, STALE)` or missing `status.json`, AND `retry_count < max_retries` |
 | True     | True           | Unstarted ∪ failed/cancelled |
 
 ### ADDED — `max_retries: int = 3` field on `Experiment`
@@ -94,3 +94,11 @@ def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
 After `ray.cancel(ref, force=True)`, write `status=CANCELLED` for that episode via
 `storage.write_episode_status()`. Increment `retry_count` by reading the current
 status first.
+
+After `ray.shutdown()`, sweep all episode directories. For any episode still in
+`RUNNING` state, check `last_heartbeat_at`:
+- Fresh (within threshold) → leave as `RUNNING` (sequential edge case or overlap window)
+- Stale or missing → write `status=STALE`; these will be retried on the next run
+
+This sweep is the only reliable way to detect dead workers: the driver is the last
+process alive after the Ray cluster shuts down.

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -42,30 +42,34 @@ the worker died before the episode could initialise — treat as retriable.
 
 ## experiment/spec.md
 
-### REMOVED — `_is_trajectory_successful`
+### REMOVED — `_is_trajectory_successful`, `_load_successful_trajectory_ids`
 
-Replaced entirely by status file check. Trajectory deserialization is no longer part
-of the retry decision path.
+Replaced by `_load_episode_statuses` which reads only `status.json` per episode
+directory. No trajectory deserialization in the retry decision path.
 
 ### MODIFIED — Resume / retry semantics table
 
 | `resume` | `retry_failed` | Episodes returned |
 |----------|----------------|-------------------|
 | False    | False          | All episodes from scratch |
-| True     | False          | Episodes with no `status.json` or `status == STALE` — i.e. unstarted or abandoned |
-| False    | True           | Episodes with `status IN (FAILED, CANCELLED, STALE)` or missing `status.json`, AND `retry_count < max_retries` |
-| True     | True           | Unstarted ∪ failed/cancelled |
+| True     | False          | Episodes with no `status.json` (never started) |
+| False    | True           | Episodes with `status IN (FAILED, STALE, CANCELLED)` or missing `status.json`, AND `retry_count < max_retries` |
+| True     | True           | Union of the above two |
 
 ### ADDED — `max_retries: int = 3` field on `Experiment`
 
 Controls how many times a failed episode is retried. Episodes at `retry_count >= max_retries`
-are reported as permanently failed and skipped.
+are reported as permanently failed and excluded from future runs.
 
-### MODIFIED — `_load_completed_trajectory_ids` (replaces `_load_successful_trajectory_ids`)
+### ADDED — `max_retry_rounds: int = 1` parameter on `run_with_ray` and `run_sequentially`
 
-Reads only `status.json` per episode directory. No trajectory deserialization.
+After the main run completes, the runner checks for retriable episodes. If any exist
+and `retry_rounds < max_retry_rounds`, it runs again with `retry_failed=True` on the
+same output directory. The loop repeats until no retriable episodes remain or
+`max_retry_rounds` is exhausted. The final `ExpResult` aggregates all rounds.
 
-Stale RUNNING detection: `now - last_heartbeat_at > 120` seconds.
+This allows a single `run_with_ray(exp)` call to automatically recover from transient
+failures without caller intervention.
 
 ---
 

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -1,0 +1,96 @@
+# Deltas — Episode Status File
+
+Applies to: `openspec/specs/episode/spec.md`, `openspec/specs/experiment/spec.md`,
+`openspec/specs/storage/spec.md`
+
+---
+
+## episode/spec.md
+
+### ADDED — `EpisodeStatus` dataclass
+
+```python
+@dataclass
+class EpisodeStatus:
+    status: Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED"]
+    task_id: str
+    episode_id: int
+    started_at: float
+    ended_at: float | None = None
+    last_heartbeat_at: float | None = None
+    reward: float | None = None
+    had_step_errors: bool = False
+    retry_count: int = 0
+```
+
+### MODIFIED — `Episode._run_loop` lifecycle
+
+Before (no status file):
+- Trajectory written incrementally; no terminal signal on crash.
+
+After:
+1. Write `status=RUNNING` via `storage.write_episode_status()` before `setup_fn()`
+2. Start background heartbeat thread (30s interval, updates `last_heartbeat_at`)
+3. In `finally`: stop heartbeat thread; write `status=COMPLETED` or `status=FAILED`
+
+### INVARIANT
+
+`status.json` is always written before any step file. A missing `status.json` means
+the worker died before the episode could initialise — treat as retriable.
+
+---
+
+## experiment/spec.md
+
+### REMOVED — `_is_trajectory_successful`
+
+Replaced entirely by status file check. Trajectory deserialization is no longer part
+of the retry decision path.
+
+### MODIFIED — Resume / retry semantics table
+
+| `resume` | `retry_failed` | Episodes returned |
+|----------|----------------|-------------------|
+| False    | False          | All episodes from scratch |
+| True     | False          | Episodes with no `status.json` or `status != COMPLETED` with `status == RUNNING` and stale heartbeat — i.e. unstarted |
+| False    | True           | Episodes with `status IN (FAILED, CANCELLED)` or stale RUNNING, AND `retry_count < max_retries` |
+| True     | True           | Unstarted ∪ failed/cancelled |
+
+### ADDED — `max_retries: int = 3` field on `Experiment`
+
+Controls how many times a failed episode is retried. Episodes at `retry_count >= max_retries`
+are reported as permanently failed and skipped.
+
+### MODIFIED — `_load_completed_trajectory_ids` (replaces `_load_successful_trajectory_ids`)
+
+Reads only `status.json` per episode directory. No trajectory deserialization.
+
+Stale RUNNING detection: `now - last_heartbeat_at > 120` seconds.
+
+---
+
+## storage/spec.md
+
+### ADDED — `Storage` Protocol methods
+
+```python
+def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
+    # Atomic: write to .tmp, then os.replace()
+
+def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
+    # Returns None if status.json does not exist
+```
+
+### ADDED — `FileStorage` implementation
+
+- `write_episode_status`: serialises `EpisodeStatus` to JSON, writes atomically via
+  a `.tmp` sibling file + `os.replace()`.
+- `read_episode_status`: reads `<episode_dir>/status.json`; returns `None` on missing file.
+
+---
+
+## exp_runner.py (not a spec file — implementation note)
+
+After `ray.cancel(ref, force=True)`, write `status=CANCELLED` for that episode via
+`storage.write_episode_status()`. Increment `retry_count` by reading the current
+status first.

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -30,8 +30,8 @@ Before (no status file):
 
 After:
 1. Write `status=RUNNING` via `storage.write_episode_status()` before `setup_fn()`
-2. Start background heartbeat thread (30s interval, updates `last_heartbeat_at`)
-3. In `finally`: stop heartbeat thread; write `status=COMPLETED` or `status=FAILED`
+2. Write step-boundary heartbeat updates (`last_heartbeat_at`, `current_step`) from the worker main thread
+3. In `finally`: write terminal `status` (`COMPLETED`, `MAX_STEPS_REACHED`, or `FAILED`)
 
 ### INVARIANT
 
@@ -47,14 +47,16 @@ the worker died before the episode could initialise — treat as retriable.
 Replaced by `_load_episode_statuses` which reads only `status.json` per episode
 directory. No trajectory deserialization in the retry decision path.
 
-### MODIFIED — Resume / retry semantics table
+### MODIFIED — Resume and auto-retry semantics
 
-| `resume` | `retry_failed` | Episodes returned |
-|----------|----------------|-------------------|
-| False    | False          | All episodes from scratch |
-| True     | False          | Episodes with no `status.json` (never started) |
-| False    | True           | Episodes with `status IN (FAILED, STALE, CANCELLED)` or missing `status.json`, AND `retry_count < max_retries` |
-| True     | True           | Union of the above two |
+`Experiment.get_episodes_to_run()` is now status-driven and keyed off `resume`:
+
+| `resume` | Episodes returned |
+|----------|-------------------|
+| False    | All episodes from scratch |
+| True     | Episodes with no `status.json` (never started), plus retriable statuses (`FAILED`, `STALE`, `CANCELLED`) with `retry_count < max_retries` |
+
+In-flight statuses (`QUEUED`, `RUNNING`) are never returned. Terminal non-retriable statuses (`COMPLETED`, `MAX_STEPS_REACHED`) are skipped.
 
 ### ADDED — `max_retries: int = 3` field on `Experiment`
 
@@ -64,8 +66,8 @@ are reported as permanently failed and excluded from future runs.
 ### ADDED — `max_retry_rounds: int = 3` parameter on `run_with_ray` and `run_sequentially`
 
 After the main run completes, the runner checks for retriable episodes. If any exist
-and `retry_rounds < max_retry_rounds`, it runs again with `retry_failed=True` on the
-same output directory. The loop repeats until no retriable episodes remain or
+and `retry_rounds < max_retry_rounds`, it runs another retry round on the
+same output directory (`resume=True`). The loop repeats until no retriable episodes remain or
 `max_retry_rounds` is exhausted. The final `ExpResult` aggregates all rounds.
 
 This allows a single `run_with_ray(exp)` call to automatically recover from transient

--- a/openspec/changes/episode-status/deltas.md
+++ b/openspec/changes/episode-status/deltas.md
@@ -7,71 +7,146 @@ Applies to: `openspec/specs/episode/spec.md`, `openspec/specs/experiment/spec.md
 
 ## episode/spec.md
 
-### ADDED — `EpisodeStatus` dataclass
+### ADDED — `EpisodeStatus` dataclass (new module: `cube_harness/episode_status.py`)
+
+`EpisodeStatus` lives in its own module to avoid circular imports between `episode.py`
+and `storage.py`. Both import from `episode_status.py`.
 
 ```python
+Status = Literal["QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"]
+
+IN_FLIGHT_STATUSES  = frozenset({"QUEUED", "RUNNING"})
+TERMINAL_STATUSES   = frozenset({"COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"})
+RETRIABLE_STATUSES  = frozenset({"FAILED", "CANCELLED", "STALE"})
+
 @dataclass
 class EpisodeStatus:
-    status: Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE"]
+    status: Status
     task_id: str
     episode_id: int
     started_at: float
     ended_at: float | None = None
     last_heartbeat_at: float | None = None
+    current_step: int = 0
     reward: float | None = None
     had_step_errors: bool = False
+    error_type: str | None = None
+    error_message: str | None = None
     retry_count: int = 0
+    extra: dict = field(default_factory=dict)
 ```
+
+Status meanings:
+
+| Status             | Written by                     | Meaning                                                          |
+|--------------------|--------------------------------|------------------------------------------------------------------|
+| `QUEUED`           | driver (`_pre_claim`)          | Submitted to Ray; worker hasn't started yet                      |
+| `RUNNING`          | worker (`_open_status`)        | Worker is actively executing the episode                         |
+| `COMPLETED`        | worker (`finally`)             | Loop reached natural end (`done=True` or agent gave up)          |
+| `MAX_STEPS_REACHED`| worker (`finally`)             | Loop exhausted `max_steps` without `done=True`; not retriable    |
+| `FAILED`           | worker (`finally`)             | Unhandled exception propagated out of `_run_loop`                |
+| `CANCELLED`        | driver (`_kill_stale_workers`) | Step heartbeat went stale; driver force-killed the worker        |
+| `STALE`            | `sweep_stale_statuses` (driver)| Worker died without writing a terminal status                    |
+
+`MAX_STEPS_REACHED` is terminal but **not** retriable — the agent legitimately ran out of
+its step budget; retrying from a fresh initial state would just truncate again.
+
+### ADDED — `next_retry_count(prior: EpisodeStatus | None) -> int`
+
+Helper in `episode_status.py`:
+
+- `prior is None` → `0` (original attempt)
+- `prior.status in IN_FLIGHT_STATUSES` → `prior.retry_count` (idempotent re-pre-claim)
+- `prior.status in TERMINAL_STATUSES` → `prior.retry_count + 1`
 
 ### MODIFIED — `Episode._run_loop` lifecycle
 
 Before (no status file):
+
 - Trajectory written incrementally; no terminal signal on crash.
 
 After:
-1. Write `status=RUNNING` via `storage.write_episode_status()` before `setup_fn()`
-2. Write step-boundary heartbeat updates (`last_heartbeat_at`, `current_step`) from the worker main thread
-3. In `finally`: write terminal `status` (`COMPLETED`, `MAX_STEPS_REACHED`, or `FAILED`)
+
+1. `Episode._open_status(trajectory_id)` is called at the top of `_run_loop`.
+   - Reads any prior `status.json`.
+   - If prior status is terminal and `allow_overwrite=True`, archives the old episode directory.
+   - Writes `status=RUNNING` with `last_heartbeat_at=now` and `current_step=0`.
+   - This covers stuck `setup_fn` (env reset, container boot).
+2. At the start of each turn (before `agent.step()` and `step_fn()`):
+   - Updates `last_heartbeat_at` and `current_step` in-place and writes to `status.json`.
+3. In `finally`: sets `ended_at` and `last_heartbeat_at` to `now`, then writes terminal status:
+   - `COMPLETED` — loop exited normally (`done=True` or agent returned no actions).
+   - `MAX_STEPS_REACHED` — `turns >= max_steps` and `done` was never `True`.
+   - `FAILED` — unhandled exception; also sets `error_type` and `error_message`.
 
 ### INVARIANT
 
-`status.json` is always written before any step file. A missing `status.json` means
-the worker died before the episode could initialise — treat as retriable.
+`status.json` (`QUEUED` or `RUNNING`) is always written before any step file. A
+missing `status.json` in an episode directory with a config means the worker died
+before entering `_run_loop` — treat as retriable.
 
 ---
 
 ## experiment/spec.md
 
-### REMOVED — `_is_trajectory_successful`, `_load_successful_trajectory_ids`
+### REMOVED — `retry_failed: bool` field on `Experiment`
 
-Replaced by `_load_episode_statuses` which reads only `status.json` per episode
-directory. No trajectory deserialization in the retry decision path.
+The `retry_failed` flag and the 2×2 `resume` × `retry_failed` selection table are
+removed. Retry behaviour is now fully controlled by `resume=True` combined with the
+status file: retriable statuses (`FAILED`, `CANCELLED`, `STALE`) are picked up
+automatically when `resume=True`, so a separate flag is redundant.
 
-### MODIFIED — Resume and auto-retry semantics
+### REMOVED — `_is_trajectory_successful`, `_load_successful_trajectory_ids`, `_load_started_trajectory_ids`, `_find_episodes_to_relaunch`
 
-`Experiment.get_episodes_to_run()` is now status-driven and keyed off `resume`:
+Replaced by status-driven selection via `storage.list_episode_statuses()`.
+No trajectory deserialisation in the retry decision path.
+
+### MODIFIED — Resume semantics
+
+`Experiment.get_episodes_to_run()` is status-driven and keyed off `resume`:
 
 | `resume` | Episodes returned |
 |----------|-------------------|
-| False    | All episodes from scratch |
-| True     | Episodes with no `status.json` (never started), plus retriable statuses (`FAILED`, `STALE`, `CANCELLED`) with `retry_count < max_retries` |
+| `False`  | All episodes from scratch |
+| `True`   | Episodes with no `status.json` (never started), plus retriable statuses (`FAILED`, `STALE`, `CANCELLED`) with `retry_count < max_retries` |
 
-In-flight statuses (`QUEUED`, `RUNNING`) are never returned. Terminal non-retriable statuses (`COMPLETED`, `MAX_STEPS_REACHED`) are skipped.
+`RUNNING` / `QUEUED` (in-flight) are never returned. `COMPLETED` and
+`MAX_STEPS_REACHED` (terminal, non-retriable) are skipped.
+
+When `resume=True`, `sweep_stale_statuses` runs first so orphaned `RUNNING`/`QUEUED`
+entries become `STALE` and are eligible for retry.
+
+### ADDED — `sweep_stale_statuses` (in `experiment.py`)
+
+Marks in-flight episodes whose worker is dead as `STALE`:
+
+- `RUNNING` with `last_heartbeat_at` older than `step_timeout_s + cancel_grace_s` → `STALE`
+- `QUEUED` with `started_at` older than `orphan_threshold_s` (default 1 h) → `STALE`
+
+Run at:
+
+- The start of `get_episodes_to_run()` when `resume=True`
+- After `ray.shutdown()` in `_run_with_ray_impl`
+
+### ADDED — `is_retriable(status, max_retries) -> bool` (in `experiment.py`)
+
+Standalone helper; `True` if status is `None` or in `RETRIABLE_STATUSES` with
+`retry_count < max_retries`.
 
 ### ADDED — `max_retries: int = 3` field on `Experiment`
 
 Controls how many times a failed episode is retried. Episodes at `retry_count >= max_retries`
-are reported as permanently failed and excluded from future runs.
+are excluded from future runs.
 
 ### ADDED — `max_retry_rounds: int = 3` parameter on `run_with_ray` and `run_sequentially`
 
-After the main run completes, the runner checks for retriable episodes. If any exist
-and `retry_rounds < max_retry_rounds`, it runs another retry round on the
-same output directory (`resume=True`). The loop repeats until no retriable episodes remain or
-`max_retry_rounds` is exhausted. The final `ExpResult` aggregates all rounds.
+After each round, the runner calls `_has_retriable_episodes(exp)`. If any exist and
+`round_num < max_retry_rounds`, it runs another round with `resume=True` on the same
+`output_dir`. The loop repeats until no retriable episodes remain or the round budget
+is exhausted. The final `ExpResult` aggregates trajectories and failures across all
+rounds.
 
-This allows a single `run_with_ray(exp)` call to automatically recover from transient
-failures without caller intervention.
+Pass `max_retry_rounds=0` to disable auto-retry entirely.
 
 ---
 
@@ -80,31 +155,52 @@ failures without caller intervention.
 ### ADDED — `Storage` Protocol methods
 
 ```python
-def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
-    # Atomic: write to .tmp, then os.replace()
+def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None: ...
+    # Atomic: write to .tmp sibling, then os.replace()
 
-def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
-    # Returns None if status.json does not exist
+def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
+    # Returns None if status.json does not exist or is corrupt
 ```
 
 ### ADDED — `FileStorage` implementation
 
-- `write_episode_status`: serialises `EpisodeStatus` to JSON, writes atomically via
-  a `.tmp` sibling file + `os.replace()`.
-- `read_episode_status`: reads `<episode_dir>/status.json`; returns `None` on missing file.
+- `write_episode_status`: delegates to `EpisodeStatus.write(path)`, which writes
+  atomically via a `.tmp` sibling + `os.replace()`.
+- `read_episode_status`: delegates to `EpisodeStatus.read(path)`; returns `None` on
+  missing or corrupt file.
+- `list_episode_statuses() -> dict[str, EpisodeStatus]`: returns `{trajectory_id: status}`
+  for every non-archived episode directory that has a `status.json`. Used by the
+  retry loop and `sweep_stale_statuses`.
+
+Status files live at `episodes/{trajectory_id}/status.json`.
 
 ---
 
-## exp_runner.py (not a spec file — implementation note)
+## exp_runner.py (not a spec file — implementation notes)
 
-After `ray.cancel(ref, force=True)`, write `status=CANCELLED` for that episode via
-`storage.write_episode_status()`. Increment `retry_count` by reading the current
-status first.
+### Pre-claim (`_pre_claim`)
 
-After `ray.shutdown()`, sweep all episode directories. For any episode still in
-`RUNNING` state, check `last_heartbeat_at`:
-- Fresh (within threshold) → leave as `RUNNING` (sequential edge case or overlap window)
-- Stale or missing → write `status=STALE`; these will be retried on the next run
+Before submitting episodes to Ray, the driver calls `_pre_claim(storage, episode)`:
 
-This sweep is the only reliable way to detect dead workers: the driver is the last
-process alive after the Ray cluster shuts down.
+- Reads any prior `status.json`.
+- If prior is terminal, archives the episode directory (preserving per-attempt history).
+- Writes `status=QUEUED` with `last_heartbeat_at=None` and `retry_count` from `next_retry_count(prior)`.
+
+A concurrent runner sees `QUEUED` / `RUNNING` and skips those episodes.
+
+### Step-timeout kill (`_kill_stale_workers`)
+
+In the driver poll loop, after each `ray.wait()` batch:
+
+- Reads `status.json` for each in-progress ref.
+- Skips refs in `QUEUED` state (no heartbeat to check yet).
+- If `last_heartbeat_at` age exceeds `step_timeout_s + cancel_grace_s`: calls
+  `ray.cancel(ref, force=True)`, re-reads status (to avoid clobbering a race-won
+  terminal write), and writes `status=CANCELLED` with `error_type="StepTimeout"`.
+
+### End-of-run STALE sweep
+
+After `ray.shutdown()` in `_run_with_ray_impl`, `sweep_stale_statuses` is called.
+Any `RUNNING` entries whose worker was just killed by `ray.shutdown()` (and therefore
+never wrote a terminal status) are swept to `STALE` so the next retry round can pick
+them up.

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -35,6 +35,18 @@ for retry decisions. The trajectory is data; `status.json` is control.
 | `COMPLETED` | `episode._run_loop` in finally | Loop ran to natural end (done or max_steps); reward is irrelevant |
 | `FAILED` | `episode._run_loop` in finally | Unhandled exception propagated out of the run loop |
 | `CANCELLED` | `exp_runner` after `ray.cancel(force=True)` | Explicitly timed out by the harness |
+| `STALE` | `exp_runner` after `ray.shutdown()` | Worker was killed externally and will never write a terminal status |
+
+**Core invariant:** `RUNNING` with a fresh heartbeat means the episode is actively
+executing — do not retry. `RUNNING` with a stale heartbeat means the worker is dead
+and the episode will never finish. The exp_runner driver (which outlives all workers)
+sweeps for stale `RUNNING` episodes after `ray.shutdown()` and writes `STALE`, making
+them eligible for retry on the next run.
+
+`STALE` vs `FAILED`: `FAILED` means the worker lived long enough to catch an exception
+and write terminal status. `STALE` means it was killed before that could happen. Both
+are retried, but the distinction helps with diagnosis: many `STALE` = infrastructure
+problem (OOM, cluster failure); many `FAILED` = application bug.
 
 ### `status.json` schema
 
@@ -63,21 +75,24 @@ Fields:
 ### Heartbeat
 
 A background thread in `_run_loop` writes `last_heartbeat_at` to `status.json` every
-30 seconds while the episode is running. On recovery:
+30 seconds while the episode is running. After `ray.shutdown()`, the exp_runner driver
+sweeps all episode directories and for any episode still in `RUNNING` state:
 
-- `status == RUNNING` and `now - last_heartbeat_at < threshold` (e.g. 2 minutes) → truly running, do not retry
-- `status == RUNNING` and `last_heartbeat_at` is stale or missing → dead worker, treat as FAILED for retry purposes
+- `now - last_heartbeat_at < threshold` (e.g. 2 minutes) → truly still running (sequential mode or overlap window) — leave as `RUNNING`
+- `last_heartbeat_at` is stale or missing → worker is dead, episode will never finish → write `STALE`
 
 This works for both local (sequential) and distributed (Ray) runs without requiring
 access to the Ray dashboard or any external state.
 
 ### Retry logic
 
-An episode is eligible for retry if:
+An episode is eligible for retry if `retry_count < max_retries` (proposed default: 3) and:
 1. `status.json` does not exist (worker died before writing `RUNNING`)
-2. `status == RUNNING` and heartbeat is stale
+2. `status == STALE` (driver confirmed the worker is dead)
 3. `status == FAILED` or `status == CANCELLED`
-4. `retry_count < max_retries` (proposed default: 3)
+
+An episode is **never** retried if `status == RUNNING` with a fresh heartbeat —
+it is currently executing.
 
 An episode is considered done (do not retry) if:
 - `status == COMPLETED`

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -1,6 +1,6 @@
 # RFC: Episode Status File
 
-**Version:** 0.3 — heartbeat & timeout consolidation, 2026-04-27
+**Version:** 0.4 — aligned with implementation, 2026-04-28
 
 ## Problem
 
@@ -35,7 +35,7 @@ The mechanism has three pieces:
    worker's main thread.
 2. **Driver poll loop** reads `status.json` from the filesystem instead of querying
    the Ray dashboard for elapsed time. Step-timeout is the only kill trigger.
-3. **STALE sweep** cleans up orphaned `RUNNING` entries from crashed drivers.
+3. **STALE sweep** cleans up orphaned in-flight entries from crashed drivers.
 
 > **Load-bearing assumption**: `output_dir` is on a filesystem visible to both the
 > driver and every Ray worker (NFS, shared object store, single host). This is
@@ -45,21 +45,76 @@ The mechanism has three pieces:
 
 ### Episode statuses
 
-| Status | Written by | Meaning |
-|---|---|---|
-| `RUNNING` | driver (pre-claim) → worker | Episode queued or actively executing |
-| `COMPLETED` | worker (`finally`) | Loop reached natural end (done or `max_steps`) |
-| `FAILED` | worker (`finally`) | Unhandled exception propagated out of `_run_loop` |
-| `CANCELLED` | driver after `ray.cancel(force=True)` | Step heartbeat went stale → driver killed it |
-| `STALE` | STALE sweep (driver) | Worker died without writing terminal status |
+| Status              | Written by                      | Meaning                                                       |
+|---------------------|---------------------------------|---------------------------------------------------------------|
+| `QUEUED`            | driver (`_pre_claim`)           | Submitted to Ray; worker hasn't picked it up yet              |
+| `RUNNING`           | worker (`_open_status`)         | Worker is actively executing the episode                      |
+| `COMPLETED`         | worker (`finally`)              | Loop reached natural end (`done=True` or agent gave up)       |
+| `MAX_STEPS_REACHED` | worker (`finally`)              | Loop exhausted `max_steps` without `done=True`; not retriable |
+| `FAILED`            | worker (`finally`)              | Unhandled exception propagated out of `_run_loop`             |
+| `CANCELLED`         | driver (`_kill_stale_workers`)  | Step heartbeat went stale; driver force-killed the worker     |
+| `STALE`             | `sweep_stale_statuses` (driver) | Worker died without writing a terminal status                 |
 
-**Retry-eligibility ground truth:**
-- `RUNNING` with fresh heartbeat → **skip** (alive or queued).
-- `RUNNING` with stale heartbeat → **retry** (worker is dead, will be swept to `STALE`).
-- `COMPLETED` → **never retry** (`reward == 0` is a legitimate agent failure, not a
-  technical one).
-- `FAILED` / `STALE` / `CANCELLED` / missing → **retry**, gated by `retry_count <
-  max_retries`.
+`QUEUED` and `RUNNING` are *in-flight* — never included in retry selection.
+`COMPLETED` and `MAX_STEPS_REACHED` are terminal but *not retriable* — the agent
+either succeeded or legitimately ran out of steps; a retry would just repeat from
+a fresh initial state.
+
+### State transition diagram
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> QUEUED : _pre_claim · driver
+
+    QUEUED --> RUNNING    : _open_status · worker picks up
+    QUEUED --> STALE      : sweep_stale_statuses · started_at > orphan_threshold_s
+
+    RUNNING --> COMPLETED        : worker finally · done=True or agent gave up
+    RUNNING --> MAX_STEPS_REACHED: worker finally · turns >= max_steps
+    RUNNING --> FAILED           : worker finally · unhandled exception
+    RUNNING --> CANCELLED        : _kill_stale_workers · heartbeat age > step_timeout_s + cancel_grace_s
+    RUNNING --> STALE            : sweep_stale_statuses · no fresh heartbeat after ray.shutdown or crash
+
+    FAILED    --> QUEUED : _pre_claim · retry_count < max_retries
+    CANCELLED --> QUEUED : _pre_claim · retry_count < max_retries
+    STALE     --> QUEUED : _pre_claim · retry_count < max_retries
+
+    COMPLETED        --> [*] : not retriable
+    MAX_STEPS_REACHED --> [*] : not retriable
+    FAILED    --> [*] : retry_count >= max_retries
+    CANCELLED --> [*] : retry_count >= max_retries
+    STALE     --> [*] : retry_count >= max_retries
+```
+
+**Transition table:**
+
+| From | To | Written by | Condition |
+| --- | --- | --- | --- |
+| `[none]` | `QUEUED` | driver · `_pre_claim` | First submission — no prior `status.json` exists |
+| `[none]` | `RUNNING` | worker · `_open_status` | Sequential mode only — no pre-claim; worker writes `RUNNING` directly¹ |
+| `QUEUED` | `RUNNING` | worker · `_open_status` | Worker picks up the episode and begins executing |
+| `QUEUED` | `STALE` | driver · `sweep_stale_statuses` | `now − started_at > orphan_threshold_s` — never picked up by Ray |
+| `RUNNING` | `RUNNING` | worker · heartbeat | Start of each turn — updates `last_heartbeat_at` and `current_step` only |
+| `RUNNING` | `COMPLETED` | worker · `finally` | `done=True` or agent returned no actions |
+| `RUNNING` | `MAX_STEPS_REACHED` | worker · `finally` | `turns >= max_steps` and `done` was never `True` |
+| `RUNNING` | `FAILED` | worker · `finally` | Unhandled exception propagated out of `_run_loop` |
+| `RUNNING` | `CANCELLED` | driver · `_kill_stale_workers` | `now − last_heartbeat_at > step_timeout_s + cancel_grace_s` → `ray.cancel(force=True)` |
+| `RUNNING` | `STALE` | driver · `sweep_stale_statuses` | No fresh heartbeat after `ray.shutdown()` or driver crash |
+| `FAILED` | `QUEUED` | driver · `_pre_claim` | `retry_count < max_retries` — archives prior dir, queues next attempt |
+| `CANCELLED` | `QUEUED` | driver · `_pre_claim` | `retry_count < max_retries` — archives prior dir, queues next attempt |
+| `STALE` | `QUEUED` | driver · `_pre_claim` | `retry_count < max_retries` — archives prior dir, queues next attempt |
+| `FAILED` | `[terminal]` | — | `retry_count >= max_retries` — cap reached, permanently failed |
+| `CANCELLED` | `[terminal]` | — | `retry_count >= max_retries` — cap reached, permanently failed |
+| `STALE` | `[terminal]` | — | `retry_count >= max_retries` — cap reached, permanently failed |
+| `COMPLETED` | `[terminal]` | — | Always — legitimate success, not retriable |
+| `MAX_STEPS_REACHED` | `[terminal]` | — | Always — agent exhausted step budget, not retriable |
+
+> ¹ **Known gap:** sequential mode currently skips `_pre_claim`, so episodes waiting
+> their turn have no `status.json`. A crash mid-run makes them indistinguishable from
+> episodes that were never submitted. The fix is to pre-claim all episodes upfront in
+> `_run_sequentially_impl` before the loop starts — tracked as a follow-up.
 
 ---
 
@@ -68,13 +123,15 @@ The mechanism has three pieces:
 Inside `Episode._run_loop`, the worker writes `last_heartbeat_at` and `current_step`
 to `status.json` at:
 
-1. The very top of `_run_loop` (covers stuck `setup_fn` — env reset, container boot).
+1. The very top of `_run_loop` (via `_open_status`) — covers stuck `setup_fn` (env
+   reset, container boot).
 2. The start of each turn, before `agent.step()` and before `step_fn()`.
 
 That is the entire mechanism. **No background thread. No child process. No asyncio
 interaction.** Just a file write in the worker's main thread at natural sync points.
 
 **Why this works where threads and subprocesses didn't:**
+
 - Ray workers run inside an asyncio event loop. A daemon thread doing I/O while the
   main thread is in an async call deadlocks or gets silently dropped on shutdown.
 - Ray workers are daemon processes; Python disallows non-daemon children of daemons.
@@ -87,26 +144,30 @@ It's not "obvious in hindsight"; it's a different topology.
 
 ### Pre-claim: race protection on submission
 
-Before submitting episodes to Ray, the driver writes `RUNNING` for every episode it
-intends to launch:
+Before submitting episodes to Ray, the driver calls `_pre_claim(storage, episode)` for
+every episode it intends to launch. This writes `QUEUED` — a distinct state from
+`RUNNING` that signals "submitted to Ray, but no worker has picked it up yet":
 
 ```python
 storage.write_episode_status(traj_id, EpisodeStatus(
-    status="RUNNING",
+    status="QUEUED",
     started_at=now,
-    last_heartbeat_at=None,    # worker hasn't started; queued in Ray
-    retry_count=incremented_from_previous,
+    last_heartbeat_at=None,   # None until the worker enters _open_status
+    retry_count=next_retry_count(prior),
     ...,
 ))
 ```
 
-A concurrent runner that opens the same `output_dir` then sees `RUNNING` and skips:
-- `resume=True` skips because it only returns missing-`status.json`.
-- `retry_failed=True` skips because `RUNNING` ∉ `{FAILED, STALE, CANCELLED}` and the
-  heartbeat-staleness check screens out the rest.
+If the previous attempt left a terminal status, `_pre_claim` archives the episode
+directory first so the per-attempt history (including the terminal `status.json`) is
+preserved before being overwritten.
 
-When the worker actually picks up the episode, `_run_loop` overwrites the pre-claim
-with `started_at = now()` and starts writing heartbeats.
+A concurrent runner that opens the same `output_dir` sees `QUEUED` or `RUNNING` and
+skips — `resume=True` only returns episodes with no `status.json` or retriable
+terminal statuses, and `QUEUED` / `RUNNING` are neither.
+
+When the worker picks up the episode, `Episode._open_status` overwrites `QUEUED` →
+`RUNNING` with a fresh `started_at` and begins writing heartbeats.
 
 > **Limitation, accepted for v1.** Two drivers starting within the same ~second can
 > both call `get_episodes_to_run()` before either pre-claims, then race-write
@@ -117,15 +178,15 @@ with `started_at = now()` and starts writing heartbeats.
 
 ### `last_heartbeat_at = None` is two semantics in one absent field
 
-The field is `None` between pre-claim (driver) and the first heartbeat (worker), i.e.
-while the episode is **queued in Ray** but not yet picked up. It's also `None` if the
-worker died after pre-claim but before reaching `_run_loop` (rare).
+The field is `None` while the episode is `QUEUED` (submitted to Ray, worker hasn't
+started). It's also `None` if the worker died after pre-claim but before reaching
+`_open_status` (rare).
 
-Two distinct policies follow:
+Two distinct policies apply:
 
 | Caller | Behaviour for `last_heartbeat_at = None` |
 |---|---|
-| Driver poll (mid-run) | **Skip** — assume it's queued, don't kill |
+| Driver poll (`_kill_stale_workers`, mid-run) | **Skip** — status is `QUEUED`, not `RUNNING`; no heartbeat to check |
 | STALE sweep (start of next run, or after `ray.shutdown`) | Mark `STALE` if `now − started_at > orphan_threshold_s` (default 1 h — generous Ray-queue allowance) |
 
 This pins down a behaviour that would otherwise live in folklore.
@@ -135,29 +196,37 @@ This pins down a behaviour that would otherwise live in folklore.
 ### Driver kill via filesystem read, not Ray dashboard
 
 Replace `_get_running_elapsed_s` (which calls `ray.util.state.api.list_tasks` on the
-Ray dashboard) with a filesystem read:
+Ray dashboard) with a filesystem read in `_kill_stale_workers`:
 
 ```python
-for ref in episodes_in_progress:
+for ref in list(episodes_in_progress):
     traj_id = ref_to_traj_id[ref]
     status = storage.read_episode_status(traj_id)
-    if status is None or status.last_heartbeat_at is None:
-        continue   # not started yet — let Ray handle queueing
+    # QUEUED → not yet picked up; skip.
+    if status is None or status.status != "RUNNING" or status.last_heartbeat_at is None:
+        continue
 
     age = now - status.last_heartbeat_at
-    if age > step_timeout_s + cancel_grace_s:
-        ray.cancel(ref, force=True)
-        status.status = "CANCELLED"
-        status.ended_at = now
-        status.error_type = "StepTimeout"
-        status.error_message = f"Step {status.current_step} exceeded {step_timeout_s:.0f}s"
-        storage.write_episode_status(traj_id, status)
-        episodes_in_progress.remove(ref)
+    if age <= step_timeout_s + cancel_grace_s:
+        continue
+
+    ray.cancel(ref, force=True)
+
+    # Re-read before overwriting: the worker may have raced to a terminal status.
+    fresh = storage.read_episode_status(traj_id)
+    if fresh is not None and fresh.status != "RUNNING":
+        continue   # don't clobber a legitimate COMPLETED/FAILED
+    status.status = "CANCELLED"
+    status.ended_at = now
+    status.error_type = "StepTimeout"
+    status.error_message = f"Step {status.current_step} exceeded {step_timeout_s:.0f}s"
+    storage.write_episode_status(traj_id, status)
 ```
 
 Wins:
-- **No Ray-dashboard dependency.** `from ray.util.state.api import list_tasks`
-  deleted. Past us has been bitten by this API drifting between Ray versions.
+
+- **No Ray-dashboard dependency.** `from ray.util.state.api import list_tasks` deleted.
+  Past us has been bitten by this API drifting between Ray versions.
 - **Per-step granularity.** Detects "stuck on step 14 for 30 min" instead of waiting
   for total elapsed to exceed an episode-wide cap.
 - **Always writes a terminal status.** No more zombie `RUNNING` after a force kill.
@@ -187,20 +256,21 @@ repo runs near it).
 }
 ```
 
-| Field | Type | Set by | Notes |
-|---|---|---|---|
-| `status` | enum | both | Lifecycle state |
-| `task_id` | str | both | For grouping / listing |
-| `episode_id` | int | both | For grouping / listing |
-| `started_at` | float | driver (pre-claim), then worker (actual start) | Wall clock |
-| `ended_at` | float\|None | worker / driver | Wall clock at terminal status |
-| `last_heartbeat_at` | float\|None | worker | `None` until first turn begins |
-| `current_step` | int | worker | `0` during `setup_fn`; `1..` once turn loop starts |
-| `reward` | float\|None | worker | `None` until `COMPLETED` |
-| `had_step_errors` | bool | worker | Informational; does not affect retry |
-| `error_type` | str\|None | worker / driver | Exception class for failures |
-| `error_message` | str\|None | worker / driver | Short message — first-line diagnosis |
-| `retry_count` | int | driver | See semantics below |
+| Field              | Type          | Set by              | Notes                                          |
+|--------------------|---------------|---------------------|------------------------------------------------|
+| `status`           | enum          | both                | Lifecycle state                                |
+| `task_id`          | str           | both                | For grouping / listing                         |
+| `episode_id`       | int           | both                | For grouping / listing                         |
+| `started_at`       | float         | driver, then worker | Wall clock; overwritten when worker picks up   |
+| `ended_at`         | float\|None   | worker / driver     | Wall clock at terminal status                  |
+| `last_heartbeat_at`| float\|None   | worker              | `None` while `QUEUED`; set on first turn       |
+| `current_step`     | int           | worker              | `0` during `setup_fn`; `1+` once loop starts   |
+| `reward`           | float\|None   | worker              | `None` until terminal; set on `COMPLETED`      |
+| `had_step_errors`  | bool          | worker              | Informational; does not affect retry           |
+| `error_type`       | str\|None     | worker / driver     | Exception class for failures                   |
+| `error_message`    | str\|None     | worker / driver     | Short message — first-line diagnosis           |
+| `retry_count`      | int           | driver              | See semantics below                            |
+| `extra`            | dict          | either              | Extension bag; ignored by current readers      |
 
 ### `retry_count` semantics
 
@@ -209,15 +279,19 @@ repo runs near it).
 - Episode is retried iff `retry_count < max_retries`.
 - `max_retries = 3` ⇒ attempts at `retry_count` 0, 1, 2, 3 ⇒ **4 total attempts**.
 
-The driver computes the new value during pre-claim: it reads the existing
-`status.json` (if any), increments `retry_count` by one if a previous attempt exists,
-then writes `RUNNING`.
+The `next_retry_count(prior)` helper in `episode_status.py` computes the value:
+idempotent if prior is in-flight (same count), incremented by one if prior is terminal,
+zero if there is no prior status.
+
+The driver sets `retry_count` during pre-claim (or `_open_status` in sequential mode)
+and **always writes `QUEUED`** (Ray) or `RUNNING` (sequential) — never increments
+while the episode is running.
 
 ---
 
 ### `Experiment.get_episodes_to_run()` semantics
 
-A new field:
+New field on `Experiment`:
 
 ```python
 class Experiment(TypedBaseModel):
@@ -225,33 +299,40 @@ class Experiment(TypedBaseModel):
     max_retries: int = 3
 ```
 
-| `resume` | `retry_failed` | Episodes returned |
-|---|---|---|
-| F | F | All episodes from scratch |
-| T | F | Missing `status.json` (never started) |
-| F | T | `status IN (FAILED, STALE, CANCELLED)` **or** missing, with `retry_count < max_retries` |
-| T | T | Union of the above two |
+| `resume` | Episodes returned |
+| --- | --- |
+| `False` | All episodes from scratch |
+| `True` | Episodes with no `status.json` (never started) **plus** retriable statuses (`FAILED`, `STALE`, `CANCELLED`) with `retry_count < max_retries` |
 
-`RUNNING` (with fresh heartbeat) is **never** included — by either flag.
+`QUEUED` / `RUNNING` (in-flight) are **never** returned. `COMPLETED` and
+`MAX_STEPS_REACHED` (non-retriable terminal) are always skipped.
+
+When `resume=True`, `sweep_stale_statuses` runs first so orphaned `RUNNING`/`QUEUED`
+entries are marked `STALE` and become eligible.
 
 The deletion list in `experiment.py`:
-- `_is_trajectory_successful` — superseded by COMPLETED status.
+
+- `_is_trajectory_successful` — superseded by `COMPLETED` status check.
 - `_load_successful_trajectory_ids` — full trajectory scans no longer needed.
-- `_load_started_trajectory_ids` — replaced by `_read_episode_status_map`.
+- `_load_started_trajectory_ids` — replaced by `storage.list_episode_statuses()`.
 - `_find_episodes_to_relaunch` — folded into `get_episodes_to_run`.
 
 ---
 
 ### STALE sweep
 
-Marks `RUNNING` → `STALE` for episodes that meet:
+`sweep_stale_statuses` in `experiment.py` marks in-flight episodes whose worker is
+dead as `STALE`. Two cases:
 
-- `last_heartbeat_at` set, and `now − last_heartbeat_at > step_timeout_s + cancel_grace_s`, **or**
-- `last_heartbeat_at == None`, and `now − started_at > orphan_threshold_s` (default 1 h).
+- `RUNNING` with `last_heartbeat_at` set and `now − last_heartbeat_at > step_timeout_s + cancel_grace_s`
+  → worker died mid-episode without writing a terminal status.
+- `QUEUED` with `now − started_at > orphan_threshold_s` (default 1 h)
+  → driver pre-claimed but Ray never picked the episode up (prior driver crashed before submit).
 
 Run at:
-- The **start** of `get_episodes_to_run()` whenever `resume=True` or `retry_failed=True`
-  — cleans up after a previous driver that crashed without `ray.shutdown()`.
+
+- The **start** of `get_episodes_to_run()` when `resume=True` — cleans up after a
+  previous driver that crashed without `ray.shutdown()`.
 - **After** `ray.shutdown()` in `_run_with_ray_impl` — handles the normal end-of-run
   case where workers are killed when the cluster shuts down.
 
@@ -260,8 +341,9 @@ Run at:
 ### Auto-retry loop
 
 `run_with_ray` and `run_sequentially` gain `max_retry_rounds: int = 3`. After each
-round, the runner queries for retriable episodes; if any exist and we haven't hit
-the round budget, it re-runs them with `retry_failed=True` on the same `output_dir`.
+round, the runner calls `_has_retriable_episodes(exp)`. If any exist and the round
+budget hasn't been exhausted, it sets `exp.resume = True` and runs another round on
+the same `output_dir`:
 
 ```python
 def run_with_ray(
@@ -269,10 +351,10 @@ def run_with_ray(
     *,
     n_cpus: int = 4,
     ray_poll_timeout: float = 2.0,
-    step_timeout_s: float = 1800.0,        # 30 min — kill if a single step hangs
-    cancel_grace_s: float = 120.0,         # buffer over step_timeout
-    orphan_threshold_s: float = 3600.0,    # 1 h — for never-started pre-claims
-    max_retry_rounds: int = 3,             # post-run retry sweeps
+    step_timeout_s: float = 1800.0,    # 30 min — kill if a single step hangs
+    cancel_grace_s: float = 120.0,     # buffer over step_timeout
+    orphan_threshold_s: float = 3600.0,# 1 h — for QUEUED orphan detection
+    max_retry_rounds: int = 3,         # post-run retry sweeps
     ...,
 ) -> ExpResult:
 ```
@@ -281,17 +363,19 @@ Existing recipes that call `run_with_ray(exp)` get auto-retry out of the box. Pa
 `max_retry_rounds=0` to opt out.
 
 The final `ExpResult` aggregates trajectories and failures across all rounds.
+`exp.resume` is restored to its original value after the retry loop completes.
 
 ---
 
 ### Sequential mode
 
-`run_sequentially` shares `max_retry_rounds`. It does **not** enforce
-`step_timeout_s` (no driver poll loop, no external killer for the in-process
-worker). Heartbeats are still written for status visibility; pre-claim is skipped
-(no concurrency to defend against). A hung step in sequential mode requires a
-human Ctrl-C — acceptable, since sequential is the debug path. A future RFC can
-add a `signal.alarm`-based per-step timeout if it becomes needed.
+`run_sequentially` shares `max_retry_rounds` and the same retry loop. It does **not**
+enforce `step_timeout_s` (no driver poll loop, no external killer for the in-process
+worker). Heartbeats are still written for status visibility. Pre-claim (`_pre_claim`)
+is skipped — there's no concurrency to defend against — but `Episode._open_status`
+still archives any prior terminal directory and writes `RUNNING` before the loop
+starts. A hung step in sequential mode requires a human Ctrl-C — acceptable, since
+sequential is the debug path.
 
 ---
 
@@ -304,7 +388,8 @@ class Storage(Protocol):
     def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
 ```
 
-`FileStorage` implements them with atomic write (`.tmp` sibling + `os.replace()`).
+`FileStorage` also adds `list_episode_statuses() -> dict[str, EpisodeStatus]`, used
+by the retry loop and sweep. Atomic write is via a `.tmp` sibling + `os.replace()`.
 Status lives at `episodes/{trajectory_id}/status.json`.
 
 ---
@@ -313,7 +398,8 @@ Status lives at `episodes/{trajectory_id}/status.json`.
 
 A plain `@dataclass` in `cube_harness/episode_status.py`. Imported by both
 `episode.py` and `storage.py`. Avoids the circular import that would arise from
-defining it in `episode.py`.
+defining it in `episode.py`. Also exports `IN_FLIGHT_STATUSES`, `TERMINAL_STATUSES`,
+`RETRIABLE_STATUSES`, and `next_retry_count`.
 
 ---
 
@@ -362,28 +448,45 @@ viewer, sequential-mode debug experience.
 
 ## Testing strategy
 
-### One Ray-based integration test, four scenarios
+### Integration tests (`tests/test_retry_integration.py`)
 
-A single `run_with_ray(...)` over a 4-task benchmark covers ~80% of the retry
-machinery in one shot. Each task exercises a distinct code path:
+Four tests covering distinct scenarios:
 
-| Episode | Scenario list | Final status | retry_count | Archived dirs |
-|---|---|---|---|---|
-| 0 — `task_succeed` | `["succeed"]` | `COMPLETED` | 0 | 0 |
-| 1 — `task_flaky` | `["fail", "fail", "succeed"]` | `COMPLETED` | 2 | 2 (both `FAILED`) |
-| 2 — `task_dead` | `["fail"] * 4` | `FAILED` (max_retries cap) | 3 | 3 |
-| 3 — `task_hang` | `["hang", "succeed"]` | `COMPLETED` | 1 | 1 (`CANCELLED`, `error_type="StepTimeout"`) |
+**`test_retry_machinery_end_to_end`** — single `run_with_ray(...)` over a 4-task
+benchmark (marked `@pytest.mark.slow`):
+
+| Episode       | Scenarios                     | Final status        | retry_count | Archives |
+|---------------|-------------------------------|---------------------|-------------|----------|
+| `task_succeed`| `["succeed"]`                 | `COMPLETED`         | 0           | 0        |
+| `task_flaky`  | `["fail", "fail", "succeed"]` | `COMPLETED`         | 2           | 2        |
+| `task_dead`   | `["fail"] * 4`                | `FAILED` (cap)      | 3           | 3        |
+| `task_hang`   | `["hang", "succeed"]`         | `COMPLETED`         | 1           | 1        |
+
+**`test_mixed_state_recovery_via_ray`** — simulates a crashed prior driver by
+hand-writing heterogeneous state (`COMPLETED`, stale `RUNNING`, missing), then
+verifies a new driver with `resume=True` makes the right decision per episode.
+
+**`test_run_sequentially_auto_retries_flaky_episode`** — sequential path: one fail +
+one succeed, verifies archive and final `COMPLETED`.
+
+**`test_max_steps_terminates_with_forced_eval`** — agent loops forever, `max_steps=2`
+fires, status is `MAX_STEPS_REACHED`, reward is from forced `evaluate()`, not zero.
+`resume=True` afterwards returns nothing.
+
+**`test_max_retries_zero_disables_auto_retry`** — `max_retries=0` keeps a failing
+episode at `FAILED` with `retry_count=0` and no archives.
 
 ### Debug agent
 
-`tests/test_retry_integration.py::DebugAgent` reads
-`scenario[task_id][attempt_num]` from a per-test JSON file and:
+`DebugAgent` reads `scenarios[task_id]` indexed by attempt number. Behaviours:
+
 - `"succeed"` → returns `final_step` action
 - `"fail"` → raises `RuntimeError("scripted failure")`
-- `"hang"` → `time.sleep(step_timeout_s * 10)` (driver kills it)
+- `"hang"` → `time.sleep(hang_seconds)` — driver kills it via step-timeout
+- `"loop"` → returns a non-terminating action — drives runner toward `max_steps`
 
-The agent atomically increments a per-task attempt counter (fcntl-locked file in
-`tmp_dir`) so retries see consecutive attempt numbers across worker processes.
+Attempt counters are incremented atomically with `fcntl.flock` so retries see
+consecutive attempt numbers across Ray worker processes.
 
 ### Run config (tuned for fast tests)
 
@@ -392,42 +495,46 @@ exp = Experiment(..., max_retries=3)
 result = run_with_ray(
     exp,
     n_cpus=2,
-    step_timeout_s=2.0,
-    cancel_grace_s=1.0,
-    max_retry_rounds=3,
+    ray_poll_timeout=0.5,
+    step_timeout_s=1.5,
+    cancel_grace_s=0.5,
+    orphan_threshold_s=30.0,
 )
 ```
 
-Target wall-clock: 30–60 s including Ray startup. Mark with `@pytest.mark.slow`
-(or `integration`).
+Target wall-clock: 30–60 s including Ray startup. Marked `@pytest.mark.slow`.
 
 ### Coverage matrix
 
-| Code path | Covered by integration test |
+| Code path | Test |
 |---|---|
-| Pre-claim writes `RUNNING` for all 4 episodes before Ray submit | ✅ |
-| Worker writes `RUNNING` → `COMPLETED` / `FAILED` | ✅ |
-| Step-boundary heartbeat | ✅ (hang scenario can't fire without it) |
-| Driver poll reads `status.json`, force-cancels on stale heartbeat | ✅ |
-| Driver writes `CANCELLED` after force-kill, with `error_type="StepTimeout"` | ✅ |
-| Auto-retry loop (`max_retry_rounds`) | ✅ |
-| `retry_count` increment on pre-claim | ✅ |
-| `max_retries` cap respected | ✅ (Episode 2 stops at 3) |
-| Archive of old attempts (`.archived_<ts>/`) preserved | ✅ |
-| `error_type` / `error_message` populated end-to-end | ✅ |
-| `current_step` advances | ✅ |
-| `COMPLETED` never retried | ✅ (Episode 0) |
+| Pre-claim writes `QUEUED` for all episodes before Ray submit | `test_retry_machinery_end_to_end` |
+| Worker overwrites `QUEUED` → `RUNNING` in `_open_status` | `test_retry_machinery_end_to_end` |
+| Worker writes `RUNNING` → `COMPLETED` / `FAILED` | `test_retry_machinery_end_to_end` |
+| Step-boundary heartbeat | `test_retry_machinery_end_to_end` (hang can't fire without it) |
+| Driver re-reads status before writing `CANCELLED` (race guard) | `test_retry_machinery_end_to_end` |
+| Driver writes `CANCELLED` after force-kill, `error_type="StepTimeout"` | `test_retry_machinery_end_to_end` |
+| Auto-retry loop (`max_retry_rounds`) | `test_retry_machinery_end_to_end` |
+| `retry_count` increment on pre-claim | `test_retry_machinery_end_to_end` |
+| `max_retries` cap respected | `test_retry_machinery_end_to_end` (task_dead stops at 3) |
+| Archive of old attempts preserved | `test_retry_machinery_end_to_end` |
+| `error_type` / `error_message` populated end-to-end | `test_retry_machinery_end_to_end` |
+| `COMPLETED` never retried | `test_retry_machinery_end_to_end` (task_succeed) |
+| `MAX_STEPS_REACHED` not retriable; forced `evaluate()` reward | `test_max_steps_terminates_with_forced_eval` |
+| `max_retries=0` disables all retries | `test_max_retries_zero_disables_auto_retry` |
+| Stale `RUNNING` swept to `STALE` and retried | `test_mixed_state_recovery_via_ray` |
+| `COMPLETED` untouched on mixed-state resume | `test_mixed_state_recovery_via_ray` |
+| Sequential auto-retry + worker-side archive | `test_run_sequentially_auto_retries_flaky_episode` |
 
-### Focused unit tests for what the integration test can't reach
+### Unit tests (`tests/test_experiment.py`)
 
-- `tests/test_experiment.py::test_stale_sweep_marks_orphaned_running` — write a
-  `RUNNING` status with a stale heartbeat by hand, call the sweep, assert
-  `status == STALE` and the episode shows up in `retry_failed=True` selection.
-- `tests/test_experiment.py::test_resume_returns_missing_status_only` — episode
-  configs exist, no `status.json`, `resume=True` returns them; `retry_failed=True`
-  also returns them when paired with the missing-status branch.
-- `tests/test_storage.py::test_episode_status_atomic_write` — interrupted writes
-  via `.tmp` sibling never expose a partial `status.json`.
+- `test_stale_sweep_marks_orphaned_running` — stale heartbeat by hand; assert swept to `STALE`.
+- `test_queued_orphan_swept_to_stale` — old `QUEUED` entry swept to `STALE`.
+- `test_queued_fresh_not_swept` — fresh `QUEUED` left alone; not returned by `resume=True`.
+- `test_stale_sweep_keeps_fresh_running` — fresh `RUNNING` left alone.
+- `test_resume_returns_unstarted_and_failed_skipping_completed` — `resume=True` returns missing + `FAILED`, skips `COMPLETED`.
+- `test_resume_skips_max_steps_reached` — `MAX_STEPS_REACHED` excluded from `resume=True`.
+- `test_retry_respects_max_retries` — capped episode excluded; under-cap episode included.
 
 ### Out of scope for v1 tests
 
@@ -440,16 +547,18 @@ Target wall-clock: 30–60 s including Ray startup. Mark with `@pytest.mark.slow
 ## Resolved questions
 
 | # | Question | Decision |
-|---|---|---|
-| 1 | `Experiment.max_retries` default? | **3** (4 total attempts) |
-| 2 | `max_retry_rounds` default? | **3** |
-| 3 | Heartbeat mechanism? | Step-boundary write from worker's main thread |
-| 4 | `step_timeout_s` default? | **1800s (30 min)** |
-| 5 | `cancel_grace_s` default? | **120s (2 min)** |
-| 6 | `orphan_threshold_s` default? | **3600s (1 h)** |
-| 7 | Drop `episode_timeout`? | **Yes** |
-| 8 | Drop `list_tasks` (Ray dashboard) dependency? | **Yes** |
-| 9 | `CANCELLED` retried? | **Yes**, treated like `FAILED` |
-| 10 | Missing `status.json` retried by `retry_failed=True`? | **Yes** |
+| --- | --- | --- |
+| 1  | `Experiment.max_retries` default? | **3** (4 total attempts) |
+| 2  | `max_retry_rounds` default? | **3** |
+| 3  | Heartbeat mechanism? | Step-boundary write from worker's main thread |
+| 4  | `step_timeout_s` default? | **1800s (30 min)** |
+| 5  | `cancel_grace_s` default? | **120s (2 min)** |
+| 6  | `orphan_threshold_s` default? | **3600s (1 h)** |
+| 7  | Drop `episode_timeout`? | **Yes** |
+| 8  | Drop `list_tasks` (Ray dashboard) dependency? | **Yes** |
+| 9  | `CANCELLED` retried? | **Yes**, treated like `FAILED` |
+| 10 | Missing `status.json` retried by `resume=True`? | **Yes** |
 | 11 | Sequential-mode step-timeout enforcement? | **Out of scope for v1** |
 | 12 | Concurrent-driver hard lock? | **Out of scope for v1** (pre-claim narrows; document the residual race) |
+| 13 | Separate `QUEUED` status for pre-claim? | **Yes** — distinguishes "queued in Ray" from "worker running" |
+| 14 | `MAX_STEPS_REACHED` retriable? | **No** — agent exhausted its budget; a retry would just truncate again |

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -1,38 +1,45 @@
 # RFC: Episode Status File
 
-**Version:** 0.2 — updated after design review 2026-04-27
+**Version:** 0.3 — heartbeat & timeout consolidation, 2026-04-27
 
 ## Problem
 
-The current resume/retry logic in `experiment.py` determines whether an episode needs
-re-running by loading and scanning its full trajectory for `StepError` entries. This
-has three failure modes:
+Resume / retry logic in `experiment.py` decides what to re-run by deserialising every
+trajectory and scanning for `StepError`. This has four failure modes:
 
-**1. Silent crash — dead workers leave no terminal signal.**
-If a Ray worker is killed (OOM, `ray.cancel(force=True)`, machine failure), no terminal
-status is ever written. The trajectory may be partial or missing. The current code
-catches the load failure silently and drops the episode — it neither retries nor counts
-it as done.
+1. **Silent crash.** A Ray worker killed (OOM, `ray.cancel(force=True)`, machine
+   failure) writes no terminal status. The trajectory is partial or missing. The
+   current code catches the load failure silently and drops the episode — neither
+   retried nor counted as done.
 
-**2. False positive on recovered errors.**
-A `StepError` recorded mid-episode (a tool error that the harness caught and turned into
-an error observation, then continued) causes `_is_trajectory_successful` to return
-`False`, triggering a retry even though the episode completed normally.
+2. **False positive on recovered errors.** A `StepError` written mid-episode (an env
+   error the harness caught and continued past) flips `_is_trajectory_successful` to
+   `False`, triggering a needless retry of an episode that completed normally.
 
-**3. Status requires reading the payload.**
-To check whether an episode is done, the entire trajectory must be deserialized. At
-scale (thousands of episodes per experiment) this is expensive and fragile — a single
-corrupt step file breaks the check for that episode.
+3. **Status requires reading the payload.** Checking whether N episodes are done
+   means deserialising N trajectories. At benchmark scale this is slow, and a single
+   corrupt step file breaks the check for that episode.
 
-**4. Concurrent runner collision.**
-If two callers invoke `run_with_ray` on the same output directory simultaneously (e.g.,
-a stalled run and a resume attempt), both see the same unstarted episodes and submit
-them to Ray twice. There is no mechanism to detect or prevent this.
+4. **Concurrent runner collision.** Two `run_with_ray` invocations on the same
+   `output_dir` see the same unstarted episodes and both submit them to Ray. Nothing
+   in the system detects or prevents this.
 
 ## Proposed solution
 
-Write a small `status.json` file in each episode directory. Status is the ground truth
-for retry decisions. The trajectory is data; `status.json` is control.
+A small `status.json` per episode directory drives all retry decisions. The
+trajectory is data; `status.json` is control.
+
+The mechanism has three pieces:
+
+1. **`status.json` per episode**, with a step-boundary heartbeat written from the
+   worker's main thread.
+2. **Driver poll loop** reads `status.json` from the filesystem instead of querying
+   the Ray dashboard for elapsed time. Step-timeout is the only kill trigger.
+3. **STALE sweep** cleans up orphaned `RUNNING` entries from crashed drivers.
+
+> **Load-bearing assumption**: `output_dir` is on a filesystem visible to both the
+> driver and every Ray worker (NFS, shared object store, single host). This is
+> already required for trajectory writes; this RFC just relies on it more pervasively.
 
 ---
 
@@ -40,21 +47,124 @@ for retry decisions. The trajectory is data; `status.json` is control.
 
 | Status | Written by | Meaning |
 |---|---|---|
-| `RUNNING` | driver (pre-claim) then worker | Episode is queued or actively executing; skip during resume/retry |
-| `COMPLETED` | worker in `finally` | Loop ran to natural end (done or max_steps) |
-| `FAILED` | worker in `finally` | Unhandled exception propagated out of the run loop |
-| `CANCELLED` | `exp_runner` after `ray.cancel(force=True)` | Explicitly timed out by the harness |
-| `STALE` | STALE sweep | Worker was killed; heartbeat went cold; episode will never finish |
+| `RUNNING` | driver (pre-claim) → worker | Episode queued or actively executing |
+| `COMPLETED` | worker (`finally`) | Loop reached natural end (done or `max_steps`) |
+| `FAILED` | worker (`finally`) | Unhandled exception propagated out of `_run_loop` |
+| `CANCELLED` | driver after `ray.cancel(force=True)` | Step heartbeat went stale → driver killed it |
+| `STALE` | STALE sweep (driver) | Worker died without writing terminal status |
 
-**Core invariant:** `RUNNING` with a fresh heartbeat = skip (episode is alive or queued).
-`RUNNING` with a stale heartbeat = dead worker. `COMPLETED` = done, never retry.
-Everything else (`FAILED`, `STALE`, `CANCELLED`) = eligible for retry if
-`retry_count < max_retries`.
+**Retry-eligibility ground truth:**
+- `RUNNING` with fresh heartbeat → **skip** (alive or queued).
+- `RUNNING` with stale heartbeat → **retry** (worker is dead, will be swept to `STALE`).
+- `COMPLETED` → **never retry** (`reward == 0` is a legitimate agent failure, not a
+  technical one).
+- `FAILED` / `STALE` / `CANCELLED` / missing → **retry**, gated by `retry_count <
+  max_retries`.
 
-`STALE` vs `FAILED`: `FAILED` means the worker lived long enough to catch an exception.
-`STALE` means it was killed silently. Both are retried, but the distinction aids
-diagnosis: many `STALE` = infrastructure problem (OOM, cluster failure); many `FAILED`
-= application bug.
+---
+
+### Step-boundary heartbeat
+
+Inside `Episode._run_loop`, the worker writes `last_heartbeat_at` and `current_step`
+to `status.json` at:
+
+1. The very top of `_run_loop` (covers stuck `setup_fn` — env reset, container boot).
+2. The start of each turn, before `agent.step()` and before `step_fn()`.
+
+That is the entire mechanism. **No background thread. No child process. No asyncio
+interaction.** Just a file write in the worker's main thread at natural sync points.
+
+**Why this works where threads and subprocesses didn't:**
+- Ray workers run inside an asyncio event loop. A daemon thread doing I/O while the
+  main thread is in an async call deadlocks or gets silently dropped on shutdown.
+- Ray workers are daemon processes; Python disallows non-daemon children of daemons.
+
+The step-boundary write avoids both because it doesn't run *concurrently* with the
+episode — it runs *between* steps, on the same thread that's executing the episode.
+It's not "obvious in hindsight"; it's a different topology.
+
+---
+
+### Pre-claim: race protection on submission
+
+Before submitting episodes to Ray, the driver writes `RUNNING` for every episode it
+intends to launch:
+
+```python
+storage.write_episode_status(traj_id, EpisodeStatus(
+    status="RUNNING",
+    started_at=now,
+    last_heartbeat_at=None,    # worker hasn't started; queued in Ray
+    retry_count=incremented_from_previous,
+    ...,
+))
+```
+
+A concurrent runner that opens the same `output_dir` then sees `RUNNING` and skips:
+- `resume=True` skips because it only returns missing-`status.json`.
+- `retry_failed=True` skips because `RUNNING` ∉ `{FAILED, STALE, CANCELLED}` and the
+  heartbeat-staleness check screens out the rest.
+
+When the worker actually picks up the episode, `_run_loop` overwrites the pre-claim
+with `started_at = now()` and starts writing heartbeats.
+
+> **Limitation, accepted for v1.** Two drivers starting within the same ~second can
+> both call `get_episodes_to_run()` before either pre-claims, then race-write
+> overlapping pre-claims. The harness can't fully prevent this without an
+> experiment-level lock. Document and revisit if it becomes a real problem.
+
+---
+
+### `last_heartbeat_at = None` is two semantics in one absent field
+
+The field is `None` between pre-claim (driver) and the first heartbeat (worker), i.e.
+while the episode is **queued in Ray** but not yet picked up. It's also `None` if the
+worker died after pre-claim but before reaching `_run_loop` (rare).
+
+Two distinct policies follow:
+
+| Caller | Behaviour for `last_heartbeat_at = None` |
+|---|---|
+| Driver poll (mid-run) | **Skip** — assume it's queued, don't kill |
+| STALE sweep (start of next run, or after `ray.shutdown`) | Mark `STALE` if `now − started_at > orphan_threshold_s` (default 1 h — generous Ray-queue allowance) |
+
+This pins down a behaviour that would otherwise live in folklore.
+
+---
+
+### Driver kill via filesystem read, not Ray dashboard
+
+Replace `_get_running_elapsed_s` (which calls `ray.util.state.api.list_tasks` on the
+Ray dashboard) with a filesystem read:
+
+```python
+for ref in episodes_in_progress:
+    traj_id = ref_to_traj_id[ref]
+    status = storage.read_episode_status(traj_id)
+    if status is None or status.last_heartbeat_at is None:
+        continue   # not started yet — let Ray handle queueing
+
+    age = now - status.last_heartbeat_at
+    if age > step_timeout_s + cancel_grace_s:
+        ray.cancel(ref, force=True)
+        status.status = "CANCELLED"
+        status.ended_at = now
+        status.error_type = "StepTimeout"
+        status.error_message = f"Step {status.current_step} exceeded {step_timeout_s:.0f}s"
+        storage.write_episode_status(traj_id, status)
+        episodes_in_progress.remove(ref)
+```
+
+Wins:
+- **No Ray-dashboard dependency.** `from ray.util.state.api import list_tasks`
+  deleted. Past us has been bitten by this API drifting between Ray versions.
+- **Per-step granularity.** Detects "stuck on step 14 for 30 min" instead of waiting
+  for total elapsed to exceed an episode-wide cap.
+- **Always writes a terminal status.** No more zombie `RUNNING` after a force kill.
+
+`episode_timeout` is **removed**. Total-time is bounded by `max_steps × step_timeout_s`
+(with `max_steps=50`, `step_timeout=30 min` → 25 h ceiling — adequate; nothing in the
+repo runs near it).
 
 ---
 
@@ -63,192 +173,206 @@ diagnosis: many `STALE` = infrastructure problem (OOM, cluster failure); many `F
 ```json
 {
   "status": "FAILED",
-  "task_id": "workarena.servicenow.create-incident",
+  "task_id": "workarena.create-incident",
   "episode_id": 3,
   "started_at": 1745000000.0,
   "ended_at": 1745000042.0,
   "last_heartbeat_at": 1745000040.0,
+  "current_step": 14,
   "reward": null,
   "had_step_errors": true,
   "error_type": "ConnectionError",
-  "error_message": "Environment container failed to start on port 8080",
+  "error_message": "Container failed to bind on port 8080",
   "retry_count": 1
 }
 ```
 
-**Fields:**
-- `status` — one of the five values above
-- `started_at` — set by the driver on pre-claim (see below); overwritten by worker at actual start
-- `ended_at` — wall-clock timestamp; `None` until a terminal status is written
-- `last_heartbeat_at` — updated by the worker's background thread every 30 s while `RUNNING`; `None` if the worker never started
-- `reward` — final reward; `None` until `COMPLETED`
-- `had_step_errors` — `True` if any step recorded a `StepError`; informational only, does not affect retry
-- `error_type` / `error_message` — exception class name and message for the failure; `None` on success. Enables fast diagnosis without opening log files.
-- `retry_count` — how many times this specific episode has been retried; capped at `max_retries`
+| Field | Type | Set by | Notes |
+|---|---|---|---|
+| `status` | enum | both | Lifecycle state |
+| `task_id` | str | both | For grouping / listing |
+| `episode_id` | int | both | For grouping / listing |
+| `started_at` | float | driver (pre-claim), then worker (actual start) | Wall clock |
+| `ended_at` | float\|None | worker / driver | Wall clock at terminal status |
+| `last_heartbeat_at` | float\|None | worker | `None` until first turn begins |
+| `current_step` | int | worker | `0` during `setup_fn`; `1..` once turn loop starts |
+| `reward` | float\|None | worker | `None` until `COMPLETED` |
+| `had_step_errors` | bool | worker | Informational; does not affect retry |
+| `error_type` | str\|None | worker / driver | Exception class for failures |
+| `error_message` | str\|None | worker / driver | Short message — first-line diagnosis |
+| `retry_count` | int | driver | See semantics below |
+
+### `retry_count` semantics
+
+- `retry_count = 0` → original attempt.
+- `retry_count = N` → the N-th retry.
+- Episode is retried iff `retry_count < max_retries`.
+- `max_retries = 3` ⇒ attempts at `retry_count` 0, 1, 2, 3 ⇒ **4 total attempts**.
+
+The driver computes the new value during pre-claim: it reads the existing
+`status.json` (if any), increments `retry_count` by one if a previous attempt exists,
+then writes `RUNNING`.
 
 ---
 
-### Pre-claim: preventing concurrent runner collision
+### `Experiment.get_episodes_to_run()` semantics
 
-Before submitting episodes to Ray, the driver writes `RUNNING` for every episode it
-is about to launch. This "pre-claim" step converts all targeted episodes from
-"unstarted" (no `status.json`) to `RUNNING` before any other process can see them.
+A new field:
 
-A second runner calling `get_episodes_to_run(resume=True)` or
-`get_episodes_to_run(retry_failed=True)` will see `RUNNING` episodes with a fresh
-`started_at` and skip them — no collision.
-
-When the Ray worker actually picks up the episode, `_run_loop` overwrites the pre-claim
-with a new `RUNNING` entry (same `retry_count`, updated `started_at`) and starts the
-heartbeat thread.
-
-Pre-claim only applies to `run_with_ray`. The sequential runner (`run_sequentially`)
-has no concurrency to protect against; the worker writes `RUNNING` directly.
-
----
-
-### Heartbeat: distinguishing alive workers from dead ones
-
-A background thread in the worker's `_run_loop` writes `last_heartbeat_at` to
-`status.json` every **30 seconds** while the episode is executing.
-
-**STALE sweep** is the complementary mechanism on the driver side. It scans all episode
-directories for `RUNNING` entries with a stale `last_heartbeat_at` and rewrites them
-as `STALE`. It is called:
-
-1. **Before every `get_episodes_to_run()` call with `resume=True` or `retry_failed=True`** — cleans up orphaned `RUNNING` from a previous run that crashed without calling `ray.shutdown()`.
-2. **After `ray.shutdown()`** — handles the normal case where workers are killed at experiment completion.
-
-Staleness threshold: `now - (last_heartbeat_at or started_at) > 2 * HEARTBEAT_INTERVAL`
-(default: `2 * 30s = 60s`). If `last_heartbeat_at` is `None` (worker never started),
-the threshold is applied to `started_at` instead. Because the driver pre-claims with
-`started_at = now`, a freshly claimed but not-yet-started episode is always within the
-threshold, so a concurrent STALE sweep will never incorrectly evict it.
-
-Note: episode timeout (`episode_timeout` in `run_with_ray`, default 3600 s) handles
-hung episodes. The heartbeat mechanism handles OOM / external kills that bypass the
-timeout path.
-
----
-
-### Retry logic
-
-An episode is **eligible for retry** if `retry_count < max_retries` (default: **3**) and any of:
-1. `status.json` is missing (worker died before the driver could pre-claim, or before the worker could write `RUNNING`)
-2. `status == STALE`
-3. `status == FAILED`
-4. `status == CANCELLED`
-
-An episode is **skipped** (treated as currently executing) if:
-- `status == RUNNING` with `(last_heartbeat_at or started_at)` within the staleness threshold
-
-An episode is **done** (never retry) if:
-- `status == COMPLETED`
-
-`COMPLETED` with `reward == 0` is a legitimate agent failure, not a technical failure.
-Retrying it wastes quota.
-
----
-
-### `Experiment.get_episodes_to_run()` — new flag semantics
+```python
+class Experiment(TypedBaseModel):
+    ...
+    max_retries: int = 3
+```
 
 | `resume` | `retry_failed` | Episodes returned |
 |---|---|---|
-| False | False | All episodes from scratch |
-| True | False | Episodes with missing `status.json` (never started) |
-| False | True | Episodes with `status IN (FAILED, STALE, CANCELLED)` **or** missing `status.json`, with `retry_count < max_retries` |
-| True | True | Union: all missing **+** all retriable failures |
+| F | F | All episodes from scratch |
+| T | F | Missing `status.json` (never started) |
+| F | T | `status IN (FAILED, STALE, CANCELLED)` **or** missing, with `retry_count < max_retries` |
+| T | T | Union of the above two |
 
-A new field on `Experiment`:
-```python
-max_retries: int = 3
-```
+`RUNNING` (with fresh heartbeat) is **never** included — by either flag.
 
-Replaces the trajectory-scan path:
-- `_is_trajectory_successful` → **deleted**
-- `_load_successful_trajectory_ids` → **deleted**
-- `_load_started_trajectory_ids` → **replaced** by `_read_episode_status_map`
-- `_find_episodes_to_relaunch` → **absorbed** into `get_episodes_to_run`
+The deletion list in `experiment.py`:
+- `_is_trajectory_successful` — superseded by COMPLETED status.
+- `_load_successful_trajectory_ids` — full trajectory scans no longer needed.
+- `_load_started_trajectory_ids` — replaced by `_read_episode_status_map`.
+- `_find_episodes_to_relaunch` — folded into `get_episodes_to_run`.
 
 ---
 
-### Automatic retry loop in `exp_runner`
+### STALE sweep
 
-Both `run_with_ray` and `run_sequentially` gain a `max_retry_rounds` parameter
-(default: **3**). After each round, the runner checks for retriable episodes. If any
-exist and `rounds_done < max_retry_rounds`, it runs them with `retry_failed=True`.
-The loop stops when no retriable episodes remain or the round budget is exhausted.
+Marks `RUNNING` → `STALE` for episodes that meet:
+
+- `last_heartbeat_at` set, and `now − last_heartbeat_at > step_timeout_s + cancel_grace_s`, **or**
+- `last_heartbeat_at == None`, and `now − started_at > orphan_threshold_s` (default 1 h).
+
+Run at:
+- The **start** of `get_episodes_to_run()` whenever `resume=True` or `retry_failed=True`
+  — cleans up after a previous driver that crashed without `ray.shutdown()`.
+- **After** `ray.shutdown()` in `_run_with_ray_impl` — handles the normal end-of-run
+  case where workers are killed when the cluster shuts down.
+
+---
+
+### Auto-retry loop
+
+`run_with_ray` and `run_sequentially` gain `max_retry_rounds: int = 3`. After each
+round, the runner queries for retriable episodes; if any exist and we haven't hit
+the round budget, it re-runs them with `retry_failed=True` on the same `output_dir`.
 
 ```python
 def run_with_ray(
     exp: Experiment,
+    *,
+    n_cpus: int = 4,
+    ray_poll_timeout: float = 2.0,
+    step_timeout_s: float = 1800.0,        # 30 min — kill if a single step hangs
+    cancel_grace_s: float = 120.0,         # buffer over step_timeout
+    orphan_threshold_s: float = 3600.0,    # 1 h — for never-started pre-claims
+    max_retry_rounds: int = 3,             # post-run retry sweeps
     ...,
-    max_retry_rounds: int = 3,
 ) -> ExpResult:
 ```
 
-The final `ExpResult` aggregates trajectories and failures across all rounds.
+Existing recipes that call `run_with_ray(exp)` get auto-retry out of the box. Pass
+`max_retry_rounds=0` to opt out.
 
-Existing recipes that call `run_with_ray(exp)` get automatic retry out of the box
-(`max_retry_rounds=3`). Pass `max_retry_rounds=0` to opt out.
+The final `ExpResult` aggregates trajectories and failures across all rounds.
 
 ---
 
-### Storage changes
+### Sequential mode
 
-Two new methods on `Storage` Protocol and `FileStorage`:
+`run_sequentially` shares `max_retry_rounds`. It does **not** enforce
+`step_timeout_s` (no driver poll loop, no external killer for the in-process
+worker). Heartbeats are still written for status visibility; pre-claim is skipped
+(no concurrency to defend against). A hung step in sequential mode requires a
+human Ctrl-C — acceptable, since sequential is the debug path. A future RFC can
+add a `signal.alarm`-based per-step timeout if it becomes needed.
+
+---
+
+### Storage Protocol additions
 
 ```python
-def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
-    # Atomic: write to .tmp then os.replace()
-
-def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
-    # Returns None if status.json does not exist
+class Storage(Protocol):
+    ...
+    def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None: ...
+    def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
 ```
 
-`EpisodeStatus` is a plain Python `@dataclass` (not Pydantic) defined in a new
-`cube_harness/episode_status.py` module. Both `episode.py` and `storage.py` import
-from it; this avoids the circular-import problem that would arise if it lived in
-`episode.py`.
+`FileStorage` implements them with atomic write (`.tmp` sibling + `os.replace()`).
+Status lives at `episodes/{trajectory_id}/status.json`.
+
+---
+
+### `EpisodeStatus` lives in a new module
+
+A plain `@dataclass` in `cube_harness/episode_status.py`. Imported by both
+`episode.py` and `storage.py`. Avoids the circular import that would arise from
+defining it in `episode.py`.
 
 ---
 
 ### Error logging
 
-The full stack trace is always written to the episode's log file (existing behaviour
-via `redirect_output_to_log`). `error_type` and `error_message` in `status.json`
-provide the first line of diagnosis without opening logs. No other changes to logging.
+Stack traces continue to land in the per-episode log file via the existing
+`redirect_output_to_log` plumbing. `error_type` and `error_message` in
+`status.json` are the **first-line** diagnosis — surfaced in summaries / dashboards
+without forcing a log open.
+
+For driver-written `CANCELLED`, the driver populates `error_type = "StepTimeout"`
+and a message like `"Step 14 exceeded 1800s"`.
 
 ---
 
 ## Alternatives considered
 
-**Ray dashboard query.** Rejected: couples status to Ray infrastructure, broken for
-sequential runs.
+**Background-thread heartbeat.** Rejected: Ray-worker / asyncio interactions made
+this unstable in the past — see the "Why this works" section.
 
-**PID file.** Rejected: PIDs are recycled; unreliable across multi-node clusters.
+**Child-process heartbeat.** Rejected: Ray workers are daemon processes; Python
+forbids non-daemon children of daemons.
 
-**Trajectory existence as sentinel.** Current approach. Rejected: requires full
-deserialization; silently drops crashed episodes.
+**Ray-dashboard query (current behaviour).** Rejected: requires the dashboard to be
+reachable (sometimes it isn't), couples retry to Ray-state-API versioning.
 
-**Experiment-level lock file.** Would prevent concurrent runners at the experiment
-level but gives no per-episode visibility. Replaced by the pre-claim mechanism, which
-is more surgical: episodes claimed by an active run are individually locked.
+**PID file.** Rejected: PIDs recycle; unreliable on multi-node clusters.
+
+**Trajectory existence as sentinel (current behaviour).** Rejected: requires full
+deserialisation; silently drops crashed episodes.
+
+**Experiment-level lock file.** Discussed for v1, deferred. Pre-claim narrows the
+race window; a lock would close it. Add when needed.
+
+---
 
 ## Scope
 
-Touches: `episode.py`, `episode_status.py` (new), `experiment.py`, `exp_runner.py`,
-`storage.py` — and their specs.
+**Touches:** `episode.py`, `episode_status.py` (new), `experiment.py`, `exp_runner.py`,
+`storage.py`, plus their specs and tests.
 
-Does **not** change: trajectory format, `Trajectory` model, existing step files,
-XRay viewer.
+**Does not change:** trajectory format, `Trajectory` model, existing step files, XRay
+viewer, sequential-mode debug experience.
 
-## Open questions (resolved)
+---
+
+## Resolved questions
 
 | # | Question | Decision |
 |---|---|---|
-| 1 | `max_retries` default? | **3** |
+| 1 | `Experiment.max_retries` default? | **3** (4 total attempts) |
 | 2 | `max_retry_rounds` default? | **3** |
-| 3 | Heartbeat interval / staleness threshold? | **30 s / 60 s** |
-| 4 | Should `CANCELLED` be retried? | **Yes** — treated same as `FAILED` |
-| 5 | Should missing `status.json` be retried by `retry_failed=True`? | **Yes** |
+| 3 | Heartbeat mechanism? | Step-boundary write from worker's main thread |
+| 4 | `step_timeout_s` default? | **1800s (30 min)** |
+| 5 | `cancel_grace_s` default? | **120s (2 min)** |
+| 6 | `orphan_threshold_s` default? | **3600s (1 h)** |
+| 7 | Drop `episode_timeout`? | **Yes** |
+| 8 | Drop `list_tasks` (Ray dashboard) dependency? | **Yes** |
+| 9 | `CANCELLED` retried? | **Yes**, treated like `FAILED` |
+| 10 | Missing `status.json` retried by `retry_failed=True`? | **Yes** |
+| 11 | Sequential-mode step-timeout enforcement? | **Out of scope for v1** |
+| 12 | Concurrent-driver hard lock? | **Out of scope for v1** (pre-claim narrows; document the residual race) |

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -111,10 +111,10 @@ stateDiagram-v2
 | `COMPLETED` | `[terminal]` | — | Always — legitimate success, not retriable |
 | `MAX_STEPS_REACHED` | `[terminal]` | — | Always — agent exhausted step budget, not retriable |
 
-> ¹ **Known gap:** sequential mode currently skips `_pre_claim`, so episodes waiting
-> their turn have no `status.json`. A crash mid-run makes them indistinguishable from
-> episodes that were never submitted. The fix is to pre-claim all episodes upfront in
-> `_run_sequentially_impl` before the loop starts — tracked as a follow-up.
+> ¹ Sequential mode now calls `_pre_claim` for each episode before it runs (same
+> semantics as Ray mode). Episodes that will not run in the current `debug_limit` slice
+> are not pre-claimed, so they remain invisible to the retry loop and are picked up
+> cleanly on a future `resume=True` run.
 
 ---
 
@@ -371,11 +371,12 @@ The final `ExpResult` aggregates trajectories and failures across all rounds.
 
 `run_sequentially` shares `max_retry_rounds` and the same retry loop. It does **not**
 enforce `step_timeout_s` (no driver poll loop, no external killer for the in-process
-worker). Heartbeats are still written for status visibility. Pre-claim (`_pre_claim`)
-is skipped — there's no concurrency to defend against — but `Episode._open_status`
-still archives any prior terminal directory and writes `RUNNING` before the loop
-starts. A hung step in sequential mode requires a human Ctrl-C — acceptable, since
-sequential is the debug path.
+worker). Heartbeats are still written for status visibility. `_pre_claim` is called
+for each episode immediately before it runs, writing `QUEUED` and archiving any prior
+terminal directory. Episodes beyond `debug_limit` are not pre-claimed, so they remain
+cleanly unsubmitted and are eligible for `resume=True` without waiting for
+`orphan_threshold_s`. A hung step in sequential mode requires a human Ctrl-C —
+acceptable, since sequential is the debug path.
 
 ---
 
@@ -386,7 +387,12 @@ class Storage(Protocol):
     ...
     def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None: ...
     def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
+    def archive_episode(self, trajectory_id: str) -> None: ...
 ```
+
+`archive_episode` renames the episode directory to `<id>.archived_<ts>/`, preserving
+per-attempt history. Callers (including `_pre_claim`) use the Protocol method rather
+than reaching into `FileStorage`'s private internals.
 
 `FileStorage` also adds `list_episode_statuses() -> dict[str, EpisodeStatus]`, used
 by the retry loop and sweep. Atomic write is via a `.tmp` sibling + `os.replace()`.
@@ -509,6 +515,8 @@ Target wall-clock: 30–60 s including Ray startup. Marked `@pytest.mark.slow`.
 | Code path | Test |
 |---|---|
 | Pre-claim writes `QUEUED` for all episodes before Ray submit | `test_retry_machinery_end_to_end` |
+| Sequential pre-claim writes `QUEUED` only for episodes that will run | `test_sequential_pre_claims_only_episodes_that_will_run` |
+| `debug_limit` orphans do not block `resume=True` | `test_debug_limit_orphans_do_not_block_resume` |
 | Worker overwrites `QUEUED` → `RUNNING` in `_open_status` | `test_retry_machinery_end_to_end` |
 | Worker writes `RUNNING` → `COMPLETED` / `FAILED` | `test_retry_machinery_end_to_end` |
 | Step-boundary heartbeat | `test_retry_machinery_end_to_end` (hang can't fire without it) |

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -117,18 +117,66 @@ before the trajectory object exists).
 
 Atomic write (write-then-rename) ensures a reader never sees a partial file.
 
-### Changes to `Experiment`
+### Migration: `Experiment.get_episodes_to_run()`
 
-`_is_trajectory_successful` and `_load_successful_trajectory_ids` are replaced by:
+Current code path (to be replaced):
+
+```
+_load_started_trajectory_ids()        # scans episodes/ dir for existing trajectories
+_load_successful_trajectory_ids()     # loads every trajectory and scans steps for StepError
+_find_episodes_to_relaunch()          # filters config files by trajectory ID sets
+```
+
+Replacement:
+
+```
+_load_episode_statuses()              # reads status.json from each episode dir — one small file each
+get_episodes_to_run()                 # filters directly on status: retry if FAILED/STALE/CANCELLED/missing
+```
+
+`_is_trajectory_successful` and `_load_successful_trajectory_ids` are deleted.
+`_load_started_trajectory_ids` is replaced by `_load_episode_statuses`.
+`_find_episodes_to_relaunch` logic is absorbed into `get_episodes_to_run`.
+
+The `resume` / `retry_failed` flags on `Experiment` map to status as follows:
+
+| Flag | Episodes returned |
+|---|---|
+| neither | All episodes created from scratch |
+| `resume=True` | Episodes with no `status.json` (never started) |
+| `retry_failed=True` | Episodes with `status IN (FAILED, STALE, CANCELLED)` and `retry_count < max_retries` |
+| both | Union of the above |
+
+`allow_overwrite = True` is set on retried episodes, same as today.
+
+### Automatic retry loop in `exp_runner`
+
+Today the caller must explicitly set `retry_failed=True` and re-run to pick up
+failures. The launcher should support an automatic retry loop so a single invocation
+can recover from transient failures without human intervention:
 
 ```python
-def _load_completed_trajectory_ids(self, storage: FileStorage) -> set[str]:
-    # Reads only status.json per episode directory — no trajectory deserialization
+def run_with_ray(
+    exp: Experiment,
+    ...
+    max_retry_rounds: int = 1,   # NEW: how many post-run retry sweeps to attempt
+) -> ExpResult:
 ```
+
+After the main Ray run completes, the runner checks for `FAILED`/`STALE`/`CANCELLED`
+episodes with `retry_count < max_retries`. If any exist and `retry_rounds < max_retry_rounds`,
+it marks the experiment `retry_failed=True` and runs again — reusing the same output
+directory. This loop repeats until no retriable episodes remain or `max_retry_rounds`
+is exhausted. The final `ExpResult` aggregates all rounds.
+
+`run_sequentially` gets the same `max_retry_rounds` parameter for consistency.
 
 ### Changes to `exp_runner`
 
-After `ray.cancel(force=True)`, write `status == CANCELLED` for that episode.
+After `ray.cancel(force=True)`, write `status=CANCELLED` for that episode.
+
+After `ray.shutdown()`, sweep all episode directories: any `RUNNING` episode with a
+stale heartbeat is written as `STALE`.
 
 ## Alternatives considered
 

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -1,204 +1,254 @@
 # RFC: Episode Status File
 
+**Version:** 0.2 — updated after design review 2026-04-27
+
 ## Problem
 
 The current resume/retry logic in `experiment.py` determines whether an episode needs
 re-running by loading and scanning its full trajectory for `StepError` entries. This
 has three failure modes:
 
-**1. Stale RUNNING with no heartbeat.**
+**1. Silent crash — dead workers leave no terminal signal.**
 If a Ray worker is killed (OOM, `ray.cancel(force=True)`, machine failure), no terminal
 status is ever written. The trajectory may be partial or missing. The current code
 catches the load failure silently and drops the episode — it neither retries nor counts
 it as done.
 
 **2. False positive on recovered errors.**
-A `StepError` recorded mid-episode (e.g. a tool error that the harness caught and
-turned into an error observation, then continued) causes `_is_trajectory_successful`
-to return `False`, triggering a retry even though the episode completed normally.
+A `StepError` recorded mid-episode (a tool error that the harness caught and turned into
+an error observation, then continued) causes `_is_trajectory_successful` to return
+`False`, triggering a retry even though the episode completed normally.
 
 **3. Status requires reading the payload.**
-To check whether an episode is done, the entire trajectory must be deserialized.
-At scale (thousands of episodes per experiment) this is expensive and fragile — a
-single corrupt step file breaks the check for that episode.
+To check whether an episode is done, the entire trajectory must be deserialized. At
+scale (thousands of episodes per experiment) this is expensive and fragile — a single
+corrupt step file breaks the check for that episode.
+
+**4. Concurrent runner collision.**
+If two callers invoke `run_with_ray` on the same output directory simultaneously (e.g.,
+a stalled run and a resume attempt), both see the same unstarted episodes and submit
+them to Ray twice. There is no mechanism to detect or prevent this.
 
 ## Proposed solution
 
 Write a small `status.json` file in each episode directory. Status is the ground truth
 for retry decisions. The trajectory is data; `status.json` is control.
 
+---
+
 ### Episode statuses
 
 | Status | Written by | Meaning |
 |---|---|---|
-| `RUNNING` | `episode._run_loop` at start | Episode has started; worker is alive |
-| `COMPLETED` | `episode._run_loop` in finally | Loop ran to natural end (done or max_steps); reward is irrelevant |
-| `FAILED` | `episode._run_loop` in finally | Unhandled exception propagated out of the run loop |
+| `RUNNING` | driver (pre-claim) then worker | Episode is queued or actively executing; skip during resume/retry |
+| `COMPLETED` | worker in `finally` | Loop ran to natural end (done or max_steps) |
+| `FAILED` | worker in `finally` | Unhandled exception propagated out of the run loop |
 | `CANCELLED` | `exp_runner` after `ray.cancel(force=True)` | Explicitly timed out by the harness |
-| `STALE` | `exp_runner` after `ray.shutdown()` | Worker was killed externally and will never write a terminal status |
+| `STALE` | STALE sweep | Worker was killed; heartbeat went cold; episode will never finish |
 
-**Core invariant:** `RUNNING` with a fresh heartbeat means the episode is actively
-executing — do not retry. `RUNNING` with a stale heartbeat means the worker is dead
-and the episode will never finish. The exp_runner driver (which outlives all workers)
-sweeps for stale `RUNNING` episodes after `ray.shutdown()` and writes `STALE`, making
-them eligible for retry on the next run.
+**Core invariant:** `RUNNING` with a fresh heartbeat = skip (episode is alive or queued).
+`RUNNING` with a stale heartbeat = dead worker. `COMPLETED` = done, never retry.
+Everything else (`FAILED`, `STALE`, `CANCELLED`) = eligible for retry if
+`retry_count < max_retries`.
 
-`STALE` vs `FAILED`: `FAILED` means the worker lived long enough to catch an exception
-and write terminal status. `STALE` means it was killed before that could happen. Both
-are retried, but the distinction helps with diagnosis: many `STALE` = infrastructure
-problem (OOM, cluster failure); many `FAILED` = application bug.
+`STALE` vs `FAILED`: `FAILED` means the worker lived long enough to catch an exception.
+`STALE` means it was killed silently. Both are retried, but the distinction aids
+diagnosis: many `STALE` = infrastructure problem (OOM, cluster failure); many `FAILED`
+= application bug.
+
+---
 
 ### `status.json` schema
 
 ```json
 {
-  "status": "COMPLETED",
+  "status": "FAILED",
   "task_id": "workarena.servicenow.create-incident",
   "episode_id": 3,
   "started_at": 1745000000.0,
-  "ended_at": 1745000120.0,
-  "last_heartbeat_at": 1745000118.0,
-  "reward": 1.0,
+  "ended_at": 1745000042.0,
+  "last_heartbeat_at": 1745000040.0,
+  "reward": null,
   "had_step_errors": true,
-  "retry_count": 0
+  "error_type": "ConnectionError",
+  "error_message": "Environment container failed to start on port 8080",
+  "retry_count": 1
 }
 ```
 
-Fields:
-- `status` — one of the four values above
-- `started_at` / `ended_at` — wall-clock timestamps (None if not reached)
-- `last_heartbeat_at` — updated by a background thread every N seconds while RUNNING
-- `reward` — final reward (None until COMPLETED)
-- `had_step_errors` — True if any step recorded a StepError; informational only, does not affect retry
-- `retry_count` — how many times this episode has been retried; capped at `max_retries` to prevent infinite loops
+**Fields:**
+- `status` — one of the five values above
+- `started_at` — set by the driver on pre-claim (see below); overwritten by worker at actual start
+- `ended_at` — wall-clock timestamp; `None` until a terminal status is written
+- `last_heartbeat_at` — updated by the worker's background thread every 30 s while `RUNNING`; `None` if the worker never started
+- `reward` — final reward; `None` until `COMPLETED`
+- `had_step_errors` — `True` if any step recorded a `StepError`; informational only, does not affect retry
+- `error_type` / `error_message` — exception class name and message for the failure; `None` on success. Enables fast diagnosis without opening log files.
+- `retry_count` — how many times this specific episode has been retried; capped at `max_retries`
 
-### Heartbeat
+---
 
-A background thread in `_run_loop` writes `last_heartbeat_at` to `status.json` every
-30 seconds while the episode is running. After `ray.shutdown()`, the exp_runner driver
-sweeps all episode directories and for any episode still in `RUNNING` state:
+### Pre-claim: preventing concurrent runner collision
 
-- `now - last_heartbeat_at < threshold` (e.g. 2 minutes) → truly still running (sequential mode or overlap window) — leave as `RUNNING`
-- `last_heartbeat_at` is stale or missing → worker is dead, episode will never finish → write `STALE`
+Before submitting episodes to Ray, the driver writes `RUNNING` for every episode it
+is about to launch. This "pre-claim" step converts all targeted episodes from
+"unstarted" (no `status.json`) to `RUNNING` before any other process can see them.
 
-This works for both local (sequential) and distributed (Ray) runs without requiring
-access to the Ray dashboard or any external state.
+A second runner calling `get_episodes_to_run(resume=True)` or
+`get_episodes_to_run(retry_failed=True)` will see `RUNNING` episodes with a fresh
+`started_at` and skip them — no collision.
+
+When the Ray worker actually picks up the episode, `_run_loop` overwrites the pre-claim
+with a new `RUNNING` entry (same `retry_count`, updated `started_at`) and starts the
+heartbeat thread.
+
+Pre-claim only applies to `run_with_ray`. The sequential runner (`run_sequentially`)
+has no concurrency to protect against; the worker writes `RUNNING` directly.
+
+---
+
+### Heartbeat: distinguishing alive workers from dead ones
+
+A background thread in the worker's `_run_loop` writes `last_heartbeat_at` to
+`status.json` every **30 seconds** while the episode is executing.
+
+**STALE sweep** is the complementary mechanism on the driver side. It scans all episode
+directories for `RUNNING` entries with a stale `last_heartbeat_at` and rewrites them
+as `STALE`. It is called:
+
+1. **Before every `get_episodes_to_run()` call with `resume=True` or `retry_failed=True`** — cleans up orphaned `RUNNING` from a previous run that crashed without calling `ray.shutdown()`.
+2. **After `ray.shutdown()`** — handles the normal case where workers are killed at experiment completion.
+
+Staleness threshold: `now - (last_heartbeat_at or started_at) > 2 * HEARTBEAT_INTERVAL`
+(default: `2 * 30s = 60s`). If `last_heartbeat_at` is `None` (worker never started),
+the threshold is applied to `started_at` instead. Because the driver pre-claims with
+`started_at = now`, a freshly claimed but not-yet-started episode is always within the
+threshold, so a concurrent STALE sweep will never incorrectly evict it.
+
+Note: episode timeout (`episode_timeout` in `run_with_ray`, default 3600 s) handles
+hung episodes. The heartbeat mechanism handles OOM / external kills that bypass the
+timeout path.
+
+---
 
 ### Retry logic
 
-An episode is eligible for retry if `retry_count < max_retries` (proposed default: 3) and:
-1. `status.json` does not exist (worker died before writing `RUNNING`)
-2. `status == STALE` (driver confirmed the worker is dead)
-3. `status == FAILED` or `status == CANCELLED`
+An episode is **eligible for retry** if `retry_count < max_retries` (default: **3**) and any of:
+1. `status.json` is missing (worker died before the driver could pre-claim, or before the worker could write `RUNNING`)
+2. `status == STALE`
+3. `status == FAILED`
+4. `status == CANCELLED`
 
-An episode is **never** retried if `status == RUNNING` with a fresh heartbeat —
-it is currently executing.
+An episode is **skipped** (treated as currently executing) if:
+- `status == RUNNING` with `(last_heartbeat_at or started_at)` within the staleness threshold
 
-An episode is considered done (do not retry) if:
+An episode is **done** (never retry) if:
 - `status == COMPLETED`
 
-Note: `COMPLETED` with `reward == 0` is a legitimate agent failure, not a technical
-failure. Retrying it wastes quota.
+`COMPLETED` with `reward == 0` is a legitimate agent failure, not a technical failure.
+Retrying it wastes quota.
 
-### Changes to `Storage`
+---
 
-Two new methods on `FileStorage` (and `Storage` Protocol):
+### `Experiment.get_episodes_to_run()` — new flag semantics
 
+| `resume` | `retry_failed` | Episodes returned |
+|---|---|---|
+| False | False | All episodes from scratch |
+| True | False | Episodes with missing `status.json` (never started) |
+| False | True | Episodes with `status IN (FAILED, STALE, CANCELLED)` **or** missing `status.json`, with `retry_count < max_retries` |
+| True | True | Union: all missing **+** all retriable failures |
+
+A new field on `Experiment`:
 ```python
-def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
-    # Atomic write: write to .tmp then rename
-
-def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
-    # Returns None if file does not exist
+max_retries: int = 3
 ```
 
-`EpisodeStatus` is a small dataclass (not a full Pydantic model — it must be writable
-before the trajectory object exists).
+Replaces the trajectory-scan path:
+- `_is_trajectory_successful` → **deleted**
+- `_load_successful_trajectory_ids` → **deleted**
+- `_load_started_trajectory_ids` → **replaced** by `_read_episode_status_map`
+- `_find_episodes_to_relaunch` → **absorbed** into `get_episodes_to_run`
 
-Atomic write (write-then-rename) ensures a reader never sees a partial file.
-
-### Migration: `Experiment.get_episodes_to_run()`
-
-Current code path (to be replaced):
-
-```
-_load_started_trajectory_ids()        # scans episodes/ dir for existing trajectories
-_load_successful_trajectory_ids()     # loads every trajectory and scans steps for StepError
-_find_episodes_to_relaunch()          # filters config files by trajectory ID sets
-```
-
-Replacement:
-
-```
-_load_episode_statuses()              # reads status.json from each episode dir — one small file each
-get_episodes_to_run()                 # filters directly on status: retry if FAILED/STALE/CANCELLED/missing
-```
-
-`_is_trajectory_successful` and `_load_successful_trajectory_ids` are deleted.
-`_load_started_trajectory_ids` is replaced by `_load_episode_statuses`.
-`_find_episodes_to_relaunch` logic is absorbed into `get_episodes_to_run`.
-
-The `resume` / `retry_failed` flags on `Experiment` map to status as follows:
-
-| Flag | Episodes returned |
-|---|---|
-| neither | All episodes created from scratch |
-| `resume=True` | Episodes with no `status.json` (never started) |
-| `retry_failed=True` | Episodes with `status IN (FAILED, STALE, CANCELLED)` and `retry_count < max_retries` |
-| both | Union of the above |
-
-`allow_overwrite = True` is set on retried episodes, same as today.
+---
 
 ### Automatic retry loop in `exp_runner`
 
-Today the caller must explicitly set `retry_failed=True` and re-run to pick up
-failures. The launcher should support an automatic retry loop so a single invocation
-can recover from transient failures without human intervention:
+Both `run_with_ray` and `run_sequentially` gain a `max_retry_rounds` parameter
+(default: **3**). After each round, the runner checks for retriable episodes. If any
+exist and `rounds_done < max_retry_rounds`, it runs them with `retry_failed=True`.
+The loop stops when no retriable episodes remain or the round budget is exhausted.
 
 ```python
 def run_with_ray(
     exp: Experiment,
-    ...
-    max_retry_rounds: int = 1,   # NEW: how many post-run retry sweeps to attempt
+    ...,
+    max_retry_rounds: int = 3,
 ) -> ExpResult:
 ```
 
-After the main Ray run completes, the runner checks for `FAILED`/`STALE`/`CANCELLED`
-episodes with `retry_count < max_retries`. If any exist and `retry_rounds < max_retry_rounds`,
-it marks the experiment `retry_failed=True` and runs again — reusing the same output
-directory. This loop repeats until no retriable episodes remain or `max_retry_rounds`
-is exhausted. The final `ExpResult` aggregates all rounds.
+The final `ExpResult` aggregates trajectories and failures across all rounds.
 
-`run_sequentially` gets the same `max_retry_rounds` parameter for consistency.
+Existing recipes that call `run_with_ray(exp)` get automatic retry out of the box
+(`max_retry_rounds=3`). Pass `max_retry_rounds=0` to opt out.
 
-### Changes to `exp_runner`
+---
 
-After `ray.cancel(force=True)`, write `status=CANCELLED` for that episode.
+### Storage changes
 
-After `ray.shutdown()`, sweep all episode directories: any `RUNNING` episode with a
-stale heartbeat is written as `STALE`.
+Two new methods on `Storage` Protocol and `FileStorage`:
+
+```python
+def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
+    # Atomic: write to .tmp then os.replace()
+
+def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
+    # Returns None if status.json does not exist
+```
+
+`EpisodeStatus` is a plain Python `@dataclass` (not Pydantic) defined in a new
+`cube_harness/episode_status.py` module. Both `episode.py` and `storage.py` import
+from it; this avoids the circular-import problem that would arise if it lived in
+`episode.py`.
+
+---
+
+### Error logging
+
+The full stack trace is always written to the episode's log file (existing behaviour
+via `redirect_output_to_log`). `error_type` and `error_message` in `status.json`
+provide the first line of diagnosis without opening logs. No other changes to logging.
+
+---
 
 ## Alternatives considered
 
-**Ray dashboard query.** Store the Ray job ID and query the dashboard to check if it
-is still running. Rejected: couples status check to Ray infrastructure, does not work
-for sequential runs, requires network access.
+**Ray dashboard query.** Rejected: couples status to Ray infrastructure, broken for
+sequential runs.
 
-**PID file.** Store the worker PID and check if the process is alive. Rejected: PIDs
-are recycled; unreliable on multi-node clusters.
+**PID file.** Rejected: PIDs are recycled; unreliable across multi-node clusters.
 
-**Trajectory existence as sentinel.** Current approach — treat any trajectory as done.
-Rejected: requires full deserialization, drops silently-failed episodes.
+**Trajectory existence as sentinel.** Current approach. Rejected: requires full
+deserialization; silently drops crashed episodes.
+
+**Experiment-level lock file.** Would prevent concurrent runners at the experiment
+level but gives no per-episode visibility. Replaced by the pre-claim mechanism, which
+is more surgical: episodes claimed by an active run are individually locked.
 
 ## Scope
 
-Touches: `episode.py`, `experiment.py`, `exp_runner.py`, `storage.py`, `storage` spec,
-`episode` spec, `experiment` spec.
+Touches: `episode.py`, `episode_status.py` (new), `experiment.py`, `exp_runner.py`,
+`storage.py` — and their specs.
 
-Does not change: trajectory format, `Trajectory` model, existing step files, XRay viewer.
+Does **not** change: trajectory format, `Trajectory` model, existing step files,
+XRay viewer.
 
-## Open questions
+## Open questions (resolved)
 
-1. What should `max_retries` default to? Proposed: 3.
-2. Heartbeat interval: 30s? Staleness threshold: 2 minutes?
-3. Should `CANCELLED` be retried by default, or only on explicit opt-in?
+| # | Question | Decision |
+|---|---|---|
+| 1 | `max_retries` default? | **3** |
+| 2 | `max_retry_rounds` default? | **3** |
+| 3 | Heartbeat interval / staleness threshold? | **30 s / 60 s** |
+| 4 | Should `CANCELLED` be retried? | **Yes** — treated same as `FAILED` |
+| 5 | Should missing `status.json` be retried by `retry_failed=True`? | **Yes** |

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -1,0 +1,141 @@
+# RFC: Episode Status File
+
+## Problem
+
+The current resume/retry logic in `experiment.py` determines whether an episode needs
+re-running by loading and scanning its full trajectory for `StepError` entries. This
+has three failure modes:
+
+**1. Stale RUNNING with no heartbeat.**
+If a Ray worker is killed (OOM, `ray.cancel(force=True)`, machine failure), no terminal
+status is ever written. The trajectory may be partial or missing. The current code
+catches the load failure silently and drops the episode — it neither retries nor counts
+it as done.
+
+**2. False positive on recovered errors.**
+A `StepError` recorded mid-episode (e.g. a tool error that the harness caught and
+turned into an error observation, then continued) causes `_is_trajectory_successful`
+to return `False`, triggering a retry even though the episode completed normally.
+
+**3. Status requires reading the payload.**
+To check whether an episode is done, the entire trajectory must be deserialized.
+At scale (thousands of episodes per experiment) this is expensive and fragile — a
+single corrupt step file breaks the check for that episode.
+
+## Proposed solution
+
+Write a small `status.json` file in each episode directory. Status is the ground truth
+for retry decisions. The trajectory is data; `status.json` is control.
+
+### Episode statuses
+
+| Status | Written by | Meaning |
+|---|---|---|
+| `RUNNING` | `episode._run_loop` at start | Episode has started; worker is alive |
+| `COMPLETED` | `episode._run_loop` in finally | Loop ran to natural end (done or max_steps); reward is irrelevant |
+| `FAILED` | `episode._run_loop` in finally | Unhandled exception propagated out of the run loop |
+| `CANCELLED` | `exp_runner` after `ray.cancel(force=True)` | Explicitly timed out by the harness |
+
+### `status.json` schema
+
+```json
+{
+  "status": "COMPLETED",
+  "task_id": "workarena.servicenow.create-incident",
+  "episode_id": 3,
+  "started_at": 1745000000.0,
+  "ended_at": 1745000120.0,
+  "last_heartbeat_at": 1745000118.0,
+  "reward": 1.0,
+  "had_step_errors": true,
+  "retry_count": 0
+}
+```
+
+Fields:
+- `status` — one of the four values above
+- `started_at` / `ended_at` — wall-clock timestamps (None if not reached)
+- `last_heartbeat_at` — updated by a background thread every N seconds while RUNNING
+- `reward` — final reward (None until COMPLETED)
+- `had_step_errors` — True if any step recorded a StepError; informational only, does not affect retry
+- `retry_count` — how many times this episode has been retried; capped at `max_retries` to prevent infinite loops
+
+### Heartbeat
+
+A background thread in `_run_loop` writes `last_heartbeat_at` to `status.json` every
+30 seconds while the episode is running. On recovery:
+
+- `status == RUNNING` and `now - last_heartbeat_at < threshold` (e.g. 2 minutes) → truly running, do not retry
+- `status == RUNNING` and `last_heartbeat_at` is stale or missing → dead worker, treat as FAILED for retry purposes
+
+This works for both local (sequential) and distributed (Ray) runs without requiring
+access to the Ray dashboard or any external state.
+
+### Retry logic
+
+An episode is eligible for retry if:
+1. `status.json` does not exist (worker died before writing `RUNNING`)
+2. `status == RUNNING` and heartbeat is stale
+3. `status == FAILED` or `status == CANCELLED`
+4. `retry_count < max_retries` (proposed default: 3)
+
+An episode is considered done (do not retry) if:
+- `status == COMPLETED`
+
+Note: `COMPLETED` with `reward == 0` is a legitimate agent failure, not a technical
+failure. Retrying it wastes quota.
+
+### Changes to `Storage`
+
+Two new methods on `FileStorage` (and `Storage` Protocol):
+
+```python
+def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
+    # Atomic write: write to .tmp then rename
+
+def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
+    # Returns None if file does not exist
+```
+
+`EpisodeStatus` is a small dataclass (not a full Pydantic model — it must be writable
+before the trajectory object exists).
+
+Atomic write (write-then-rename) ensures a reader never sees a partial file.
+
+### Changes to `Experiment`
+
+`_is_trajectory_successful` and `_load_successful_trajectory_ids` are replaced by:
+
+```python
+def _load_completed_trajectory_ids(self, storage: FileStorage) -> set[str]:
+    # Reads only status.json per episode directory — no trajectory deserialization
+```
+
+### Changes to `exp_runner`
+
+After `ray.cancel(force=True)`, write `status == CANCELLED` for that episode.
+
+## Alternatives considered
+
+**Ray dashboard query.** Store the Ray job ID and query the dashboard to check if it
+is still running. Rejected: couples status check to Ray infrastructure, does not work
+for sequential runs, requires network access.
+
+**PID file.** Store the worker PID and check if the process is alive. Rejected: PIDs
+are recycled; unreliable on multi-node clusters.
+
+**Trajectory existence as sentinel.** Current approach — treat any trajectory as done.
+Rejected: requires full deserialization, drops silently-failed episodes.
+
+## Scope
+
+Touches: `episode.py`, `experiment.py`, `exp_runner.py`, `storage.py`, `storage` spec,
+`episode` spec, `experiment` spec.
+
+Does not change: trajectory format, `Trajectory` model, existing step files, XRay viewer.
+
+## Open questions
+
+1. What should `max_retries` default to? Proposed: 3.
+2. Heartbeat interval: 30s? Staleness threshold: 2 minutes?
+3. Should `CANCELLED` be retried by default, or only on explicit opt-in?

--- a/openspec/changes/episode-status/proposal.md
+++ b/openspec/changes/episode-status/proposal.md
@@ -360,6 +360,83 @@ viewer, sequential-mode debug experience.
 
 ---
 
+## Testing strategy
+
+### One Ray-based integration test, four scenarios
+
+A single `run_with_ray(...)` over a 4-task benchmark covers ~80% of the retry
+machinery in one shot. Each task exercises a distinct code path:
+
+| Episode | Scenario list | Final status | retry_count | Archived dirs |
+|---|---|---|---|---|
+| 0 — `task_succeed` | `["succeed"]` | `COMPLETED` | 0 | 0 |
+| 1 — `task_flaky` | `["fail", "fail", "succeed"]` | `COMPLETED` | 2 | 2 (both `FAILED`) |
+| 2 — `task_dead` | `["fail"] * 4` | `FAILED` (max_retries cap) | 3 | 3 |
+| 3 — `task_hang` | `["hang", "succeed"]` | `COMPLETED` | 1 | 1 (`CANCELLED`, `error_type="StepTimeout"`) |
+
+### Debug agent
+
+`tests/test_retry_integration.py::DebugAgent` reads
+`scenario[task_id][attempt_num]` from a per-test JSON file and:
+- `"succeed"` → returns `final_step` action
+- `"fail"` → raises `RuntimeError("scripted failure")`
+- `"hang"` → `time.sleep(step_timeout_s * 10)` (driver kills it)
+
+The agent atomically increments a per-task attempt counter (fcntl-locked file in
+`tmp_dir`) so retries see consecutive attempt numbers across worker processes.
+
+### Run config (tuned for fast tests)
+
+```python
+exp = Experiment(..., max_retries=3)
+result = run_with_ray(
+    exp,
+    n_cpus=2,
+    step_timeout_s=2.0,
+    cancel_grace_s=1.0,
+    max_retry_rounds=3,
+)
+```
+
+Target wall-clock: 30–60 s including Ray startup. Mark with `@pytest.mark.slow`
+(or `integration`).
+
+### Coverage matrix
+
+| Code path | Covered by integration test |
+|---|---|
+| Pre-claim writes `RUNNING` for all 4 episodes before Ray submit | ✅ |
+| Worker writes `RUNNING` → `COMPLETED` / `FAILED` | ✅ |
+| Step-boundary heartbeat | ✅ (hang scenario can't fire without it) |
+| Driver poll reads `status.json`, force-cancels on stale heartbeat | ✅ |
+| Driver writes `CANCELLED` after force-kill, with `error_type="StepTimeout"` | ✅ |
+| Auto-retry loop (`max_retry_rounds`) | ✅ |
+| `retry_count` increment on pre-claim | ✅ |
+| `max_retries` cap respected | ✅ (Episode 2 stops at 3) |
+| Archive of old attempts (`.archived_<ts>/`) preserved | ✅ |
+| `error_type` / `error_message` populated end-to-end | ✅ |
+| `current_step` advances | ✅ |
+| `COMPLETED` never retried | ✅ (Episode 0) |
+
+### Focused unit tests for what the integration test can't reach
+
+- `tests/test_experiment.py::test_stale_sweep_marks_orphaned_running` — write a
+  `RUNNING` status with a stale heartbeat by hand, call the sweep, assert
+  `status == STALE` and the episode shows up in `retry_failed=True` selection.
+- `tests/test_experiment.py::test_resume_returns_missing_status_only` — episode
+  configs exist, no `status.json`, `resume=True` returns them; `retry_failed=True`
+  also returns them when paired with the missing-status branch.
+- `tests/test_storage.py::test_episode_status_atomic_write` — interrupted writes
+  via `.tmp` sibling never expose a partial `status.json`.
+
+### Out of scope for v1 tests
+
+- **Concurrent-driver collision** — needs subprocess orchestration; documented as
+  out-of-scope for v1.
+- **Sequential-mode step timeout** — no driver-side enforcement in v1.
+
+---
+
 ## Resolved questions
 
 | # | Question | Decision |

--- a/openspec/specs/experiment/spec.md
+++ b/openspec/specs/experiment/spec.md
@@ -18,13 +18,18 @@ class Experiment(TypedBaseModel):
     agent_config: AgentConfig
     benchmark: Benchmark             # cube.benchmark.Benchmark
     resume: bool = False
-    retry_failed: bool = False
     max_steps: int = MAX_STEPS
+    max_retries: int = 3             # per-episode retry cap
 
     @property
     def config(self) -> dict          # model_dump(serialize_as_any=True)
 
-    def get_episodes_to_run(self) -> list[Episode]
+    def get_episodes_to_run(
+        self,
+        step_timeout_s: float = 1800.0,
+        cancel_grace_s: float = 120.0,
+        orphan_threshold_s: float = 3600.0,
+    ) -> list[Episode]
     def save_config(self) -> None     # writes experiment_config.json
     @classmethod
     def load_config(cls, path: str) -> Experiment
@@ -33,14 +38,17 @@ class Experiment(TypedBaseModel):
 ```
 
 ### Resume / retry semantics
-| `resume` | `retry_failed` | Episodes returned |
-|----------|----------------|-------------------|
-| False    | False          | All episodes created from scratch |
-| True     | False          | Unstarted episodes only (configs exist, no trajectory) |
-| False    | True           | Failed episodes only (trajectory exists but not successful); `allow_overwrite=True` |
-| True     | True           | Unstarted ∪ failed |
 
-Successful = `trajectory.last_env_step().done and no step.output.error`.
+| `resume` | Episodes returned                                                                                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `False`  | All episodes from scratch                                                                                                                 |
+| `True`   | Episodes with no `status.json` (never started), plus retriable statuses (`FAILED`, `CANCELLED`, `STALE`) with `retry_count < max_retries` |
+
+`RUNNING` / `QUEUED` (in-flight) are never returned. `COMPLETED` and
+`MAX_STEPS_REACHED` (terminal, non-retriable) are always skipped.
+
+When `resume=True`, `sweep_stale_statuses` runs first so orphaned `RUNNING`/`QUEUED`
+entries become `STALE` and are eligible for retry.
 
 ### `ExpResult`
 ```python

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -18,9 +18,12 @@ class Storage(Protocol):
     def save_step(self, step: TrajectoryStep, trajectory_id: str, step_num: int) -> None
     def save_episode_config(self, episode_config: EpisodeConfig) -> None
     def update_experiment_summary(self, trajectory: Trajectory) -> None
+    def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
+    def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
+    def archive_episode(self, trajectory_id: str) -> None
 ```
 
-Custom backends (cloud storage, DB) must implement all four.
+Custom backends (cloud storage, DB) must implement all seven.
 
 ### `FileStorage`
 Writes V2 only. Reads V2 + V1.
@@ -35,6 +38,10 @@ class FileStorage:
     def save_episode_config(ep_config)
     def save_failure(trajectory_id: str, stack_trace: str)      # failure.txt
     def update_experiment_summary(trajectory)                   # experiment_summary.json (flock-protected)
+    def write_episode_status(trajectory_id, status)             # atomic via .tmp + os.replace()
+    def read_episode_status(trajectory_id) -> EpisodeStatus | None  # None if missing or corrupt
+    def archive_episode(trajectory_id)                          # renames dir to <id>.archived_<ts>/
+    def list_episode_statuses() -> dict[str, EpisodeStatus]     # all non-archived dirs with status.json
 
     # Reads (V2 + V1 fallback)
     def load_trajectory(trajectory_id) -> Trajectory
@@ -63,6 +70,7 @@ class FileStorage:
 ├── experiment_summary.json           # aggregated stats; flock-protected
 └── episodes/
     └── <trajectory_id>/              # f"{task_id}_ep{episode_id}"
+        ├── status.json               # EpisodeStatus (QUEUED→RUNNING→terminal)
         ├── episode_config.json
         ├── episode.metadata.json     # Trajectory without steps
         ├── steps/

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -12,6 +12,7 @@ from termcolor import colored
 
 from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
+from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
@@ -133,7 +134,7 @@ class Episode:
     ) -> Trajectory:
         """Run loop for the agent on the task."""
         task_id = self.config.task_config.task_id
-        trajectory_id = f"{task_id}_ep{self.config.id}"
+        trajectory_id = trajectory_log_id(task_id, self.config.id)
         tracer = get_tracer(self.config.exp_name)
 
         # Heartbeat 1: top of _run_loop (covers stuck setup_fn — env reset, container boot).

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -117,13 +117,14 @@ class Episode:
         action_set = task.action_set
         step_fn = task.step
         close_fn = task.close
+        evaluate_fn = task.evaluate
 
         def setup_fn() -> EnvironmentOutput:
             obs, info = task.reset()
             return EnvironmentOutput(obs=obs, info=info)
 
         agent = self.config.agent_config.make(action_set, task_id=self.config.task_config.task_id)
-        return self._run_loop(setup_fn, step_fn, close_fn, agent)
+        return self._run_loop(setup_fn, step_fn, evaluate_fn, close_fn, agent)
 
     def _open_status(self, trajectory_id: str) -> EpisodeStatus:
         """Initialise `status.json` for this attempt.
@@ -156,6 +157,7 @@ class Episode:
         self,
         setup_fn: Callable[[], EnvironmentOutput],
         step_fn: Callable,
+        evaluate_fn: Callable,
         close_fn: Callable,
         agent,
     ) -> Trajectory:
@@ -251,6 +253,29 @@ class Episode:
                         span.set_attribute("done", env_output.done)
                         span.set_attribute("reward", env_output.reward)
                         turns += 1
+                # Loop exited without `done=True` — either max_steps fired or the agent
+                # gave up. cube's task.step only calls evaluate() when done or
+                # validate_per_step, so we'd otherwise return reward=0.0. Force one
+                # final evaluation and save it as a synthetic env step so the
+                # trajectory's last_env_step carries the real reward.
+                max_steps_reached = turns >= self.config.max_steps and not env_output.done
+                if not env_output.done:
+                    try:
+                        eval_ts = time.time()
+                        forced_reward, forced_info = evaluate_fn(env_output.obs)
+                        env_output = EnvironmentOutput(
+                            obs=env_output.obs,
+                            reward=forced_reward,
+                            done=env_output.done,
+                            info={**env_output.info, **forced_info},
+                            error=env_output.error,
+                        )
+                        forced_step = TrajectoryStep(output=env_output, start_time=eval_ts, end_time=time.time())
+                        self.storage.save_step(forced_step, trajectory.id, len(trajectory.steps))
+                        summary_proc.on_step(len(trajectory.steps), forced_step)
+                        trajectory.steps.append(forced_step)
+                    except Exception:
+                        logger.exception("Final evaluate() raised; trajectory keeps last step's reward")
                 trajectory.end_time = time.time()
                 trajectory.reward_info = {"reward": env_output.reward, "done": env_output.done, **env_output.info}
                 trajectory.summary_stats = _compute_summary_stats(trajectory)
@@ -261,7 +286,7 @@ class Episode:
                 ep_status.reward = final_reward
                 status = StatusCode.OK if final_reward > 0 else StatusCode.ERROR
                 episode_span.set_status(status)
-            ep_status.status = "COMPLETED"
+            ep_status.status = "MAX_STEPS_REACHED" if max_steps_reached else "COMPLETED"
         except Exception as e:
             logger.exception(f"Error during agent run: {e}")
             ep_status.status = "FAILED"

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -125,6 +125,33 @@ class Episode:
         agent = self.config.agent_config.make(action_set, task_id=self.config.task_config.task_id)
         return self._run_loop(setup_fn, step_fn, close_fn, agent)
 
+    def _open_status(self, trajectory_id: str) -> EpisodeStatus:
+        """Initialise `status.json` for this attempt.
+
+        If the prior status is terminal and this Episode opted in to overwrite
+        (a legitimate retry), archive the prior directory so its terminal
+        `status.json` survives. Without `allow_overwrite`, `save_trajectory`
+        will later raise — preserving the safety guard against accidental
+        double-runs.
+        """
+        prior = self.storage.read_episode_status(trajectory_id)
+        if prior is not None and prior.status in TERMINAL_STATUSES and self.allow_overwrite:
+            ep_dir = self.storage._episode_dir(trajectory_id)
+            if ep_dir.exists():
+                self.storage._archive_episode(ep_dir)
+        now = time.time()
+        ep_status = EpisodeStatus(
+            status="RUNNING",
+            task_id=self.config.task_config.task_id,
+            episode_id=self.config.id,
+            started_at=now,
+            last_heartbeat_at=now,
+            current_step=0,
+            retry_count=next_retry_count(prior),
+        )
+        self.storage.write_episode_status(trajectory_id, ep_status)
+        return ep_status
+
     def _run_loop(
         self,
         setup_fn: Callable[[], EnvironmentOutput],
@@ -137,26 +164,8 @@ class Episode:
         trajectory_id = trajectory_log_id(task_id, self.config.id)
         tracer = get_tracer(self.config.exp_name)
 
-        # Heartbeat 1: top of _run_loop (covers stuck setup_fn — env reset, container boot).
-        # If the prior status is terminal AND this Episode opted in to overwrite (a
-        # legitimate retry), archive the prior directory so its terminal status.json
-        # survives. Without `allow_overwrite`, save_trajectory will raise — preserving
-        # the existing safety guard against accidental double-runs.
-        prior = self.storage.read_episode_status(trajectory_id)
-        if prior is not None and prior.status in TERMINAL_STATUSES and self.allow_overwrite:
-            ep_dir = self.storage._episode_dir(trajectory_id)
-            if ep_dir.exists():
-                self.storage._archive_episode(ep_dir)
-        ep_status = EpisodeStatus(
-            status="RUNNING",
-            task_id=task_id,
-            episode_id=self.config.id,
-            started_at=time.time(),
-            last_heartbeat_at=time.time(),
-            current_step=0,
-            retry_count=next_retry_count(prior),
-        )
-        self.storage.write_episode_status(trajectory_id, ep_status)
+        # Heartbeat 1: covers stuck setup_fn (env reset, container boot).
+        ep_status = self._open_status(trajectory_id)
 
         trajectory: Trajectory | None = None
         try:

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -12,6 +12,7 @@ from termcolor import colored
 
 from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
+from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -132,14 +133,38 @@ class Episode:
     ) -> Trajectory:
         """Run loop for the agent on the task."""
         task_id = self.config.task_config.task_id
+        trajectory_id = f"{task_id}_ep{self.config.id}"
         tracer = get_tracer(self.config.exp_name)
+
+        # Heartbeat 1: top of _run_loop (covers stuck setup_fn — env reset, container boot).
+        # If the prior status is terminal AND this Episode opted in to overwrite (a
+        # legitimate retry), archive the prior directory so its terminal status.json
+        # survives. Without `allow_overwrite`, save_trajectory will raise — preserving
+        # the existing safety guard against accidental double-runs.
+        prior = self.storage.read_episode_status(trajectory_id)
+        if prior is not None and prior.status in TERMINAL_STATUSES and self.allow_overwrite:
+            ep_dir = self.storage._episode_dir(trajectory_id)
+            if ep_dir.exists():
+                self.storage._archive_episode(ep_dir)
+        ep_status = EpisodeStatus(
+            status="RUNNING",
+            task_id=task_id,
+            episode_id=self.config.id,
+            started_at=time.time(),
+            last_heartbeat_at=time.time(),
+            current_step=0,
+            retry_count=next_retry_count(prior),
+        )
+        self.storage.write_episode_status(trajectory_id, ep_status)
+
+        trajectory: Trajectory | None = None
         try:
             with tracer.episode(task_id, experiment=self.config.exp_name) as episode_span:
-                start_time = time.time()
+                start_time = ep_status.started_at
                 env_output = setup_fn()
                 agent_name = type(self.config.agent_config).__name__
                 trajectory = Trajectory(
-                    id=f"{task_id}_ep{self.config.id}",
+                    id=trajectory_id,
                     steps=[TrajectoryStep(output=env_output, start_time=start_time, end_time=time.time())],
                     metadata={
                         "task_id": task_id,
@@ -158,6 +183,11 @@ class Episode:
                 logger.info(colored(f"Episode started — done={env_output.done} reward={env_output.reward}", "blue"))
                 turns = 0
                 while not env_output.done and turns < self.config.max_steps:
+                    # Heartbeat 2: start of each turn, before agent.step() and step_fn().
+                    ep_status.last_heartbeat_at = time.time()
+                    ep_status.current_step = turns + 1
+                    self.storage.write_episode_status(trajectory_id, ep_status)
+
                     with tracer.step(f"turn_{turns}") as span:
                         ts = time.time()
                         try:
@@ -169,6 +199,7 @@ class Episode:
                             self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
                             summary_proc.on_step(len(trajectory.steps), agent_step)
                             trajectory.steps.append(agent_step)
+                            ep_status.had_step_errors = True
                             raise e
 
                         self.log_agent_output(turns, agent_output)
@@ -176,6 +207,8 @@ class Episode:
                         self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
                         summary_proc.on_step(len(trajectory.steps), agent_step)
                         trajectory.steps.append(agent_step)
+                        if agent_output.error is not None:
+                            ep_status.had_step_errors = True
 
                         if not agent_output.actions and not agent_output.error:
                             logger.info(colored("Agent returned no actions — stopping episode.", "yellow"))
@@ -191,6 +224,7 @@ class Episode:
                             self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
                             summary_proc.on_step(len(trajectory.steps), env_step)
                             trajectory.steps.append(env_step)
+                            ep_status.had_step_errors = True
                             raise e
 
                         logger.info(
@@ -202,6 +236,8 @@ class Episode:
                         self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
                         summary_proc.on_step(len(trajectory.steps), env_step)
                         trajectory.steps.append(env_step)
+                        if env_output.error is not None:
+                            ep_status.had_step_errors = True
                         span.set_attribute("done", env_output.done)
                         span.set_attribute("reward", env_output.reward)
                         turns += 1
@@ -212,12 +248,23 @@ class Episode:
                 summary_proc.on_episode_complete(trajectory, self.storage)
                 logger.info(colored(f"Episode completed in {turns} turns, reward: {env_output.reward}", "blue"))
                 final_reward = trajectory.last_env_step().reward
+                ep_status.reward = final_reward
                 status = StatusCode.OK if final_reward > 0 else StatusCode.ERROR
                 episode_span.set_status(status)
+            ep_status.status = "COMPLETED"
         except Exception as e:
             logger.exception(f"Error during agent run: {e}")
+            ep_status.status = "FAILED"
+            ep_status.error_type = type(e).__name__
+            ep_status.error_message = str(e)[:500]
             raise e
         finally:
+            ep_status.ended_at = time.time()
+            ep_status.last_heartbeat_at = ep_status.ended_at
+            try:
+                self.storage.write_episode_status(trajectory_id, ep_status)
+            except Exception:
+                logger.exception("Failed to write final episode status")
             close_fn()
             tracer.shutdown()
         return trajectory

--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Literal
 
@@ -51,7 +51,15 @@ class EpisodeStatus:
 
     @classmethod
     def from_json(cls, raw: str) -> "EpisodeStatus":
-        return cls(**json.loads(raw))
+        """Parse a status.json blob, ignoring unknown keys for forward compat.
+
+        A status file written by a future version may carry fields this version
+        doesn't know about. Dropping them silently lets older readers continue
+        functioning instead of treating the file as corrupt.
+        """
+        data = json.loads(raw)
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
     @classmethod
     def read(cls, path: Path) -> "EpisodeStatus | None":

--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -15,9 +15,15 @@ from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Literal
 
-Status = Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE"]
+Status = Literal["QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"]
 
-TERMINAL_STATUSES: frozenset[Status] = frozenset({"COMPLETED", "FAILED", "CANCELLED", "STALE"})
+# In-flight: episode hasn't reached a terminal state yet. Driver poll should
+# leave these alone (subject to orphan/heartbeat sweeps for dead-worker cleanup).
+IN_FLIGHT_STATUSES: frozenset[Status] = frozenset({"QUEUED", "RUNNING"})
+
+TERMINAL_STATUSES: frozenset[Status] = frozenset({"COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"})
+# MAX_STEPS_REACHED is terminal but NOT retriable: the agent legitimately ran out of
+# its step budget, retrying would just truncate again from a fresh initial state.
 RETRIABLE_STATUSES: frozenset[Status] = frozenset({"FAILED", "CANCELLED", "STALE"})
 
 STATUS_FILENAME = "status.json"
@@ -82,11 +88,11 @@ def next_retry_count(prior: "EpisodeStatus | None") -> int:
     """Return the retry_count for a new attempt, given the prior status (if any).
 
     - No prior: 0 (original attempt).
-    - Prior was RUNNING: same retry_count (e.g., re-pre-claim within a round, idempotent).
-    - Prior was terminal (FAILED/CANCELLED/STALE/COMPLETED): prior + 1.
+    - Prior in-flight (QUEUED / RUNNING): same retry_count (idempotent re-pre-claim).
+    - Prior terminal (FAILED/CANCELLED/STALE/COMPLETED/MAX_STEPS_REACHED): prior + 1.
     """
     if prior is None:
         return 0
-    if prior.status == "RUNNING":
+    if prior.status in IN_FLIGHT_STATUSES:
         return prior.retry_count
     return prior.retry_count + 1

--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -1,0 +1,84 @@
+"""Per-episode status file used to drive resume/retry decisions.
+
+`status.json` is the control-plane sibling of the trajectory data. It is read
+and written without deserialising trajectory steps, so the driver can make
+retry decisions in O(N) file reads rather than O(N×steps) deserialisations.
+
+See `openspec/changes/episode-status/proposal.md` for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal
+
+Status = Literal["RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE"]
+
+TERMINAL_STATUSES: frozenset[Status] = frozenset({"COMPLETED", "FAILED", "CANCELLED", "STALE"})
+RETRIABLE_STATUSES: frozenset[Status] = frozenset({"FAILED", "CANCELLED", "STALE"})
+
+STATUS_FILENAME = "status.json"
+
+
+@dataclass
+class EpisodeStatus:
+    """Lifecycle snapshot of an episode.
+
+    Written by both the worker (real progress) and the driver (pre-claim,
+    cancellation). `last_heartbeat_at` is `None` until the worker enters
+    `_run_loop`; this is the "queued in Ray" signal for the driver poll.
+    """
+
+    status: Status
+    task_id: str
+    episode_id: int
+    started_at: float
+    ended_at: float | None = None
+    last_heartbeat_at: float | None = None
+    current_step: int = 0
+    reward: float | None = None
+    had_step_errors: bool = False
+    error_type: str | None = None
+    error_message: str | None = None
+    retry_count: int = 0
+    extra: dict = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "EpisodeStatus":
+        return cls(**json.loads(raw))
+
+    @classmethod
+    def read(cls, path: Path) -> "EpisodeStatus | None":
+        if not path.exists():
+            return None
+        try:
+            return cls.from_json(path.read_text())
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+
+    def write(self, path: Path) -> None:
+        """Atomic write: tmp sibling + os.replace() so partial files are never observed."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(self.to_json())
+        os.replace(tmp, path)
+
+
+def next_retry_count(prior: "EpisodeStatus | None") -> int:
+    """Return the retry_count for a new attempt, given the prior status (if any).
+
+    - No prior: 0 (original attempt).
+    - Prior was RUNNING: same retry_count (e.g., re-pre-claim within a round, idempotent).
+    - Prior was terminal (FAILED/CANCELLED/STALE/COMPLETED): prior + 1.
+    """
+    if prior is None:
+        return 0
+    if prior.status == "RUNNING":
+        return prior.retry_count
+    return prior.retry_count + 1

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -68,6 +68,7 @@ def run_with_ray(
     step_timeout_s: float = 1800.0,
     cancel_grace_s: float = 120.0,
     orphan_threshold_s: float = 3600.0,
+    max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
     agent_name: str | None = None,
@@ -90,6 +91,7 @@ def run_with_ray(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                max_retry_rounds=max_retry_rounds,
             )
     finally:
         tracer.shutdown()
@@ -109,6 +111,7 @@ def _run_with_retries(
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
+    max_retry_rounds: int,
 ) -> ExpResult:
     """Run the experiment, then keep re-running retriable failures until none remain.
 
@@ -137,6 +140,12 @@ def _run_with_retries(
                 aggregated.failures.pop(k, None)
 
             if not _has_retriable_episodes(exp):
+                break
+
+            if round_num >= max_retry_rounds:
+                logger.info(
+                    f"Stopping auto-retry after {round_num} round(s): reached max_retry_rounds={max_retry_rounds}"
+                )
                 break
 
             round_num += 1
@@ -331,6 +340,7 @@ def run_sequentially(
     step_timeout_s: float = 1800.0,
     cancel_grace_s: float = 120.0,
     orphan_threshold_s: float = 3600.0,
+    max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
     agent_name: str | None = None,
@@ -352,6 +362,7 @@ def run_sequentially(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                max_retry_rounds=max_retry_rounds,
             )
     finally:
         tracer.shutdown()
@@ -364,6 +375,7 @@ def _run_sequentially_with_retries(
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
+    max_retry_rounds: int,
 ) -> ExpResult:
     """Run sequential rounds back-to-back until no retriable failures remain.
 
@@ -389,6 +401,12 @@ def _run_sequentially_with_retries(
                 aggregated.failures.pop(k, None)
 
             if not _has_retriable_episodes(exp):
+                break
+
+            if round_num >= max_retry_rounds:
+                logger.info(
+                    f"Stopping auto-retry after {round_num} round(s): reached max_retry_rounds={max_retry_rounds}"
+                )
                 break
 
             round_num += 1

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -2,7 +2,6 @@
 
 import logging
 import time
-import traceback
 from uuid import uuid4
 
 import ray

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -10,7 +10,7 @@ import ray
 from cube_harness.core import Trajectory
 from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
-from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
+from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage
@@ -31,7 +31,11 @@ def _trajectory_id(episode: Episode) -> str:
 
 
 def _pre_claim(storage: FileStorage, episode: Episode) -> None:
-    """Write `RUNNING` for an episode before submitting it to Ray.
+    """Write `QUEUED` for an episode before submitting it to Ray.
+
+    `QUEUED` distinguishes "submitted to Ray, waiting for a worker" from
+    `RUNNING` (a worker has actually picked it up and is heartbeating). The
+    worker overwrites `QUEUED` → `RUNNING` when it enters `_open_status`.
 
     If the previous attempt left a terminal status, archive its directory first
     so the per-attempt history (including the terminal `status.json`) is preserved.
@@ -45,7 +49,7 @@ def _pre_claim(storage: FileStorage, episode: Episode) -> None:
     storage.write_episode_status(
         traj_id,
         EpisodeStatus(
-            status="RUNNING",
+            status="QUEUED",
             task_id=episode.config.task_config.task_id,
             episode_id=episode.config.id,
             started_at=time.time(),
@@ -64,12 +68,11 @@ def run_with_ray(
     step_timeout_s: float = 1800.0,
     cancel_grace_s: float = 120.0,
     orphan_threshold_s: float = 3600.0,
-    max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
     agent_name: str | None = None,
 ) -> ExpResult:
-    """Run `exp` in parallel on Ray, with auto-retry rounds and step-timeout enforcement."""
+    """Run `exp` in parallel on Ray, with auto-retry and step-timeout enforcement."""
     model = model or _extract_model(exp)
     tracer = get_tracer(
         exp.name,
@@ -87,10 +90,15 @@ def run_with_ray(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
-                max_retry_rounds=max_retry_rounds,
             )
     finally:
         tracer.shutdown()
+
+
+def _has_retriable_episodes(exp: Experiment) -> bool:
+    """True iff any episode is FAILED/STALE/CANCELLED with retry_count below the cap."""
+    statuses = FileStorage(exp.output_dir).list_episode_statuses()
+    return any(s.status in RETRIABLE_STATUSES and s.retry_count < exp.max_retries for s in statuses.values())
 
 
 def _run_with_retries(
@@ -101,12 +109,15 @@ def _run_with_retries(
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
-    max_retry_rounds: int,
 ) -> ExpResult:
-    """Run the experiment, then re-run any retriable failures up to `max_retry_rounds` times."""
+    """Run the experiment, then keep re-running retriable failures until none remain.
+
+    Termination is guaranteed by the per-episode `max_retries` cap: each retried
+    episode increments `retry_count`, so eventually every retriable episode either
+    succeeds or hits the cap and `_has_retriable_episodes` returns False.
+    """
     aggregated = ExpResult(tasks_num=0, config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     original_resume = exp.resume
-    original_retry_failed = exp.retry_failed
     try:
         round_num = 0
         while True:
@@ -125,27 +136,15 @@ def _run_with_retries(
             for k in round_result.trajectories:
                 aggregated.failures.pop(k, None)
 
-            if round_num >= max_retry_rounds:
-                break
-
-            # Decide whether to run another retry round by checking if anything is still retriable.
-            storage = FileStorage(exp.output_dir)
-            statuses = storage.list_episode_statuses()
-            has_retriable = any(
-                s.status in ("FAILED", "CANCELLED", "STALE") and s.retry_count < exp.max_retries
-                for s in statuses.values()
-            )
-            if not has_retriable:
+            if not _has_retriable_episodes(exp):
                 break
 
             round_num += 1
-            logger.info(f"Auto-retry round {round_num}/{max_retry_rounds}: re-running retriable episodes")
-            exp.resume = False
-            exp.retry_failed = True
+            logger.info(f"Auto-retry round {round_num}: re-running retriable episodes")
+            exp.resume = True
         return aggregated
     finally:
         exp.resume = original_resume
-        exp.retry_failed = original_retry_failed
 
 
 def _run_with_ray_impl(
@@ -290,8 +289,9 @@ def _kill_stale_workers(
     for ref in list(episodes_in_progress):
         traj_id = ref_to_traj_id[ref]
         status = storage.read_episode_status(traj_id)
-        if status is None or status.last_heartbeat_at is None:
-            # Pre-claim only — episode is queued in Ray, not yet picked up.
+        # QUEUED → episode hasn't been picked up by a Ray worker yet (no heartbeat to check).
+        # The orphan threshold path in the STALE sweep handles a never-picked-up QUEUED.
+        if status is None or status.status != "RUNNING" or status.last_heartbeat_at is None:
             continue
         age = now - status.last_heartbeat_at
         if age <= step_timeout_s + cancel_grace_s:
@@ -328,7 +328,6 @@ def run_sequentially(
     exp: Experiment,
     debug_limit: int | None = None,
     *,
-    max_retry_rounds: int = 3,
     step_timeout_s: float = 1800.0,
     cancel_grace_s: float = 120.0,
     orphan_threshold_s: float = 3600.0,
@@ -336,7 +335,7 @@ def run_sequentially(
     model: str | None = None,
     agent_name: str | None = None,
 ) -> ExpResult:
-    """Run `exp` in-process (no Ray) with auto-retry rounds — the debug-friendly path."""
+    """Run `exp` in-process (no Ray) with auto-retry — the debug-friendly path."""
     model = model or _extract_model(exp)
     tracer = get_tracer(
         exp.name,
@@ -350,7 +349,6 @@ def run_sequentially(
             return _run_sequentially_with_retries(
                 exp,
                 debug_limit=debug_limit,
-                max_retry_rounds=max_retry_rounds,
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
@@ -363,15 +361,16 @@ def _run_sequentially_with_retries(
     exp: Experiment,
     *,
     debug_limit: int | None,
-    max_retry_rounds: int,
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> ExpResult:
-    """Run sequential rounds back-to-back, replaying retriable failures up to `max_retry_rounds`."""
+    """Run sequential rounds back-to-back until no retriable failures remain.
+
+    Termination is guaranteed by the per-episode `max_retries` cap.
+    """
     aggregated = ExpResult(tasks_num=0, config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     original_resume = exp.resume
-    original_retry_failed = exp.retry_failed
     try:
         round_num = 0
         while True:
@@ -389,26 +388,15 @@ def _run_sequentially_with_retries(
             for k in round_result.trajectories:
                 aggregated.failures.pop(k, None)
 
-            if round_num >= max_retry_rounds:
-                break
-
-            storage = FileStorage(exp.output_dir)
-            statuses = storage.list_episode_statuses()
-            has_retriable = any(
-                s.status in ("FAILED", "CANCELLED", "STALE") and s.retry_count < exp.max_retries
-                for s in statuses.values()
-            )
-            if not has_retriable:
+            if not _has_retriable_episodes(exp):
                 break
 
             round_num += 1
-            logger.info(f"Auto-retry round {round_num}/{max_retry_rounds}: re-running retriable episodes")
-            exp.resume = False
-            exp.retry_failed = True
+            logger.info(f"Auto-retry round {round_num}: re-running retriable episodes")
+            exp.resume = True
         return aggregated
     finally:
         exp.resume = original_resume
-        exp.retry_failed = original_retry_failed
 
 
 def _run_sequentially_impl(

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -6,19 +6,17 @@ import traceback
 from uuid import uuid4
 
 import ray
-from ray.util.state.api import list_tasks
 
 from cube_harness.core import Trajectory
 from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
-from cube_harness.experiment import Experiment, ExpResult
+from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
+from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
-
-_CANCEL_GRACE_PERIOD_S = 60
 
 
 def _extract_model(exp: Experiment) -> str | None:
@@ -26,11 +24,45 @@ def _extract_model(exp: Experiment) -> str | None:
     return llm_config.model_name if llm_config else None
 
 
+def _trajectory_id(episode: Episode) -> str:
+    return trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
+
+
+def _pre_claim(storage: FileStorage, episode: Episode) -> None:
+    """Write `RUNNING` for an episode before submitting it to Ray.
+
+    If the previous attempt left a terminal status, archive its directory first
+    so the per-attempt history (including the terminal `status.json`) is preserved.
+    """
+    traj_id = _trajectory_id(episode)
+    prior = storage.read_episode_status(traj_id)
+    if prior is not None and prior.status in TERMINAL_STATUSES:
+        ep_dir = storage._episode_dir(traj_id)
+        if ep_dir.exists():
+            storage._archive_episode(ep_dir)
+    storage.write_episode_status(
+        traj_id,
+        EpisodeStatus(
+            status="RUNNING",
+            task_id=episode.config.task_config.task_id,
+            episode_id=episode.config.id,
+            started_at=time.time(),
+            last_heartbeat_at=None,
+            current_step=0,
+            retry_count=next_retry_count(prior),
+        ),
+    )
+
+
 def run_with_ray(
     exp: Experiment,
+    *,
     n_cpus: int = 4,
     ray_poll_timeout: float = 2.0,
-    episode_timeout: float | None = 3600.0,
+    step_timeout_s: float = 1800.0,
+    cancel_grace_s: float = 120.0,
+    orphan_threshold_s: float = 3600.0,
+    max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
     agent_name: str | None = None,
@@ -45,21 +77,91 @@ def run_with_ray(
 
     try:
         with tracer.benchmark(exp.name):
-            return _run_with_ray_impl(exp, n_cpus, ray_poll_timeout, episode_timeout)
+            return _run_with_retries(
+                exp,
+                n_cpus=n_cpus,
+                ray_poll_timeout=ray_poll_timeout,
+                step_timeout_s=step_timeout_s,
+                cancel_grace_s=cancel_grace_s,
+                orphan_threshold_s=orphan_threshold_s,
+                max_retry_rounds=max_retry_rounds,
+            )
     finally:
         tracer.shutdown()
 
 
+def _run_with_retries(
+    exp: Experiment,
+    *,
+    n_cpus: int,
+    ray_poll_timeout: float,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    orphan_threshold_s: float,
+    max_retry_rounds: int,
+) -> ExpResult:
+    """Run the experiment, then re-run any retriable failures up to `max_retry_rounds` times."""
+    aggregated = ExpResult(tasks_num=0, config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
+    original_resume = exp.resume
+    original_retry_failed = exp.retry_failed
+    try:
+        round_num = 0
+        while True:
+            round_result = _run_with_ray_impl(
+                exp,
+                n_cpus=n_cpus,
+                ray_poll_timeout=ray_poll_timeout,
+                step_timeout_s=step_timeout_s,
+                cancel_grace_s=cancel_grace_s,
+                orphan_threshold_s=orphan_threshold_s,
+            )
+            aggregated.tasks_num = max(aggregated.tasks_num, round_result.tasks_num)
+            aggregated.trajectories.update(round_result.trajectories)
+            for k, v in round_result.failures.items():
+                aggregated.failures[k] = v
+            for k in round_result.trajectories:
+                aggregated.failures.pop(k, None)
+
+            if round_num >= max_retry_rounds:
+                break
+
+            # Decide whether to run another retry round by checking if anything is still retriable.
+            storage = FileStorage(exp.output_dir)
+            statuses = storage.list_episode_statuses()
+            has_retriable = any(
+                s.status in ("FAILED", "CANCELLED", "STALE") and s.retry_count < exp.max_retries
+                for s in statuses.values()
+            )
+            if not has_retriable:
+                break
+
+            round_num += 1
+            logger.info(f"Auto-retry round {round_num}/{max_retry_rounds}: re-running retriable episodes")
+            exp.resume = False
+            exp.retry_failed = True
+        return aggregated
+    finally:
+        exp.resume = original_resume
+        exp.retry_failed = original_retry_failed
+
+
 def _run_with_ray_impl(
-    exp: Experiment, n_cpus: int, ray_poll_timeout: float, episode_timeout: float | None
+    exp: Experiment,
+    *,
+    n_cpus: int,
+    ray_poll_timeout: float,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    orphan_threshold_s: float,
 ) -> ExpResult:
     exp.save_config()
     output_dir = exp.output_dir
+    storage = FileStorage(output_dir)
 
     @ray.remote
     def run_episode(episode: Episode) -> Trajectory:
-        trajectory_id = trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
-        log_file = get_log_path(output_dir, trajectory_id)
+        traj_id = _trajectory_id(episode)
+        log_file = get_log_path(output_dir, traj_id)
         with redirect_output_to_log(log_file, append=True, tee=False, log_format=LOG_FORMAT):
             return episode.run()
 
@@ -74,46 +176,57 @@ def _run_with_ray_impl(
 
     exp.benchmark.setup()
     try:
-        episodes = exp.get_episodes_to_run()
-        ref_to_episode = {run_episode.remote(episode): episode for episode in episodes}
+        episodes = exp.get_episodes_to_run(
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+            orphan_threshold_s=orphan_threshold_s,
+        )
+
+        # Pre-claim every episode before any Ray submission so a concurrent runner
+        # opening the same output_dir sees them as RUNNING (queued).
+        for episode in episodes:
+            _pre_claim(storage, episode)
+
+        ref_to_traj_id: dict[ray.ObjectRef, str] = {}
+        for episode in episodes:
+            ref = run_episode.remote(episode)
+            ref_to_traj_id[ref] = _trajectory_id(episode)
         logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
-        results = _poll_ray(exp, ref_to_episode, ray_poll_timeout, episode_timeout)
+        results = _poll_ray(
+            exp,
+            ref_to_traj_id,
+            storage,
+            ray_poll_timeout=ray_poll_timeout,
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+        )
         exp.print_stats(results)
         return results
     finally:
         ray.shutdown()
+        # End-of-run STALE sweep: any RUNNING entries whose worker just got killed
+        # by ray.shutdown() get marked STALE so the next round can retry them.
+        sweep_stale_statuses(
+            storage,
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+            orphan_threshold_s=orphan_threshold_s,
+        )
         exp.benchmark.close()
-
-
-def _get_running_elapsed_s(refs: list[ray.ObjectRef]) -> dict[ray.ObjectRef, float]:
-    """Return elapsed running time (seconds) for each ref that is actively executing.
-
-    Queries the Ray dashboard in bulk. Refs that are still queued (no start_time_ms)
-    are excluded. Returns an empty dict if the dashboard is unreachable.
-    """
-    try:
-        running = {
-            t.task_id: t.start_time_ms
-            for t in list_tasks(filters=[("state", "=", "RUNNING")])
-            if t.start_time_ms is not None
-        }
-    except Exception:
-        logger.debug("Could not reach Ray dashboard to check episode timeouts — skipping this cycle")
-        return {}
-    now_ms = time.time() * 1000
-    return {ref: (now_ms - running[ref.task_id().hex()]) / 1000 for ref in refs if ref.task_id().hex() in running}
 
 
 def _poll_ray(
     exp: Experiment,
-    ref_to_episode: dict[ray.ObjectRef, Episode],
+    ref_to_traj_id: dict[ray.ObjectRef, str],
+    storage: FileStorage,
+    *,
     ray_poll_timeout: float,
-    episode_timeout: float | None,
+    step_timeout_s: float,
+    cancel_grace_s: float,
 ) -> ExpResult:
-    storage = FileStorage(exp.output_dir)
-    results = ExpResult(tasks_num=len(ref_to_episode), config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
+    results = ExpResult(tasks_num=len(ref_to_traj_id), config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     completed = 0
-    episodes_in_progress = list(ref_to_episode.keys())
+    episodes_in_progress = list(ref_to_traj_id.keys())
     while len(episodes_in_progress) > 0:
         done, episodes_in_progress = ray.wait(
             episodes_in_progress,
@@ -124,48 +237,86 @@ def _poll_ray(
         if len(done) > 0:
             logger.info(f"{completed} episodes completed, {len(episodes_in_progress)} in progress")
         for task_ref in done:
-            episode = ref_to_episode[task_ref]
-            task_id = episode.config.task_config.task_id
-            traj_id = trajectory_log_id(task_id, episode.config.id)
+            traj_id = ref_to_traj_id[task_ref]
             try:
                 traj: Trajectory = ray.get(task_ref)
                 logger.info(
-                    "Completed trajectory for task %s with %d steps (%d agent steps, %d environment steps)",
-                    task_id,
+                    "Completed trajectory %s with %d steps (%d agent steps, %d environment steps)",
+                    traj_id,
                     len(traj.steps),
                     traj.n_agent_steps,
                     traj.n_env_steps,
                 )
-                results.trajectories[task_id] = traj
+                results.trajectories[traj_id] = traj
             except Exception as e:
-                tb = traceback.format_exc()
-                logger.error(f"Episode {traj_id} failed:\n{tb}")
-                results.failures[task_id] = str(e)
-                storage.save_failure(traj_id, tb)
-        if episode_timeout is not None:
-            for ref, elapsed in _get_running_elapsed_s(episodes_in_progress).items():
-                if elapsed > episode_timeout:
-                    episode = ref_to_episode[ref]
-                    task_id = episode.config.task_config.task_id
-                    traj_id = trajectory_log_id(task_id, episode.config.id)
-                    if elapsed < episode_timeout + _CANCEL_GRACE_PERIOD_S:
-                        logger.warning(f"Episode {traj_id} timed out after {elapsed:.0f}s — cancelling gracefully")
-                        ray.cancel(ref, force=False)
-                    else:
-                        msg = f"Episode timed out after {elapsed:.0f}s"
-                        logger.error(
-                            f"Episode {traj_id} timed out after {elapsed:.0f}s — force killing after grace period"
-                        )
-                        ray.cancel(ref, force=True)
-                        results.failures[task_id] = msg
-                        storage.save_failure(traj_id, msg)
-                        episodes_in_progress.remove(ref)
+                logger.exception(f"Run failed with exception: {e}")
+                results.failures[traj_id] = str(e)
+
+        # Driver-side step timeout via filesystem read (replaces ray-dashboard list_tasks).
+        _kill_stale_workers(
+            episodes_in_progress,
+            ref_to_traj_id,
+            storage,
+            results,
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+        )
     return results
+
+
+def _kill_stale_workers(
+    episodes_in_progress: list[ray.ObjectRef],
+    ref_to_traj_id: dict[ray.ObjectRef, str],
+    storage: FileStorage,
+    results: ExpResult,
+    *,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+) -> None:
+    """Read each active episode's status.json; force-kill workers with stale heartbeats.
+
+    A worker that has not advanced its heartbeat in `step_timeout_s + cancel_grace_s`
+    is presumed stuck. The driver force-cancels it, writes a `CANCELLED` status with
+    `error_type="StepTimeout"`, and removes the ref from the in-progress list.
+    """
+    now = time.time()
+    to_remove: list[ray.ObjectRef] = []
+    for ref in list(episodes_in_progress):
+        traj_id = ref_to_traj_id[ref]
+        status = storage.read_episode_status(traj_id)
+        if status is None or status.last_heartbeat_at is None:
+            # Pre-claim only — episode is queued in Ray, not yet picked up.
+            continue
+        age = now - status.last_heartbeat_at
+        if age <= step_timeout_s + cancel_grace_s:
+            continue
+        logger.error(
+            f"Episode {traj_id} step {status.current_step} stalled for {age:.0f}s "
+            f"(>{step_timeout_s + cancel_grace_s:.0f}s) — force killing"
+        )
+        try:
+            ray.cancel(ref, force=True)
+        except Exception:
+            logger.exception(f"ray.cancel failed for {traj_id}")
+        status.status = "CANCELLED"
+        status.ended_at = now
+        status.error_type = "StepTimeout"
+        status.error_message = f"Step {status.current_step} exceeded {step_timeout_s:.0f}s"
+        storage.write_episode_status(traj_id, status)
+        results.failures[traj_id] = status.error_message
+        to_remove.append(ref)
+    for ref in to_remove:
+        episodes_in_progress.remove(ref)
 
 
 def run_sequentially(
     exp: Experiment,
     debug_limit: int | None = None,
+    *,
+    max_retry_rounds: int = 3,
+    step_timeout_s: float = 1800.0,
+    cancel_grace_s: float = 120.0,
+    orphan_threshold_s: float = 3600.0,
     otlp_endpoint: str | None = None,
     model: str | None = None,
     agent_name: str | None = None,
@@ -180,31 +331,103 @@ def run_sequentially(
 
     try:
         with tracer.benchmark(exp.name):
-            return _run_sequentially_impl(exp, debug_limit)
+            return _run_sequentially_with_retries(
+                exp,
+                debug_limit=debug_limit,
+                max_retry_rounds=max_retry_rounds,
+                step_timeout_s=step_timeout_s,
+                cancel_grace_s=cancel_grace_s,
+                orphan_threshold_s=orphan_threshold_s,
+            )
     finally:
         tracer.shutdown()
 
 
-def _run_sequentially_impl(exp: Experiment, debug_limit: int | None) -> ExpResult:
+def _run_sequentially_with_retries(
+    exp: Experiment,
+    *,
+    debug_limit: int | None,
+    max_retry_rounds: int,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    orphan_threshold_s: float,
+) -> ExpResult:
+    aggregated = ExpResult(tasks_num=0, config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
+    original_resume = exp.resume
+    original_retry_failed = exp.retry_failed
+    try:
+        round_num = 0
+        while True:
+            round_result = _run_sequentially_impl(
+                exp,
+                debug_limit=debug_limit,
+                step_timeout_s=step_timeout_s,
+                cancel_grace_s=cancel_grace_s,
+                orphan_threshold_s=orphan_threshold_s,
+            )
+            aggregated.tasks_num = max(aggregated.tasks_num, round_result.tasks_num)
+            aggregated.trajectories.update(round_result.trajectories)
+            for k, v in round_result.failures.items():
+                aggregated.failures[k] = v
+            for k in round_result.trajectories:
+                aggregated.failures.pop(k, None)
+
+            if round_num >= max_retry_rounds:
+                break
+
+            storage = FileStorage(exp.output_dir)
+            statuses = storage.list_episode_statuses()
+            has_retriable = any(
+                s.status in ("FAILED", "CANCELLED", "STALE") and s.retry_count < exp.max_retries
+                for s in statuses.values()
+            )
+            if not has_retriable:
+                break
+
+            round_num += 1
+            logger.info(f"Auto-retry round {round_num}/{max_retry_rounds}: re-running retriable episodes")
+            exp.resume = False
+            exp.retry_failed = True
+        return aggregated
+    finally:
+        exp.resume = original_resume
+        exp.retry_failed = original_retry_failed
+
+
+def _run_sequentially_impl(
+    exp: Experiment,
+    *,
+    debug_limit: int | None,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    orphan_threshold_s: float,
+) -> ExpResult:
     exp.save_config()
     exp.benchmark.setup()
     try:
-        episodes = exp.get_episodes_to_run()
+        episodes = exp.get_episodes_to_run(
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+            orphan_threshold_s=orphan_threshold_s,
+        )
         if debug_limit is not None:
             logger.info(f"Running only first {debug_limit} episodes for debugging")
             episodes = episodes[:debug_limit]
-        trajectories = []
-        for episode in episodes:
-            trajectory_id = trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
-            log_file = get_log_path(exp.output_dir, trajectory_id)
-            with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
-                trajectories.append(episode.run())
         results = ExpResult(
             tasks_num=len(episodes),
-            trajectories={traj.metadata["task_id"]: traj for traj in trajectories},
             config=exp.config,
             exp_id=f"{exp.name}_{uuid4().hex}",
         )
+        for episode in episodes:
+            traj_id = _trajectory_id(episode)
+            log_file = get_log_path(exp.output_dir, traj_id)
+            with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
+                try:
+                    trajectory = episode.run()
+                    results.trajectories[traj_id] = trajectory
+                except Exception as e:
+                    logger.exception(f"Episode {traj_id} failed")
+                    results.failures[traj_id] = str(e)
         exp.print_stats(results)
         return results
     finally:

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -426,16 +426,20 @@ def _run_sequentially_impl(
 ) -> ExpResult:
     """Run a single sequential round in-process, returning trajectories and failures for this round."""
     exp.save_config()
+    storage = FileStorage(exp.output_dir)
     exp.benchmark.setup()
     try:
-        episodes = exp.get_episodes_to_run(
+        all_episodes = exp.get_episodes_to_run(
             step_timeout_s=step_timeout_s,
             cancel_grace_s=cancel_grace_s,
             orphan_threshold_s=orphan_threshold_s,
         )
+        for episode in all_episodes:
+            _pre_claim(storage, episode)
         if debug_limit is not None:
             logger.info(f"Running only first {debug_limit} episodes for debugging")
-            episodes = episodes[:debug_limit]
+        episodes = all_episodes[:debug_limit] if debug_limit is not None else all_episodes
+
         results = ExpResult(
             tasks_num=len(episodes),
             config=exp.config,

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -304,6 +304,15 @@ def _kill_stale_workers(
             ray.cancel(ref, force=True)
         except Exception:
             logger.exception(f"ray.cancel failed for {traj_id}")
+
+        # Re-read just before overwriting: between the staleness check above and
+        # this point, the worker may have written a terminal status (legitimate
+        # COMPLETED/FAILED). Don't clobber it — only stamp CANCELLED if we still
+        # see RUNNING.
+        fresh = storage.read_episode_status(traj_id)
+        if fresh is not None and fresh.status != "RUNNING":
+            to_remove.append(ref)
+            continue
         status.status = "CANCELLED"
         status.ended_at = now
         status.error_type = "StepTimeout"

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -12,7 +12,7 @@ from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_
 from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
-from cube_harness.storage import FileStorage
+from cube_harness.storage import FileStorage, Storage
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ def _trajectory_id(episode: Episode) -> str:
     return trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
 
 
-def _pre_claim(storage: FileStorage, episode: Episode) -> None:
+def _pre_claim(storage: Storage, episode: Episode) -> None:
     """Write `QUEUED` for an episode before submitting it to Ray.
 
     `QUEUED` distinguishes "submitted to Ray, waiting for a worker" from
@@ -42,9 +42,7 @@ def _pre_claim(storage: FileStorage, episode: Episode) -> None:
     traj_id = _trajectory_id(episode)
     prior = storage.read_episode_status(traj_id)
     if prior is not None and prior.status in TERMINAL_STATUSES:
-        ep_dir = storage._episode_dir(traj_id)
-        if ep_dir.exists():
-            storage._archive_episode(ep_dir)
+        storage.archive_episode(traj_id)
     storage.write_episode_status(
         traj_id,
         EpisodeStatus(
@@ -434,11 +432,11 @@ def _run_sequentially_impl(
             cancel_grace_s=cancel_grace_s,
             orphan_threshold_s=orphan_threshold_s,
         )
-        for episode in all_episodes:
-            _pre_claim(storage, episode)
         if debug_limit is not None:
             logger.info(f"Running only first {debug_limit} episodes for debugging")
         episodes = all_episodes[:debug_limit] if debug_limit is not None else all_episodes
+        for episode in episodes:
+            _pre_claim(storage, episode)
 
         results = ExpResult(
             tasks_num=len(episodes),

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -20,11 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def _extract_model(exp: Experiment) -> str | None:
+    """Return the LLM model name from the agent config, if any (for tracing/labeling)."""
     llm_config = getattr(exp.agent_config, "llm_config", None)
     return llm_config.model_name if llm_config else None
 
 
 def _trajectory_id(episode: Episode) -> str:
+    """Build the canonical trajectory id `{task_id}_ep{episode_id}` for an Episode."""
     return trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
 
 
@@ -67,6 +69,7 @@ def run_with_ray(
     model: str | None = None,
     agent_name: str | None = None,
 ) -> ExpResult:
+    """Run `exp` in parallel on Ray, with auto-retry rounds and step-timeout enforcement."""
     model = model or _extract_model(exp)
     tracer = get_tracer(
         exp.name,
@@ -154,12 +157,14 @@ def _run_with_ray_impl(
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> ExpResult:
+    """Run a single Ray round: pre-claim, submit, poll with step-timeout, sweep stale on shutdown."""
     exp.save_config()
     output_dir = exp.output_dir
     storage = FileStorage(output_dir)
 
     @ray.remote
     def run_episode(episode: Episode) -> Trajectory:
+        """Ray entry point: redirect logs to the episode's log file and run the episode."""
         traj_id = _trajectory_id(episode)
         log_file = get_log_path(output_dir, traj_id)
         with redirect_output_to_log(log_file, append=True, tee=False, log_format=LOG_FORMAT):
@@ -224,6 +229,7 @@ def _poll_ray(
     step_timeout_s: float,
     cancel_grace_s: float,
 ) -> ExpResult:
+    """Wait on Ray refs, collecting trajectories/failures and force-killing workers with stale heartbeats."""
     results = ExpResult(tasks_num=len(ref_to_traj_id), config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     completed = 0
     episodes_in_progress = list(ref_to_traj_id.keys())
@@ -321,6 +327,7 @@ def run_sequentially(
     model: str | None = None,
     agent_name: str | None = None,
 ) -> ExpResult:
+    """Run `exp` in-process (no Ray) with auto-retry rounds — the debug-friendly path."""
     model = model or _extract_model(exp)
     tracer = get_tracer(
         exp.name,
@@ -352,6 +359,7 @@ def _run_sequentially_with_retries(
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> ExpResult:
+    """Run sequential rounds back-to-back, replaying retriable failures up to `max_retry_rounds`."""
     aggregated = ExpResult(tasks_num=0, config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     original_resume = exp.resume
     original_retry_failed = exp.retry_failed
@@ -402,6 +410,7 @@ def _run_sequentially_impl(
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> ExpResult:
+    """Run a single sequential round in-process, returning trajectories and failures for this round."""
     exp.save_config()
     exp.benchmark.setup()
     try:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
 from cube_harness.episode import MAX_STEPS, Episode
+from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
 from cube_harness.storage import FileStorage
 
@@ -160,7 +161,7 @@ class Experiment(TypedBaseModel):
         parsed = self._parse_episode_config_filename(config_file)
         if parsed:
             episode_id, task_id = parsed
-            return f"{task_id}_ep{episode_id}"
+            return trajectory_log_id(task_id, episode_id)
         return None
 
     def _parse_episode_config_filename(self, config_file: Path) -> tuple[int, str] | None:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -236,12 +236,3 @@ def sweep_stale_statuses(
         swept.append(trajectory_id)
         logger.warning(f"Swept stale {prior_state} -> STALE for {trajectory_id}")
     return swept
-
-
-def is_retriable(status: EpisodeStatus | None, max_retries: int) -> bool:
-    """Standalone helper: True if a status (or missing status) qualifies for retry."""
-    if status is None:
-        return True
-    if status.status not in RETRIABLE_STATUSES:
-        return False
-    return status.retry_count < max_retries

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -1,15 +1,17 @@
 import json
 import logging
+import time
 from pathlib import Path
 from typing import Self
 
 from cube.benchmark import Benchmark
-from cube.core import EnvironmentOutput, TypedBaseModel
+from cube.core import TypedBaseModel
 from pydantic import Field
 
 from cube_harness.agent import AgentConfig
-from cube_harness.core import AgentOutput, Trajectory
+from cube_harness.core import Trajectory
 from cube_harness.episode import MAX_STEPS, Episode
+from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
 from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
@@ -31,18 +33,31 @@ class Experiment(TypedBaseModel):
     resume: bool = False
     retry_failed: bool = False
     max_steps: int = MAX_STEPS
+    max_retries: int = 3
 
     @property
     def config(self) -> dict:
         return self.model_dump(serialize_as_any=True)
 
-    def get_episodes_to_run(self) -> list[Episode]:
+    def get_episodes_to_run(
+        self,
+        *,
+        step_timeout_s: float = 1800.0,
+        cancel_grace_s: float = 120.0,
+        orphan_threshold_s: float = 3600.0,
+    ) -> list[Episode]:
         """Get episodes to run based on resume/retry_failed flags.
 
+        Decisions are driven by `status.json` per episode (no trajectory deserialisation).
+
         - Neither flag set: creates all episodes from scratch.
-        - resume=True: returns only unstarted episodes (have configs but no trajectory files).
-        - retry_failed=True: returns only failed episodes (started but not successful).
-        - Both flags: returns unstarted + failed episodes.
+        - resume=True: episodes with no status.json (never started).
+        - retry_failed=True: episodes with status in {FAILED, STALE, CANCELLED}, OR
+          missing status.json, gated by `retry_count < max_retries`.
+        - Both flags: union.
+
+        `RUNNING` (with fresh heartbeat) is never returned. Stale `RUNNING` entries are
+        first swept to `STALE` so they become eligible for retry.
         """
         if not self.resume and not self.retry_failed:
             return self._create_all_episodes()
@@ -53,24 +68,54 @@ class Experiment(TypedBaseModel):
             logger.warning(f"No episode configs found in {self.output_dir}, creating from scratch")
             return self._create_all_episodes()
 
-        started_ids = self._load_started_trajectory_ids()
+        # Sweep stale RUNNING entries first so they show up as STALE in retry selection.
+        sweep_stale_statuses(
+            storage,
+            step_timeout_s=step_timeout_s,
+            cancel_grace_s=cancel_grace_s,
+            orphan_threshold_s=orphan_threshold_s,
+        )
+
+        statuses = storage.list_episode_statuses()
         episodes: list[Episode] = []
 
-        if self.resume:
-            unstarted = self._find_episodes_to_relaunch(config_files, started_ids, include=False)
-            logger.info(f"Resuming: {len(unstarted)} unstarted episodes (out of {len(config_files)} total)")
-            episodes.extend(unstarted)
+        for config_file in config_files:
+            trajectory_id = self._trajectory_id_from_config(config_file)
+            if trajectory_id is None:
+                logger.warning(f"Could not parse task_id from config filename: {config_file.name}")
+                continue
+            status = statuses.get(trajectory_id)
+            if not self._should_relaunch(status):
+                continue
+            try:
+                episode = Episode.load_episode_from_config(config_file, self.benchmark)
+            except Exception:
+                logger.exception(f"Failed to load episode config {config_file}")
+                continue
+            # Existing trajectory (if any) will be archived on the next save_trajectory.
+            episode.allow_overwrite = status is not None
+            episodes.append(episode)
 
-        if self.retry_failed:
-            successful_ids = self._load_successful_trajectory_ids(storage)
-            failed_ids = started_ids - successful_ids
-            failed = self._find_episodes_to_relaunch(config_files, failed_ids, include=True)
-            for episode in failed:
-                episode.allow_overwrite = True  # Allow overwriting existing trajectory since this is a retried episode
-            logger.info(f"Retrying: {len(failed)} failed episodes (out of {len(config_files)} total)")
-            episodes.extend(failed)
-
+        logger.info(
+            f"Selected {len(episodes)} episode(s) to run (out of {len(config_files)} total) "
+            f"with resume={self.resume}, retry_failed={self.retry_failed}"
+        )
         return episodes
+
+    def _should_relaunch(self, status: EpisodeStatus | None) -> bool:
+        # Missing status.json
+        if status is None:
+            # resume picks it up unconditionally; retry_failed gates by max_retries
+            # but with retry_count=0 (the default) it always passes for missing status.
+            return self.resume or self.retry_failed
+        if status.status == "RUNNING":
+            return False  # alive (sweep ran first; surviving RUNNING is fresh)
+        if status.status == "COMPLETED":
+            return False
+        # FAILED / CANCELLED / STALE
+        if not self.retry_failed:
+            return False
+        return status.retry_count < self.max_retries
 
     def _create_all_episodes(self) -> list[Episode]:
         """Create all episodes from scratch and save their configs to disk."""
@@ -111,7 +156,6 @@ class Experiment(TypedBaseModel):
     def _trajectory_id_from_config(self, config_file: Path) -> str | None:
         """Return trajectory_id for a config file, handling both V2 and V1 filename formats."""
         if config_file.name == "episode_config.json":
-            # V2: trajectory_id is the parent directory name
             return config_file.parent.name
         parsed = self._parse_episode_config_filename(config_file)
         if parsed:
@@ -128,15 +172,10 @@ class Experiment(TypedBaseModel):
 
         Returns:
             Tuple of (episode_id, task_id) if parsing succeeds, None otherwise.
-            The episode_id is extracted from the filename prefix.
         """
-        # Extract task_id from filename: episode_{id}_task_{task_id}.json
-        # Use split with maxsplit=1 to handle task_ids that contain "_task_"
-        # Split from left so we only split on the FIRST "_task_" (the delimiter)
         parts = config_file.stem.split("_task_", 1)
         if len(parts) == 2:
             try:
-                # Extract episode id from "episode_{id}"
                 episode_id_str = parts[0].replace("episode_", "")
                 episode_id = int(episode_id_str)
                 task_id = parts[1]
@@ -144,63 +183,6 @@ class Experiment(TypedBaseModel):
             except (ValueError, AttributeError):
                 return None
         return None
-
-    def _is_trajectory_successful(self, trajectory: Trajectory) -> bool:
-        """Check if a trajectory completed successfully.
-
-        A trajectory is successful if the last env step has done=True and no steps contain errors.
-        """
-        last_env_step = trajectory.last_env_step()
-        for step in trajectory.steps:
-            if isinstance(step.output, (EnvironmentOutput, AgentOutput)) and step.output.error:
-                return False
-        return last_env_step.done
-
-    def _load_successful_trajectory_ids(self, storage: FileStorage) -> set[str]:
-        successful = set()
-        for trajectory_id in storage.list_trajectory_ids():
-            try:
-                trajectory = storage.load_trajectory(trajectory_id)
-                if self._is_trajectory_successful(trajectory):
-                    successful.add(trajectory_id)
-            except Exception as e:
-                logger.debug(f"Failed to load trajectory {trajectory_id}: {e}")
-        return successful
-
-    def _load_started_trajectory_ids(self) -> set[str]:
-        storage = FileStorage(self.output_dir)
-        return set(storage.list_trajectory_ids())
-
-    def _find_episodes_to_relaunch(
-        self, config_files: list[Path], filter_trajectory_ids: set[str], include: bool = True
-    ) -> list[Episode]:
-        """Find episodes to relaunch based on trajectory ID filter.
-
-        Args:
-            config_files: List of episode config file paths.
-            filter_trajectory_ids: Set of trajectory IDs to filter by.
-            include: If True, include episodes whose trajectory ID is in the set.
-                    If False, exclude episodes whose trajectory ID is in the set.
-
-        Returns:
-            List of Episode objects to relaunch.
-        """
-        episodes = []
-        for config_file in config_files:
-            trajectory_id = self._trajectory_id_from_config(config_file)
-            if trajectory_id:
-                should_include = (
-                    trajectory_id in filter_trajectory_ids if include else trajectory_id not in filter_trajectory_ids
-                )
-                if should_include:
-                    try:
-                        episode = Episode.load_episode_from_config(config_file, self.benchmark)
-                        episodes.append(episode)
-                    except Exception as e:
-                        logger.exception(f"Failed to load episode config {config_file}: {e}")
-            else:
-                logger.warning(f"Could not parse task_id from config filename: {config_file.name}")
-        return episodes
 
     def print_stats(self, results: ExpResult) -> None:
         if not results.trajectories:
@@ -222,3 +204,54 @@ class Experiment(TypedBaseModel):
         logger.info(f"  Accuracy (avg. final reward): {accuracy:.4f}")
         logger.info(f"  Failed tasks: {len(results.failures)}")
         logger.info(f"Saved to: {self.output_dir}")
+
+
+def sweep_stale_statuses(
+    storage: FileStorage,
+    *,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    orphan_threshold_s: float,
+) -> list[str]:
+    """Mark `RUNNING` episodes whose worker is dead as `STALE`.
+
+    A `RUNNING` entry is stale if either:
+    - `last_heartbeat_at` is set and older than `step_timeout_s + cancel_grace_s`, or
+    - `last_heartbeat_at` is `None` (queued but never picked up) and `started_at` is
+      older than `orphan_threshold_s`.
+
+    Returns the list of trajectory_ids that were swept.
+    """
+    now = time.time()
+    swept: list[str] = []
+    for trajectory_id, status in storage.list_episode_statuses().items():
+        if status.status != "RUNNING":
+            continue
+        is_stale = False
+        if status.last_heartbeat_at is not None:
+            if now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s:
+                is_stale = True
+        else:
+            if now - status.started_at > orphan_threshold_s:
+                is_stale = True
+        if not is_stale:
+            continue
+        status.status = "STALE"
+        status.ended_at = now
+        status.error_type = status.error_type or "WorkerDied"
+        status.error_message = status.error_message or (
+            "Worker died without writing terminal status (no fresh heartbeat)"
+        )
+        storage.write_episode_status(trajectory_id, status)
+        swept.append(trajectory_id)
+        logger.warning(f"Swept stale RUNNING -> STALE for {trajectory_id}")
+    return swept
+
+
+def is_retriable(status: EpisodeStatus | None, max_retries: int) -> bool:
+    """Standalone helper: True if a status (or missing status) qualifies for retry."""
+    if status is None:
+        return True
+    if status.status not in RETRIABLE_STATUSES:
+        return False
+    return status.retry_count < max_retries

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -32,7 +32,6 @@ class Experiment(TypedBaseModel):
     agent_config: AgentConfig
     benchmark: Benchmark
     resume: bool = False
-    retry_failed: bool = False
     max_steps: int = MAX_STEPS
     max_retries: int = 3
 
@@ -47,20 +46,18 @@ class Experiment(TypedBaseModel):
         cancel_grace_s: float = 120.0,
         orphan_threshold_s: float = 3600.0,
     ) -> list[Episode]:
-        """Get episodes to run based on resume/retry_failed flags.
+        """Return episodes to run based on `resume`.
 
         Decisions are driven by `status.json` per episode (no trajectory deserialisation).
 
-        - Neither flag set: creates all episodes from scratch.
-        - resume=True: episodes with no status.json (never started).
-        - retry_failed=True: episodes with status in {FAILED, STALE, CANCELLED}, OR
-          missing status.json, gated by `retry_count < max_retries`.
-        - Both flags: union.
-
-        `RUNNING` (with fresh heartbeat) is never returned. Stale `RUNNING` entries are
-        first swept to `STALE` so they become eligible for retry.
+        - `resume=False`: create all episodes from scratch (any prior data is archived
+          per-attempt by pre-claim / save_trajectory).
+        - `resume=True`: pick up everything that's not COMPLETED (or MAX_STEPS_REACHED) —
+          unstarted (no status.json) plus retriable failures (FAILED / STALE /
+          CANCELLED), gated by `retry_count < max_retries`. Stale `RUNNING` entries are
+          swept to `STALE` first so they become eligible.
         """
-        if not self.resume and not self.retry_failed:
+        if not self.resume:
             return self._create_all_episodes()
 
         storage = FileStorage(self.output_dir)
@@ -97,24 +94,15 @@ class Experiment(TypedBaseModel):
             episode.allow_overwrite = status is not None
             episodes.append(episode)
 
-        logger.info(
-            f"Selected {len(episodes)} episode(s) to run (out of {len(config_files)} total) "
-            f"with resume={self.resume}, retry_failed={self.retry_failed}"
-        )
+        logger.info(f"Selected {len(episodes)} episode(s) to run (out of {len(config_files)} total) with resume=True")
         return episodes
 
     def _should_relaunch(self, status: EpisodeStatus | None) -> bool:
-        # Missing status.json
+        """True iff `resume=True` should re-run this episode (status-driven)."""
         if status is None:
-            # resume picks it up unconditionally; retry_failed gates by max_retries
-            # but with retry_count=0 (the default) it always passes for missing status.
-            return self.resume or self.retry_failed
-        if status.status == "RUNNING":
-            return False  # alive (sweep ran first; surviving RUNNING is fresh)
-        if status.status == "COMPLETED":
-            return False
-        # FAILED / CANCELLED / STALE
-        if not self.retry_failed:
+            return True  # never started → run it
+        if status.status not in RETRIABLE_STATUSES:
+            # COMPLETED / MAX_STEPS_REACHED / in-flight (QUEUED, RUNNING) → leave alone
             return False
         return status.retry_count < self.max_retries
 
@@ -214,29 +202,30 @@ def sweep_stale_statuses(
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> list[str]:
-    """Mark `RUNNING` episodes whose worker is dead as `STALE`.
+    """Mark in-flight episodes whose worker is dead as `STALE`.
 
-    A `RUNNING` entry is stale if either:
-    - `last_heartbeat_at` is set and older than `step_timeout_s + cancel_grace_s`, or
-    - `last_heartbeat_at` is `None` (queued but never picked up) and `started_at` is
-      older than `orphan_threshold_s`.
+    Two cases:
+    - `RUNNING` with `last_heartbeat_at` older than `step_timeout_s + cancel_grace_s`
+      (worker died mid-episode without writing a terminal status).
+    - `QUEUED` with `started_at` older than `orphan_threshold_s` (driver pre-claimed
+      but Ray never picked the episode up — typically because the prior driver
+      crashed before the worker started).
 
     Returns the list of trajectory_ids that were swept.
     """
     now = time.time()
     swept: list[str] = []
     for trajectory_id, status in storage.list_episode_statuses().items():
-        if status.status != "RUNNING":
-            continue
         is_stale = False
-        if status.last_heartbeat_at is not None:
+        if status.status == "RUNNING" and status.last_heartbeat_at is not None:
             if now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s:
                 is_stale = True
-        else:
+        elif status.status == "QUEUED":
             if now - status.started_at > orphan_threshold_s:
                 is_stale = True
         if not is_stale:
             continue
+        prior_state = status.status
         status.status = "STALE"
         status.ended_at = now
         status.error_type = status.error_type or "WorkerDied"
@@ -245,7 +234,7 @@ def sweep_stale_statuses(
         )
         storage.write_episode_status(trajectory_id, status)
         swept.append(trajectory_id)
-        logger.warning(f"Swept stale RUNNING -> STALE for {trajectory_id}")
+        logger.warning(f"Swept stale {prior_state} -> STALE for {trajectory_id}")
     return swept
 
 

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -46,6 +46,8 @@ class Storage(Protocol):
 
     def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
 
+    def archive_episode(self, trajectory_id: str) -> None: ...
+
 
 _thread_local = threading.local()
 
@@ -171,6 +173,12 @@ class FileStorage:
         archived = ep_dir.parent / f"{ep_dir.name}{ARCHIVED_MARKER}{time.time()}"
         ep_dir.rename(archived)
         logger.info(f"Archived {ep_dir.name} -> {archived.name}")
+
+    def archive_episode(self, trajectory_id: str) -> None:
+        """Archive the episode directory for a terminal attempt, preserving its history."""
+        ep_dir = self._episode_dir(trajectory_id)
+        if ep_dir.exists():
+            self._archive_episode(ep_dir)
 
     def save_step(self, step: TrajectoryStep, trajectory_id: str, step_num: int) -> None:
         ep_dir = self._episode_dir(trajectory_id)

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import get_log_path as get_episode_log_path
+from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
 
 if TYPE_CHECKING:
@@ -492,7 +493,7 @@ class FileStorage:
         return stubs
 
     def save_episode_config(self, episode_config: "EpisodeConfig") -> None:
-        traj_id = f"{episode_config.task_config.task_id}_ep{episode_config.id}"
+        traj_id = trajectory_log_id(episode_config.task_config.task_id, episode_config.id)
         ep_dir = self._episode_dir(traj_id)
         ep_dir.mkdir(parents=True, exist_ok=True)
         config_path = ep_dir / "episode_config.json"

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import get_log_path as get_episode_log_path
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
 
 if TYPE_CHECKING:
     from cube_harness.episode import EpisodeConfig
@@ -39,6 +40,10 @@ class Storage(Protocol):
     def save_episode_config(self, episode_config: "EpisodeConfig") -> None: ...
 
     def update_experiment_summary(self, trajectory: Trajectory) -> None: ...
+
+    def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None: ...
+
+    def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None: ...
 
 
 _thread_local = threading.local()
@@ -517,3 +522,23 @@ class FileStorage:
         v1_config_dir = self.output_dir / "episode_configs"
         v1_configs = list(v1_config_dir.glob("episode_*_task_*.json")) if v1_config_dir.exists() else []
         return v2_configs + v1_configs
+
+    # --- Episode status (control plane) ---
+
+    def _episode_status_path(self, trajectory_id: str) -> Path:
+        return self._episode_dir(trajectory_id) / STATUS_FILENAME
+
+    def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None:
+        status.write(self._episode_status_path(trajectory_id))
+
+    def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None:
+        return EpisodeStatus.read(self._episode_status_path(trajectory_id))
+
+    def list_episode_statuses(self) -> dict[str, EpisodeStatus]:
+        """Return {trajectory_id: status} for every non-archived episode dir with a status.json."""
+        result: dict[str, EpisodeStatus] = {}
+        for ep_dir in self._episode_config_dirs():
+            status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
+            if status is not None:
+                result[ep_dir.name] = status
+        return result

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -480,14 +480,14 @@ class TestStatusBasedSelection:
         "status,extra_fields,expect_returned",
         [
             # retriable — resume must include
-            ("FAILED",    {},                     True),
-            ("CANCELLED", {},                     True),
-            ("STALE",     {},                     True),
+            ("FAILED", {}, True),
+            ("CANCELLED", {}, True),
+            ("STALE", {}, True),
             # terminal non-retriable — resume must skip
-            ("COMPLETED",         {"reward": 1.0, "ended_at": 0}, False),
+            ("COMPLETED", {"reward": 1.0, "ended_at": 0}, False),
             ("MAX_STEPS_REACHED", {"reward": 0.0, "ended_at": 0}, False),
             # in-flight — resume must skip (not swept; fresh timestamps)
-            ("QUEUED",  {},                       False),
+            ("QUEUED", {}, False),
             ("RUNNING", {"last_heartbeat_at": 0}, False),
         ],
         ids=["failed", "cancelled", "stale", "completed", "max-steps-reached", "queued", "running"],
@@ -596,9 +596,9 @@ class TestStatusBasedSelection:
             storage.write_episode_status(traj_id, s)
 
         final = storage.read_episode_status(traj_id)
-        assert final.status == "RUNNING"       # status unchanged
-        assert final.current_step == 2         # advanced through two turns
-        assert final.last_heartbeat_at > t0    # heartbeat is newer than start
+        assert final.status == "RUNNING"  # status unchanged
+        assert final.current_step == 2  # advanced through two turns
+        assert final.last_heartbeat_at > t0  # heartbeat is newer than start
 
     def test_cancelled_at_max_retries_cap_is_terminal(self, tmp_dir, mock_agent_config):
         """CANCELLED → terminal: retry_count >= max_retries excludes from retry selection."""
@@ -821,9 +821,11 @@ class TestKillStaleWorkersRaceGuard:
         episodes_in_progress = [fake_ref]
 
         # First read: stale RUNNING. Second read (after ray.cancel): COMPLETED.
-        with patch("cube_harness.exp_runner.ray.cancel") as mock_cancel, patch.object(
-            storage, "read_episode_status", side_effect=[stale_status, completed_status]
-        ), patch.object(storage, "write_episode_status") as mock_write:
+        with (
+            patch("cube_harness.exp_runner.ray.cancel") as mock_cancel,
+            patch.object(storage, "read_episode_status", side_effect=[stale_status, completed_status]),
+            patch.object(storage, "write_episode_status") as mock_write,
+        ):
             _kill_stale_workers(
                 episodes_in_progress,
                 ref_to_traj_id,
@@ -856,9 +858,11 @@ class TestKillStaleWorkersRaceGuard:
         episodes_in_progress = [fake_ref]
 
         # Both reads return RUNNING — worker never wrote a terminal status.
-        with patch("cube_harness.exp_runner.ray.cancel"), patch.object(
-            storage, "read_episode_status", side_effect=[stale_status, stale_status]
-        ), patch.object(storage, "write_episode_status") as mock_write:
+        with (
+            patch("cube_harness.exp_runner.ray.cancel"),
+            patch.object(storage, "read_episode_status", side_effect=[stale_status, stale_status]),
+            patch.object(storage, "write_episode_status") as mock_write,
+        ):
             _kill_stale_workers(
                 episodes_in_progress,
                 ref_to_traj_id,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -530,11 +530,12 @@ class TestStatusBasedSelection:
         else:
             assert result == []
 
-    def test_sequential_pre_claims_all_episodes_as_queued_before_loop(self, tmp_dir, mock_agent_config):
-        """Sequential mode pre-claims all episodes as QUEUED before the loop starts.
+    def test_sequential_pre_claims_only_episodes_that_will_run(self, tmp_dir, mock_agent_config) -> None:
+        """Sequential mode pre-claims only the episodes that will actually run.
 
-        All waiting episodes must have status.json=QUEUED from the start so a crash
-        mid-run leaves them distinguishable from episodes that were never submitted.
+        With debug_limit=1, only 1 of 3 episodes should be pre-claimed. The other 2
+        must have no status.json — they were never submitted, so a resume run can pick
+        them up without waiting for orphan_threshold_s to expire.
         """
         benchmark = _make_benchmark(3)
         exp = Experiment(
@@ -547,19 +548,43 @@ class TestStatusBasedSelection:
 
         run_sequentially(exp, debug_limit=1)
 
-        # All 3 episodes must have a status.json — not just the one that ran.
+        # Only the 1 episode that ran should have a status.json.
         all_statuses = storage.list_episode_statuses()
-        assert len(all_statuses) == 3, (
-            f"Expected all 3 episodes pre-claimed, got {len(all_statuses)}: {list(all_statuses)}"
+        assert len(all_statuses) == 1, (
+            f"Expected only 1 episode pre-claimed (debug_limit=1), got {len(all_statuses)}: {list(all_statuses)}"
         )
 
-        # The episode that ran should be COMPLETED.
+        # That episode should be COMPLETED.
         completed = [tid for tid, s in all_statuses.items() if s.status == "COMPLETED"]
         assert len(completed) == 1
 
-        # The two that didn't run should be QUEUED (pre-claimed but not started).
+    def test_debug_limit_orphans_do_not_block_resume(self, tmp_dir, mock_agent_config) -> None:
+        """Episodes beyond debug_limit must not appear as QUEUED orphans that block resumption.
+
+        Before the fix, all episodes were pre-claimed as QUEUED before debug_limit slicing.
+        QUEUED is not in RETRIABLE_STATUSES, so those orphans would be silently skipped on
+        a resume=True run until orphan_threshold_s elapsed.
+        """
+        benchmark = _make_benchmark(3)
+        exp = Experiment(
+            name="test_debug_orphan",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        storage = FileStorage(tmp_dir)
+
+        run_sequentially(exp, debug_limit=1)
+
+        # Confirm no QUEUED orphans exist for the un-run episodes.
+        all_statuses = storage.list_episode_statuses()
         queued = [tid for tid, s in all_statuses.items() if s.status == "QUEUED"]
-        assert len(queued) == 2
+        assert queued == [], f"Found orphaned QUEUED episodes that would block resume: {queued}"
+
+        # resume=True should find 2 episodes to run (the ones that weren't debug-limited).
+        exp.resume = True
+        episodes_to_resume = exp.get_episodes_to_run()
+        assert len(episodes_to_resume) == 2, f"Expected 2 episodes available for resume, got {len(episodes_to_resume)}"
 
     def test_heartbeat_advances_current_step_and_timestamp(self, tmp_dir, mock_agent_config):
         """RUNNING → RUNNING: each turn updates last_heartbeat_at and current_step without changing status."""

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -217,7 +217,7 @@ class TestExperiment:
         assert actual_task_ids == expected_task_ids
 
     def test_retry_failed_episodes(self, tmp_dir, mock_agent_config):
-        """retry_failed=True returns FAILED + missing-status episodes (gated by max_retries)."""
+        """resume=True returns FAILED + missing-status episodes (gated by max_retries)."""
         benchmark = _make_benchmark(3)
 
         exp = Experiment(
@@ -252,7 +252,7 @@ class TestExperiment:
 
         # Episode 2: no status.json (never started)
 
-        exp.retry_failed = True
+        exp.resume = True
         failed_episodes = exp.get_episodes_to_run()
         # Both episode 1 (FAILED) and episode 2 (missing status) qualify
         ids = {ep.config.id for ep in failed_episodes}
@@ -292,7 +292,7 @@ class TestExperiment:
                 retry_count=1,
             ),
         )
-        exp.retry_failed = True
+        exp.resume = True
         retried = exp.get_episodes_to_run()
         ids = {ep.config.id for ep in retried}
         assert ids == {episodes[1].config.id}
@@ -336,7 +336,7 @@ class TestExperiment:
         assert result.failures == {}
 
     def test_resume_and_retry_empty_when_all_succeeded(self, tmp_dir, mock_agent_config, mock_cube_benchmark):
-        """Test resume and retry_failed return empty when all episodes succeeded."""
+        """resume returns empty when all episodes succeeded."""
         exp = Experiment(
             name="test_no_relaunch",
             output_dir=tmp_dir,
@@ -350,7 +350,7 @@ class TestExperiment:
             episode.run()
 
         exp.resume = True
-        exp.retry_failed = True
+        exp.resume = True
         assert exp.get_episodes_to_run() == []
 
 
@@ -389,10 +389,67 @@ class TestStatusBasedSelection:
         assert status is not None
         assert status.status == "STALE"
 
-        exp.retry_failed = True
+        exp.resume = True
         retried = exp.get_episodes_to_run(step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
         assert len(retried) == 1
         assert retried[0].config.id == episodes[0].config.id
+
+    def test_queued_orphan_swept_to_stale(self, tmp_dir, mock_agent_config):
+        """A QUEUED entry older than `orphan_threshold_s` is swept to STALE."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_queued_orphan",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        # QUEUED with started_at way in the past — Ray never picked it up.
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="QUEUED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time() - 7200,
+                last_heartbeat_at=None,
+                current_step=0,
+            ),
+        )
+        swept = sweep_stale_statuses(storage, step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
+        assert swept == [traj_id]
+        assert storage.read_episode_status(traj_id).status == "STALE"
+
+    def test_queued_fresh_not_swept(self, tmp_dir, mock_agent_config):
+        """A QUEUED entry younger than `orphan_threshold_s` is left alone (still queued)."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_queued_fresh",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="QUEUED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                last_heartbeat_at=None,
+                current_step=0,
+            ),
+        )
+        swept = sweep_stale_statuses(storage, step_timeout_s=60.0, cancel_grace_s=60.0, orphan_threshold_s=3600.0)
+        assert swept == []
+        # In-flight (QUEUED) is never returned by resume.
+        exp.resume = True
+        assert exp.get_episodes_to_run() == []
 
     def test_stale_sweep_keeps_fresh_running(self, tmp_dir, mock_agent_config):
         """A RUNNING entry with a fresh heartbeat is left alone."""
@@ -419,16 +476,15 @@ class TestStatusBasedSelection:
         )
         swept = sweep_stale_statuses(storage, step_timeout_s=60.0, cancel_grace_s=60.0, orphan_threshold_s=3600.0)
         assert swept == []
-        # Fresh RUNNING is never returned, even with both flags.
+        # Fresh RUNNING is never returned, even with resume=True.
         exp.resume = True
-        exp.retry_failed = True
         assert exp.get_episodes_to_run() == []
 
-    def test_resume_returns_missing_status_only(self, tmp_dir, mock_agent_config):
-        """resume=True returns episodes whose status.json is absent (never started)."""
+    def test_resume_returns_unstarted_and_failed_skipping_completed(self, tmp_dir, mock_agent_config):
+        """resume=True returns missing-status + retriable failures, skipping COMPLETED."""
         benchmark = _make_benchmark(3)
         exp = Experiment(
-            name="test_resume_missing",
+            name="test_resume_mixed",
             output_dir=tmp_dir,
             agent_config=mock_agent_config,
             benchmark=benchmark,
@@ -448,7 +504,7 @@ class TestStatusBasedSelection:
                 reward=1.0,
             ),
         )
-        # Episode 1: FAILED — should NOT be returned by resume alone
+        # Episode 1: FAILED — SHOULD be returned (resume covers retriable failures)
         storage.write_episode_status(
             f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}",
             EpisodeStatus(
@@ -458,9 +514,38 @@ class TestStatusBasedSelection:
                 started_at=time.time(),
             ),
         )
-        # Episode 2: no status.json — SHOULD be returned by resume
+        # Episode 2: no status.json — SHOULD be returned (never started)
 
         exp.resume = True
         resumed = exp.get_episodes_to_run()
         ids = {ep.config.id for ep in resumed}
-        assert ids == {episodes[2].config.id}
+        assert ids == {episodes[1].config.id, episodes[2].config.id}
+
+    def test_resume_skips_max_steps_reached(self, tmp_dir, mock_agent_config):
+        """resume=True does NOT re-run MAX_STEPS_REACHED — it's a legitimate outcome."""
+        benchmark = _make_benchmark(2)
+        exp = Experiment(
+            name="test_max_steps_skip",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+        # Episode 0: MAX_STEPS_REACHED → skipped on resume
+        storage.write_episode_status(
+            f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}",
+            EpisodeStatus(
+                status="MAX_STEPS_REACHED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                ended_at=time.time(),
+                last_heartbeat_at=time.time(),
+                reward=0.0,
+            ),
+        )
+        # Episode 1: missing → included
+        exp.resume = True
+        resumed = exp.get_episodes_to_run()
+        assert {ep.config.id for ep in resumed} == {episodes[1].config.id}

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,16 +1,18 @@
 """Tests for cube_harness.experiment module."""
 
 import json
+import time
 
 from cube.benchmark import Benchmark as CubeBenchmark
 from cube.benchmark import BenchmarkMetadata
-from cube.core import EnvironmentOutput, Observation, StepError
+from cube.core import EnvironmentOutput, Observation
 from cube.task import TaskMetadata
 
 from cube_harness.core import Trajectory, TrajectoryStep
 from cube_harness.episode import Episode
 from cube_harness.exp_runner import run_sequentially
-from cube_harness.experiment import Experiment, ExpResult
+from cube_harness.episode_status import EpisodeStatus
+from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.storage import FileStorage
 from tests.conftest import MockCubeBenchmark, MockCubeTaskConfig
 
@@ -215,7 +217,7 @@ class TestExperiment:
         assert actual_task_ids == expected_task_ids
 
     def test_retry_failed_episodes(self, tmp_dir, mock_agent_config):
-        """Test retry_failed=True returns only failed episodes."""
+        """retry_failed=True returns FAILED + missing-status episodes (gated by max_retries)."""
         benchmark = _make_benchmark(3)
 
         exp = Experiment(
@@ -225,30 +227,75 @@ class TestExperiment:
             benchmark=benchmark,
         )
 
-        # Create episodes
         episodes = exp.get_episodes_to_run()
 
-        # Run first episode to completion (successful)
+        # Episode 0: complete successfully → COMPLETED status
         episodes[0].run()
 
-        # Simulate failure for second episode by creating a trajectory with error
+        # Episode 1: write a FAILED status manually
         storage = FileStorage(tmp_dir)
-        failed_traj = Trajectory(
-            id=f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}",
-            metadata={"task_id": episodes[1].config.task_config.task_id},
+        traj_id_1 = f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}"
+        storage.write_episode_status(
+            traj_id_1,
+            EpisodeStatus(
+                status="FAILED",
+                task_id=episodes[1].config.task_config.task_id,
+                episode_id=episodes[1].config.id,
+                started_at=time.time() - 10,
+                ended_at=time.time(),
+                last_heartbeat_at=time.time(),
+                error_type="RuntimeError",
+                error_message="boom",
+                retry_count=0,
+            ),
         )
-        obs = Observation.from_text("test")
-        failed_env_output = EnvironmentOutput(obs=obs, error=StepError.from_exception(ValueError("Test error")))
-        failed_traj.steps.append(TrajectoryStep(output=failed_env_output))
-        storage.save_trajectory(failed_traj)
 
-        # Third episode not started (no trajectory)
+        # Episode 2: no status.json (never started)
 
-        # With retry_failed=True, should find only episode 1 as failed
         exp.retry_failed = True
         failed_episodes = exp.get_episodes_to_run()
-        assert len(failed_episodes) == 1
-        assert failed_episodes[0].config.id == episodes[1].config.id
+        # Both episode 1 (FAILED) and episode 2 (missing status) qualify
+        ids = {ep.config.id for ep in failed_episodes}
+        assert ids == {episodes[1].config.id, episodes[2].config.id}
+
+    def test_retry_respects_max_retries(self, tmp_dir, mock_agent_config):
+        """retry_count >= max_retries excludes the episode from retry."""
+        benchmark = _make_benchmark(2)
+        exp = Experiment(
+            name="test_max_retries",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+            max_retries=2,
+        )
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+        # Episode 0: capped (retry_count == max_retries)
+        storage.write_episode_status(
+            f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}",
+            EpisodeStatus(
+                status="FAILED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                retry_count=2,
+            ),
+        )
+        # Episode 1: still under cap
+        storage.write_episode_status(
+            f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}",
+            EpisodeStatus(
+                status="FAILED",
+                task_id=episodes[1].config.task_config.task_id,
+                episode_id=episodes[1].config.id,
+                started_at=time.time(),
+                retry_count=1,
+            ),
+        )
+        exp.retry_failed = True
+        retried = exp.get_episodes_to_run()
+        ids = {ep.config.id for ep in retried}
+        assert ids == {episodes[1].config.id}
 
     def test_resume_returns_unstarted(self, tmp_dir, mock_agent_config):
         """Test resume=True returns only unstarted episodes."""
@@ -305,3 +352,115 @@ class TestExperiment:
         exp.resume = True
         exp.retry_failed = True
         assert exp.get_episodes_to_run() == []
+
+
+class TestStatusBasedSelection:
+    """Focused tests for the status-driven selection logic."""
+
+    def test_stale_sweep_marks_orphaned_running(self, tmp_dir, mock_agent_config):
+        """A RUNNING entry with a stale heartbeat is swept to STALE and becomes retriable."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_stale_sweep",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        # Heartbeat 1 hour ago — older than step_timeout(1s) + cancel_grace(1s)
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="RUNNING",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time() - 3600,
+                last_heartbeat_at=time.time() - 3600,
+                current_step=5,
+                retry_count=0,
+            ),
+        )
+
+        swept = sweep_stale_statuses(storage, step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
+        assert swept == [traj_id]
+        status = storage.read_episode_status(traj_id)
+        assert status is not None
+        assert status.status == "STALE"
+
+        exp.retry_failed = True
+        retried = exp.get_episodes_to_run(step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
+        assert len(retried) == 1
+        assert retried[0].config.id == episodes[0].config.id
+
+    def test_stale_sweep_keeps_fresh_running(self, tmp_dir, mock_agent_config):
+        """A RUNNING entry with a fresh heartbeat is left alone."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_fresh_running",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="RUNNING",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                last_heartbeat_at=time.time(),
+                current_step=1,
+            ),
+        )
+        swept = sweep_stale_statuses(storage, step_timeout_s=60.0, cancel_grace_s=60.0, orphan_threshold_s=3600.0)
+        assert swept == []
+        # Fresh RUNNING is never returned, even with both flags.
+        exp.resume = True
+        exp.retry_failed = True
+        assert exp.get_episodes_to_run() == []
+
+    def test_resume_returns_missing_status_only(self, tmp_dir, mock_agent_config):
+        """resume=True returns episodes whose status.json is absent (never started)."""
+        benchmark = _make_benchmark(3)
+        exp = Experiment(
+            name="test_resume_missing",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+        # Episode 0: COMPLETED — should NOT be returned
+        storage.write_episode_status(
+            f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}",
+            EpisodeStatus(
+                status="COMPLETED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                ended_at=time.time(),
+                last_heartbeat_at=time.time(),
+                reward=1.0,
+            ),
+        )
+        # Episode 1: FAILED — should NOT be returned by resume alone
+        storage.write_episode_status(
+            f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}",
+            EpisodeStatus(
+                status="FAILED",
+                task_id=episodes[1].config.task_config.task_id,
+                episode_id=episodes[1].config.id,
+                started_at=time.time(),
+            ),
+        )
+        # Episode 2: no status.json — SHOULD be returned by resume
+
+        exp.resume = True
+        resumed = exp.get_episodes_to_run()
+        ids = {ep.config.id for ep in resumed}
+        assert ids == {episodes[2].config.id}

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -10,8 +10,8 @@ from cube.task import TaskMetadata
 
 from cube_harness.core import Trajectory, TrajectoryStep
 from cube_harness.episode import Episode
-from cube_harness.exp_runner import run_sequentially
 from cube_harness.episode_status import EpisodeStatus
+from cube_harness.exp_runner import run_sequentially
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.storage import FileStorage
 from tests.conftest import MockCubeBenchmark, MockCubeTaskConfig
@@ -321,7 +321,7 @@ class TestExperiment:
         assert len(resumed_episodes) == 2
 
     def test_run_sequentially(self, tmp_dir, mock_agent_config, mock_cube_benchmark):
-        """run_sequentially completes all episodes and returns trajectories keyed by task_id."""
+        """run_sequentially completes all episodes and returns trajectories keyed by trajectory_id."""
         exp = Experiment(
             name="test_run_sequential",
             output_dir=tmp_dir,
@@ -331,8 +331,10 @@ class TestExperiment:
 
         result = run_sequentially(exp)
 
-        expected_task_ids = set(mock_cube_benchmark.task_metadata.keys())
-        assert set(result.trajectories.keys()) == expected_task_ids
+        expected_trajectory_ids = {
+            f"{ep.config.task_config.task_id}_ep{ep.config.id}" for ep in exp.get_episodes_to_run()
+        }
+        assert set(result.trajectories.keys()) == expected_trajectory_ids
         assert result.failures == {}
 
     def test_resume_and_retry_empty_when_all_succeeded(self, tmp_dir, mock_agent_config, mock_cube_benchmark):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -2,7 +2,9 @@
 
 import json
 import time
+from unittest.mock import MagicMock, patch
 
+import pytest
 from cube.benchmark import Benchmark as CubeBenchmark
 from cube.benchmark import BenchmarkMetadata
 from cube.core import EnvironmentOutput, Observation
@@ -11,10 +13,58 @@ from cube.task import TaskMetadata
 from cube_harness.core import Trajectory, TrajectoryStep
 from cube_harness.episode import Episode
 from cube_harness.episode_status import EpisodeStatus
-from cube_harness.exp_runner import run_sequentially
+from cube_harness.exp_runner import _kill_stale_workers, run_sequentially
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
 from cube_harness.storage import FileStorage
-from tests.conftest import MockCubeBenchmark, MockCubeTaskConfig
+from tests.conftest import MockCubeBenchmark, MockCubeTask, MockCubeTaskConfig, MockToolConfig
+
+
+def _make_failing_benchmark() -> CubeBenchmark:
+    """Benchmark whose single task raises on the first step() call."""
+
+    class _FailingTask(MockCubeTask):
+        def step(self, actions):
+            raise RuntimeError("injected step failure")
+
+    class _FailingTaskConfig(MockCubeTaskConfig):
+        def make(self, runtime_context=None, container_backend=None) -> _FailingTask:
+            from cube.task import TaskMetadata
+
+            return _FailingTask(
+                metadata=TaskMetadata(id=self.task_id),
+                tool_config=self.tool_config or MockToolConfig(),
+            )
+
+    class _FailingBenchmark(MockCubeBenchmark):
+        benchmark_metadata = BenchmarkMetadata(name="failing", version="0.1.0", description="test")
+        task_metadata = {"fail_task_0": TaskMetadata(id="fail_task_0")}
+        task_config_class = _FailingTaskConfig
+
+    return _FailingBenchmark()
+
+
+def _make_neverending_benchmark(max_steps: int) -> CubeBenchmark:
+    """Benchmark whose single task never sets done=True, triggering MAX_STEPS_REACHED."""
+
+    class _NeverDoneTask(MockCubeTask):
+        def step(self, actions):
+            return EnvironmentOutput(obs=Observation.from_text("still going"), reward=0.0, done=False)
+
+    class _NeverDoneTaskConfig(MockCubeTaskConfig):
+        def make(self, runtime_context=None, container_backend=None) -> _NeverDoneTask:
+            from cube.task import TaskMetadata
+
+            return _NeverDoneTask(
+                metadata=TaskMetadata(id=self.task_id),
+                tool_config=self.tool_config or MockToolConfig(),
+            )
+
+    class _NeverDoneBenchmark(MockCubeBenchmark):
+        benchmark_metadata = BenchmarkMetadata(name="neverending", version="0.1.0", description="test")
+        task_metadata = {"never_task_0": TaskMetadata(id="never_task_0")}
+        task_config_class = _NeverDoneTaskConfig
+
+    return _NeverDoneBenchmark()
 
 
 def _make_benchmark(n: int) -> CubeBenchmark:
@@ -359,11 +409,163 @@ class TestExperiment:
 class TestStatusBasedSelection:
     """Focused tests for the status-driven selection logic."""
 
-    def test_stale_sweep_marks_orphaned_running(self, tmp_dir, mock_agent_config):
-        """A RUNNING entry with a stale heartbeat is swept to STALE and becomes retriable."""
+    # ------------------------------------------------------------------
+    # Parametrized sweep: direct sweep_stale_statuses behaviour
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "initial_status,started_age,heartbeat_age,step_timeout,cancel_grace,orphan_threshold,expect_swept",
+        [
+            # RUNNING with stale heartbeat → swept
+            ("RUNNING", 3600, 3600, 1.0, 1.0, 10.0, True),
+            # RUNNING with fresh heartbeat → not swept
+            ("RUNNING", 0, 0, 60.0, 60.0, 3600.0, False),
+            # QUEUED older than orphan_threshold → swept
+            ("QUEUED", 7200, None, 1.0, 1.0, 10.0, True),
+            # QUEUED younger than orphan_threshold → not swept
+            ("QUEUED", 0, None, 60.0, 60.0, 3600.0, False),
+        ],
+        ids=["running-stale", "running-fresh", "queued-orphan", "queued-fresh"],
+    )
+    def test_sweep_stale_statuses(
+        self,
+        tmp_dir: "Path",
+        mock_agent_config: "MockAgentConfig",
+        initial_status: str,
+        started_age: float,
+        heartbeat_age: float | None,
+        step_timeout: float,
+        cancel_grace: float,
+        orphan_threshold: float,
+        expect_swept: bool,
+    ) -> None:
+        """sweep_stale_statuses marks stale in-flight entries STALE and leaves fresh ones alone."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(name="test_sweep", output_dir=tmp_dir, agent_config=mock_agent_config, benchmark=benchmark)
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        now = time.time()
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status=initial_status,
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=now - started_age,
+                last_heartbeat_at=None if heartbeat_age is None else now - heartbeat_age,
+                current_step=0,
+            ),
+        )
+
+        swept = sweep_stale_statuses(
+            storage,
+            step_timeout_s=step_timeout,
+            cancel_grace_s=cancel_grace,
+            orphan_threshold_s=orphan_threshold,
+        )
+
+        if expect_swept:
+            assert swept == [traj_id]
+            assert storage.read_episode_status(traj_id).status == "STALE"
+        else:
+            assert swept == []
+            assert storage.read_episode_status(traj_id).status == initial_status
+
+    # ------------------------------------------------------------------
+    # Parametrized table: resume=True selection by status
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "status,extra_fields,expect_returned",
+        [
+            # retriable — resume must include
+            ("FAILED",    {},                     True),
+            ("CANCELLED", {},                     True),
+            ("STALE",     {},                     True),
+            # terminal non-retriable — resume must skip
+            ("COMPLETED",         {"reward": 1.0, "ended_at": 0}, False),
+            ("MAX_STEPS_REACHED", {"reward": 0.0, "ended_at": 0}, False),
+            # in-flight — resume must skip (not swept; fresh timestamps)
+            ("QUEUED",  {},                       False),
+            ("RUNNING", {"last_heartbeat_at": 0}, False),
+        ],
+        ids=["failed", "cancelled", "stale", "completed", "max-steps-reached", "queued", "running"],
+    )
+    def test_resume_selection_by_status(
+        self,
+        tmp_dir: "Path",
+        mock_agent_config: "MockAgentConfig",
+        status: str,
+        extra_fields: dict,
+        expect_returned: bool,
+    ) -> None:
+        """resume=True returns retriable statuses and skips terminal/in-flight ones."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(name="test_sel", output_dir=tmp_dir, agent_config=mock_agent_config, benchmark=benchmark)
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+
+        now = time.time()
+        resolved = {k: (now if v == 0 else v) for k, v in extra_fields.items()}
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status=status,
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=now,
+                retry_count=0,
+                **resolved,
+            ),
+        )
+
+        exp.resume = True
+        # Use generous timeouts so fresh QUEUED/RUNNING are not swept to STALE.
+        result = exp.get_episodes_to_run(step_timeout_s=3600.0, cancel_grace_s=3600.0, orphan_threshold_s=3600.0)
+
+        if expect_returned:
+            assert len(result) == 1 and result[0].config.id == episodes[0].config.id
+        else:
+            assert result == []
+
+    def test_sequential_pre_claims_all_episodes_as_queued_before_loop(self, tmp_dir, mock_agent_config):
+        """Sequential mode pre-claims all episodes as QUEUED before the loop starts.
+
+        All waiting episodes must have status.json=QUEUED from the start so a crash
+        mid-run leaves them distinguishable from episodes that were never submitted.
+        """
+        benchmark = _make_benchmark(3)
+        exp = Experiment(
+            name="test_seq_preclaim",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        storage = FileStorage(tmp_dir)
+
+        run_sequentially(exp, debug_limit=1)
+
+        # All 3 episodes must have a status.json — not just the one that ran.
+        all_statuses = storage.list_episode_statuses()
+        assert len(all_statuses) == 3, (
+            f"Expected all 3 episodes pre-claimed, got {len(all_statuses)}: {list(all_statuses)}"
+        )
+
+        # The episode that ran should be COMPLETED.
+        completed = [tid for tid, s in all_statuses.items() if s.status == "COMPLETED"]
+        assert len(completed) == 1
+
+        # The two that didn't run should be QUEUED (pre-claimed but not started).
+        queued = [tid for tid, s in all_statuses.items() if s.status == "QUEUED"]
+        assert len(queued) == 2
+
+    def test_heartbeat_advances_current_step_and_timestamp(self, tmp_dir, mock_agent_config):
+        """RUNNING → RUNNING: each turn updates last_heartbeat_at and current_step without changing status."""
         benchmark = _make_benchmark(1)
         exp = Experiment(
-            name="test_stale_sweep",
+            name="test_heartbeat",
             output_dir=tmp_dir,
             agent_config=mock_agent_config,
             benchmark=benchmark,
@@ -371,7 +573,107 @@ class TestStatusBasedSelection:
         episodes = exp.get_episodes_to_run()
         traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
         storage = FileStorage(tmp_dir)
-        # Heartbeat 1 hour ago — older than step_timeout(1s) + cancel_grace(1s)
+
+        t0 = time.time() - 10
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="RUNNING",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=t0,
+                last_heartbeat_at=t0,
+                current_step=0,
+                retry_count=0,
+            ),
+        )
+
+        # Simulate two heartbeat writes (what the loop does at the start of each turn).
+        for turn in range(1, 3):
+            s = storage.read_episode_status(traj_id)
+            s.last_heartbeat_at = time.time()
+            s.current_step = turn
+            storage.write_episode_status(traj_id, s)
+
+        final = storage.read_episode_status(traj_id)
+        assert final.status == "RUNNING"       # status unchanged
+        assert final.current_step == 2         # advanced through two turns
+        assert final.last_heartbeat_at > t0    # heartbeat is newer than start
+
+    def test_cancelled_at_max_retries_cap_is_terminal(self, tmp_dir, mock_agent_config):
+        """CANCELLED → terminal: retry_count >= max_retries excludes from retry selection."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_cancelled_cap",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+            max_retries=2,
+        )
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="CANCELLED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                ended_at=time.time(),
+                error_type="StepTimeout",
+                error_message="Step 3 exceeded 1800s",
+                retry_count=2,  # == max_retries → capped
+            ),
+        )
+
+        exp.resume = True
+        assert exp.get_episodes_to_run() == []
+
+    def test_stale_at_max_retries_cap_is_terminal(self, tmp_dir, mock_agent_config):
+        """STALE → terminal: retry_count >= max_retries excludes from retry selection."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_stale_cap",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+            max_retries=2,
+        )
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="STALE",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=time.time(),
+                ended_at=time.time(),
+                error_type="WorkerDied",
+                retry_count=2,  # == max_retries → capped
+            ),
+        )
+
+        exp.resume = True
+        assert exp.get_episodes_to_run() == []
+
+    def test_resume_auto_sweeps_stale_running_and_returns_for_retry(self, tmp_dir, mock_agent_config) -> None:
+        """resume=True sweeps a stale RUNNING entry to STALE and returns it for retry in one call."""
+        benchmark = _make_benchmark(1)
+        exp = Experiment(
+            name="test_resume_sweep",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+        )
+        episodes = exp.get_episodes_to_run()
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+
         storage.write_episode_status(
             traj_id,
             EpisodeStatus(
@@ -380,27 +682,25 @@ class TestStatusBasedSelection:
                 episode_id=episodes[0].config.id,
                 started_at=time.time() - 3600,
                 last_heartbeat_at=time.time() - 3600,
-                current_step=5,
+                current_step=3,
                 retry_count=0,
             ),
         )
 
-        swept = sweep_stale_statuses(storage, step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
-        assert swept == [traj_id]
-        status = storage.read_episode_status(traj_id)
-        assert status is not None
-        assert status.status == "STALE"
-
         exp.resume = True
         retried = exp.get_episodes_to_run(step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
+
+        # The sweep ran implicitly — status is now STALE.
+        assert storage.read_episode_status(traj_id).status == "STALE"
+        # And the episode was returned for retry.
         assert len(retried) == 1
         assert retried[0].config.id == episodes[0].config.id
 
-    def test_queued_orphan_swept_to_stale(self, tmp_dir, mock_agent_config):
-        """A QUEUED entry older than `orphan_threshold_s` is swept to STALE."""
+    def test_resume_auto_sweeps_orphaned_queued_and_returns_for_retry(self, tmp_dir, mock_agent_config) -> None:
+        """resume=True sweeps an orphaned QUEUED entry to STALE and returns it for retry in one call."""
         benchmark = _make_benchmark(1)
         exp = Experiment(
-            name="test_queued_orphan",
+            name="test_resume_sweep_queued",
             output_dir=tmp_dir,
             agent_config=mock_agent_config,
             benchmark=benchmark,
@@ -408,7 +708,7 @@ class TestStatusBasedSelection:
         episodes = exp.get_episodes_to_run()
         traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
         storage = FileStorage(tmp_dir)
-        # QUEUED with started_at way in the past — Ray never picked it up.
+
         storage.write_episode_status(
             traj_id,
             EpisodeStatus(
@@ -418,136 +718,162 @@ class TestStatusBasedSelection:
                 started_at=time.time() - 7200,
                 last_heartbeat_at=None,
                 current_step=0,
+                retry_count=0,
             ),
         )
-        swept = sweep_stale_statuses(storage, step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
-        assert swept == [traj_id]
+
+        exp.resume = True
+        retried = exp.get_episodes_to_run(step_timeout_s=1.0, cancel_grace_s=1.0, orphan_threshold_s=10.0)
+
         assert storage.read_episode_status(traj_id).status == "STALE"
+        assert len(retried) == 1
+        assert retried[0].config.id == episodes[0].config.id
 
-    def test_queued_fresh_not_swept(self, tmp_dir, mock_agent_config):
-        """A QUEUED entry younger than `orphan_threshold_s` is left alone (still queued)."""
-        benchmark = _make_benchmark(1)
+    def test_worker_writes_failed_on_unhandled_exception(self, tmp_dir, mock_agent_config) -> None:
+        """RUNNING → FAILED: unhandled exception in step() causes the worker to write FAILED with error fields."""
+        benchmark = _make_failing_benchmark()
         exp = Experiment(
-            name="test_queued_fresh",
+            name="test_failed_status",
             output_dir=tmp_dir,
             agent_config=mock_agent_config,
             benchmark=benchmark,
         )
         episodes = exp.get_episodes_to_run()
-        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
         storage = FileStorage(tmp_dir)
-        storage.write_episode_status(
-            traj_id,
-            EpisodeStatus(
-                status="QUEUED",
-                task_id=episodes[0].config.task_config.task_id,
-                episode_id=episodes[0].config.id,
-                started_at=time.time(),
-                last_heartbeat_at=None,
-                current_step=0,
-            ),
+
+        with pytest.raises(RuntimeError, match="injected step failure"):
+            episodes[0].run()
+
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        status = storage.read_episode_status(traj_id)
+        assert status is not None
+        assert status.status == "FAILED"
+        assert status.error_type == "RuntimeError"
+        assert "injected step failure" in (status.error_message or "")
+        assert status.ended_at is not None
+
+    def test_worker_writes_max_steps_reached_when_loop_exhausted(self, tmp_dir, mock_agent_config) -> None:
+        """RUNNING → MAX_STEPS_REACHED: loop exhausts max_steps without done=True."""
+        max_steps = 2
+        benchmark = _make_neverending_benchmark(max_steps)
+        exp = Experiment(
+            name="test_max_steps_status",
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            benchmark=benchmark,
+            max_steps=max_steps,
         )
-        swept = sweep_stale_statuses(storage, step_timeout_s=60.0, cancel_grace_s=60.0, orphan_threshold_s=3600.0)
-        assert swept == []
-        # In-flight (QUEUED) is never returned by resume.
+        episodes = exp.get_episodes_to_run()
+        storage = FileStorage(tmp_dir)
+
+        episodes[0].run()
+
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        status = storage.read_episode_status(traj_id)
+        assert status is not None
+        assert status.status == "MAX_STEPS_REACHED"
+        assert status.ended_at is not None
+        # Not retriable — resume must skip it.
         exp.resume = True
         assert exp.get_episodes_to_run() == []
 
-    def test_stale_sweep_keeps_fresh_running(self, tmp_dir, mock_agent_config):
-        """A RUNNING entry with a fresh heartbeat is left alone."""
-        benchmark = _make_benchmark(1)
-        exp = Experiment(
-            name="test_fresh_running",
-            output_dir=tmp_dir,
-            agent_config=mock_agent_config,
-            benchmark=benchmark,
-        )
-        episodes = exp.get_episodes_to_run()
-        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
-        storage = FileStorage(tmp_dir)
-        storage.write_episode_status(
-            traj_id,
-            EpisodeStatus(
-                status="RUNNING",
-                task_id=episodes[0].config.task_config.task_id,
-                episode_id=episodes[0].config.id,
-                started_at=time.time(),
-                last_heartbeat_at=time.time(),
-                current_step=1,
-            ),
-        )
-        swept = sweep_stale_statuses(storage, step_timeout_s=60.0, cancel_grace_s=60.0, orphan_threshold_s=3600.0)
-        assert swept == []
-        # Fresh RUNNING is never returned, even with resume=True.
-        exp.resume = True
-        assert exp.get_episodes_to_run() == []
 
-    def test_resume_returns_unstarted_and_failed_skipping_completed(self, tmp_dir, mock_agent_config):
-        """resume=True returns missing-status + retriable failures, skipping COMPLETED."""
-        benchmark = _make_benchmark(3)
-        exp = Experiment(
-            name="test_resume_mixed",
-            output_dir=tmp_dir,
-            agent_config=mock_agent_config,
-            benchmark=benchmark,
-        )
-        episodes = exp.get_episodes_to_run()
-        storage = FileStorage(tmp_dir)
-        # Episode 0: COMPLETED — should NOT be returned
-        storage.write_episode_status(
-            f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}",
-            EpisodeStatus(
-                status="COMPLETED",
-                task_id=episodes[0].config.task_config.task_id,
-                episode_id=episodes[0].config.id,
-                started_at=time.time(),
-                ended_at=time.time(),
-                last_heartbeat_at=time.time(),
-                reward=1.0,
-            ),
-        )
-        # Episode 1: FAILED — SHOULD be returned (resume covers retriable failures)
-        storage.write_episode_status(
-            f"{episodes[1].config.task_config.task_id}_ep{episodes[1].config.id}",
-            EpisodeStatus(
-                status="FAILED",
-                task_id=episodes[1].config.task_config.task_id,
-                episode_id=episodes[1].config.id,
-                started_at=time.time(),
-            ),
-        )
-        # Episode 2: no status.json — SHOULD be returned (never started)
+class TestKillStaleWorkersRaceGuard:
+    """Unit tests for the _kill_stale_workers race guard.
 
-        exp.resume = True
-        resumed = exp.get_episodes_to_run()
-        ids = {ep.config.id for ep in resumed}
-        assert ids == {episodes[1].config.id, episodes[2].config.id}
+    The guard prevents the driver from stamping CANCELLED after the worker has
+    already written a terminal status (COMPLETED or FAILED) between the staleness
+    check and the ray.cancel call.
+    """
 
-    def test_resume_skips_max_steps_reached(self, tmp_dir, mock_agent_config):
-        """resume=True does NOT re-run MAX_STEPS_REACHED — it's a legitimate outcome."""
-        benchmark = _make_benchmark(2)
-        exp = Experiment(
-            name="test_max_steps_skip",
-            output_dir=tmp_dir,
-            agent_config=mock_agent_config,
-            benchmark=benchmark,
+    def _stale_running_status(self, task_id: str, episode_id: int) -> EpisodeStatus:
+        return EpisodeStatus(
+            status="RUNNING",
+            task_id=task_id,
+            episode_id=episode_id,
+            started_at=time.time() - 7200,
+            last_heartbeat_at=time.time() - 7200,  # ancient — triggers kill
+            current_step=5,
+            retry_count=0,
         )
-        episodes = exp.get_episodes_to_run()
+
+    def test_driver_does_not_clobber_completed_written_by_worker(self, tmp_dir) -> None:
+        """RUNNING (stale) → worker races to COMPLETED → driver skips CANCELLED."""
         storage = FileStorage(tmp_dir)
-        # Episode 0: MAX_STEPS_REACHED → skipped on resume
-        storage.write_episode_status(
-            f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}",
-            EpisodeStatus(
-                status="MAX_STEPS_REACHED",
-                task_id=episodes[0].config.task_config.task_id,
-                episode_id=episodes[0].config.id,
-                started_at=time.time(),
-                ended_at=time.time(),
-                last_heartbeat_at=time.time(),
-                reward=0.0,
-            ),
+        traj_id = "task_race_ep0"
+        task_id = "task_race"
+
+        stale_status = self._stale_running_status(task_id, 0)
+        completed_status = EpisodeStatus(
+            status="COMPLETED",
+            task_id=task_id,
+            episode_id=0,
+            started_at=time.time() - 7200,
+            ended_at=time.time(),
+            last_heartbeat_at=time.time(),
+            reward=1.0,
+            retry_count=0,
         )
-        # Episode 1: missing → included
-        exp.resume = True
-        resumed = exp.get_episodes_to_run()
-        assert {ep.config.id for ep in resumed} == {episodes[1].config.id}
+
+        fake_ref = MagicMock()
+        ref_to_traj_id = {fake_ref: traj_id}
+        results = ExpResult(exp_id="test", tasks_num=1)
+        episodes_in_progress = [fake_ref]
+
+        # First read: stale RUNNING. Second read (after ray.cancel): COMPLETED.
+        with patch("cube_harness.exp_runner.ray.cancel") as mock_cancel, patch.object(
+            storage, "read_episode_status", side_effect=[stale_status, completed_status]
+        ), patch.object(storage, "write_episode_status") as mock_write:
+            _kill_stale_workers(
+                episodes_in_progress,
+                ref_to_traj_id,
+                storage,
+                results,
+                step_timeout_s=1.0,
+                cancel_grace_s=1.0,
+            )
+
+        # ray.cancel was still called (driver didn't know worker had finished).
+        mock_cancel.assert_called_once_with(fake_ref, force=True)
+        # write_episode_status was NOT called — COMPLETED is preserved, not clobbered.
+        mock_write.assert_not_called()
+        # Ref removed from in-progress (driver moves on regardless).
+        assert fake_ref not in episodes_in_progress
+        # CANCELLED was NOT recorded as a failure.
+        assert traj_id not in results.failures
+
+    def test_driver_stamps_cancelled_when_still_running_after_cancel(self, tmp_dir) -> None:
+        """RUNNING (stale) → worker does not race → driver writes CANCELLED."""
+        storage = FileStorage(tmp_dir)
+        traj_id = "task_norace_ep0"
+        task_id = "task_norace"
+
+        stale_status = self._stale_running_status(task_id, 0)
+
+        fake_ref = MagicMock()
+        ref_to_traj_id = {fake_ref: traj_id}
+        results = ExpResult(exp_id="test", tasks_num=1)
+        episodes_in_progress = [fake_ref]
+
+        # Both reads return RUNNING — worker never wrote a terminal status.
+        with patch("cube_harness.exp_runner.ray.cancel"), patch.object(
+            storage, "read_episode_status", side_effect=[stale_status, stale_status]
+        ), patch.object(storage, "write_episode_status") as mock_write:
+            _kill_stale_workers(
+                episodes_in_progress,
+                ref_to_traj_id,
+                storage,
+                results,
+                step_timeout_s=1.0,
+                cancel_grace_s=1.0,
+            )
+
+        # CANCELLED was written.
+        assert mock_write.call_count == 1
+        written: EpisodeStatus = mock_write.call_args[0][1]
+        assert written.status == "CANCELLED"
+        assert written.error_type == "StepTimeout"
+        assert "Step 5 exceeded" in written.error_message
+        # Recorded as a failure.
+        assert traj_id in results.failures
+        assert fake_ref not in episodes_in_progress

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -32,15 +32,16 @@ from cube.task import TaskMetadata
 
 from cube_harness.agent import Agent, AgentConfig
 from cube_harness.core import AgentOutput
-from cube_harness.episode_status import STATUS_FILENAME
-from cube_harness.exp_runner import run_with_ray
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+from cube_harness.exp_runner import run_sequentially, run_with_ray
 from cube_harness.experiment import Experiment
 from cube_harness.storage import ARCHIVED_MARKER, EPISODES_DIR, FileStorage
 from tests.conftest import MockToolConfig
 
-pytestmark = pytest.mark.slow
+# Per-test slow markers below — Ray tests are slow (~30s), sequential tests are fast (~1s).
 
 
+# Scenarios for the main 4-scenario Ray integration test.
 SCENARIOS = {
     "task_succeed": ["succeed"],
     "task_flaky": ["fail", "fail", "succeed"],
@@ -73,20 +74,25 @@ class DebugCubeTaskConfig(CubeTaskConfig):
         )
 
 
-class DebugBenchmark(CubeBenchmark):
-    benchmark_metadata = BenchmarkMetadata(
-        name="debug-retry",
-        version="0.1.0",
-        description="Scripted scenarios for retry-mechanism integration test",
-    )
-    task_metadata = {tid: TaskMetadata(id=tid) for tid in SCENARIOS}
-    task_config_class = DebugCubeTaskConfig
+def make_debug_benchmark(scenarios: dict[str, list[str]]) -> CubeBenchmark:
+    """Build a CubeBenchmark whose tasks match the keys of `scenarios`."""
 
-    def _setup(self) -> None:
-        pass
+    class _DebugBenchmark(CubeBenchmark):
+        benchmark_metadata = BenchmarkMetadata(
+            name="debug-retry",
+            version="0.1.0",
+            description="Scripted scenarios for retry-mechanism integration test",
+        )
+        task_metadata = {tid: TaskMetadata(id=tid) for tid in scenarios}
+        task_config_class = DebugCubeTaskConfig
 
-    def close(self) -> None:
-        pass
+        def _setup(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    return _DebugBenchmark()
 
 
 # --- Debug agent ---
@@ -117,10 +123,11 @@ def _next_attempt(counter_dir: str, task_id: str) -> int:
 class DebugAgentConfig(AgentConfig):
     """Agent config carrying scenarios + counter dir.
 
-    Both fields are picklable plain data, so Ray can ship the config to workers.
+    All fields are picklable plain data, so Ray can ship the config to workers.
     """
 
     counter_dir: str
+    scenarios: dict[str, list[str]]
     hang_seconds: float = 60.0
     name: str = "debug_agent"
 
@@ -142,7 +149,7 @@ class DebugAgent(Agent):
         # Initial observation embeds task_id; pull it out.
         text = obs.contents[0].data if obs.contents else ""
         task_id = text.replace("task_id=", "").strip()
-        scenarios = SCENARIOS[task_id]
+        scenarios = self.config.scenarios[task_id]
         attempt = _next_attempt(self.config.counter_dir, task_id)
         # Saturate at the last scenario if attempts exceed the script length.
         behavior = scenarios[min(attempt, len(scenarios) - 1)]
@@ -167,11 +174,12 @@ def _ray_shutdown_between_tests():
         ray.shutdown()
 
 
+@pytest.mark.slow
 def test_retry_machinery_end_to_end(tmp_dir: Path) -> None:
     """4-task Ray run exercises the full retry mechanism."""
     counter_dir = str(tmp_dir / "_attempt_counters")
-    agent_config = DebugAgentConfig(counter_dir=counter_dir, hang_seconds=10.0)
-    benchmark = DebugBenchmark()
+    agent_config = DebugAgentConfig(counter_dir=counter_dir, scenarios=SCENARIOS, hang_seconds=10.0)
+    benchmark = make_debug_benchmark(SCENARIOS)
 
     exp = Experiment(
         name="retry_integration",
@@ -229,9 +237,197 @@ def test_retry_machinery_end_to_end(tmp_dir: Path) -> None:
     assert archived_status["status"] == "CANCELLED", archived_status
     assert archived_status["error_type"] == "StepTimeout"
 
+    # Per-attempt forensics: walking task_dead's archives gives retry_counts 0..2 with FAILED + populated error_type.
+    dead_archives = _read_all_archived_statuses(tmp_dir, "task_dead_ep2")
+    assert len(dead_archives) == 3
+    dead_retry_counts = sorted(a["retry_count"] for a in dead_archives)
+    assert dead_retry_counts == [0, 1, 2]
+    for archived in dead_archives:
+        assert archived["status"] == "FAILED"
+        assert archived["error_type"] == "RuntimeError"
+        assert "scripted failure" in (archived["error_message"] or "")
+
     # Aggregated result: 3 successful trajectories, 1 failure (task_dead).
     assert "task_dead_ep2" in result.failures
     assert {"task_succeed_ep0", "task_flaky_ep1", "task_hang_ep3"}.issubset(result.trajectories.keys())
+
+
+@pytest.mark.slow
+def test_mixed_state_recovery_via_ray(tmp_dir: Path) -> None:
+    """Restart with mixed pre-existing state: COMPLETED preserved, STALE swept+retried, missing retried.
+
+    Simulates "the prior driver crashed mid-experiment" by hand-writing a heterogeneous
+    `output_dir` and verifies the new driver makes the right decision per episode:
+
+    - `task_already_done`: COMPLETED status → never re-run.
+    - `task_was_stuck`: stale RUNNING → swept to STALE → retried → COMPLETED.
+    - `task_never_started`: no status.json → retried (resume + retry_failed) → COMPLETED.
+    """
+    scenarios = {
+        "task_already_done": ["succeed"],  # won't actually be re-run
+        "task_was_stuck": ["succeed"],
+        "task_never_started": ["succeed"],
+    }
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=10.0,
+    )
+    exp = Experiment(
+        name="mixed_state",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark=benchmark,
+        max_retries=3,
+    )
+
+    # Materialise episode_config.json for all three (without running anything).
+    episodes = {ep.config.task_config.task_id: ep for ep in exp.get_episodes_to_run()}
+    storage = FileStorage(tmp_dir)
+
+    # Hand-craft pre-existing state to mimic a crashed prior driver:
+    done_traj_id = f"task_already_done_ep{episodes['task_already_done'].config.id}"
+    storage.write_episode_status(
+        done_traj_id,
+        EpisodeStatus(
+            status="COMPLETED",
+            task_id="task_already_done",
+            episode_id=episodes["task_already_done"].config.id,
+            started_at=time.time() - 100,
+            ended_at=time.time() - 90,
+            last_heartbeat_at=time.time() - 90,
+            reward=1.0,
+            retry_count=0,
+        ),
+    )
+
+    stuck_traj_id = f"task_was_stuck_ep{episodes['task_was_stuck'].config.id}"
+    storage.write_episode_status(
+        stuck_traj_id,
+        EpisodeStatus(
+            status="RUNNING",
+            task_id="task_was_stuck",
+            episode_id=episodes["task_was_stuck"].config.id,
+            started_at=time.time() - 7200,
+            last_heartbeat_at=time.time() - 7200,  # stale (>>step_timeout+grace)
+            current_step=4,
+            retry_count=0,
+        ),
+    )
+
+    missing_traj_id = f"task_never_started_ep{episodes['task_never_started'].config.id}"
+    # No status.json written for this one — exists as an episode_config only.
+
+    # New driver: resume picks up missing-status; retry_failed picks up STALE.
+    exp.resume = True
+    exp.retry_failed = True
+    result = run_with_ray(
+        exp,
+        n_cpus=2,
+        ray_poll_timeout=0.5,
+        step_timeout_s=10.0,
+        cancel_grace_s=1.0,
+        orphan_threshold_s=10.0,
+        max_retry_rounds=0,
+    )
+
+    # task_already_done: untouched.
+    done = storage.read_episode_status(done_traj_id)
+    assert done is not None
+    assert done.status == "COMPLETED"
+    assert done.retry_count == 0
+    assert _archive_count(tmp_dir, done_traj_id) == 0
+    assert done_traj_id not in result.trajectories  # not re-run this round
+
+    # task_was_stuck: STALE-swept, then retried to COMPLETED. Prior STALE preserved in archive.
+    stuck = storage.read_episode_status(stuck_traj_id)
+    assert stuck is not None
+    assert stuck.status == "COMPLETED", stuck
+    assert stuck.retry_count == 1
+    stuck_archives = _read_all_archived_statuses(tmp_dir, stuck_traj_id)
+    assert len(stuck_archives) == 1
+    assert stuck_archives[0]["status"] == "STALE"
+    assert stuck_archives[0]["retry_count"] == 0
+    assert stuck_traj_id in result.trajectories
+
+    # task_never_started: ran fresh, no archive (no prior attempt).
+    missing = storage.read_episode_status(missing_traj_id)
+    assert missing is not None
+    assert missing.status == "COMPLETED"
+    assert missing.retry_count == 0
+    assert _archive_count(tmp_dir, missing_traj_id) == 0
+    assert missing_traj_id in result.trajectories
+
+
+def test_run_sequentially_auto_retries_flaky_episode(tmp_dir: Path) -> None:
+    """run_sequentially auto-retries; exercises the worker-side archive (no pre-claim path)."""
+    scenarios = {"task_seq_flaky": ["fail", "succeed"]}
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=0.0,
+    )
+    exp = Experiment(
+        name="seq_flaky",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark=benchmark,
+        max_retries=3,
+    )
+
+    result = run_sequentially(exp, max_retry_rounds=2)
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    assert len(statuses) == 1
+    traj_id, final = next(iter(statuses.items()))
+    assert final.status == "COMPLETED"
+    assert final.retry_count == 1
+
+    # The failed attempt is preserved in an archive (worker-side path, no pre-claim).
+    archived = _read_all_archived_statuses(tmp_dir, traj_id)
+    assert len(archived) == 1
+    assert archived[0]["status"] == "FAILED"
+    assert archived[0]["retry_count"] == 0
+    assert archived[0]["error_type"] == "RuntimeError"
+
+    assert traj_id in result.trajectories
+
+
+def test_max_retry_rounds_zero_disables_auto_retry(tmp_dir: Path) -> None:
+    """max_retry_rounds=0 → a failing episode stays FAILED with no retry attempts.
+
+    Scenarios script "fail" forever; with max_retry_rounds=0 we expect exactly one
+    attempt (retry_count=0, no archives), confirming the auto-retry loop short-circuits
+    even though `max_retries=3` would otherwise allow retries.
+    """
+    scenarios = {"task_no_retry": ["fail"]}
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=0.0,
+    )
+    exp = Experiment(
+        name="no_retry",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark=benchmark,
+        max_retries=3,
+    )
+
+    result = run_sequentially(exp, max_retry_rounds=0)
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    assert len(statuses) == 1
+    traj_id, final = next(iter(statuses.items()))
+    assert final.status == "FAILED"
+    assert final.retry_count == 0
+    assert _archive_count(tmp_dir, traj_id) == 0  # only one attempt was ever made
+    assert traj_id in result.failures
 
 
 def _archive_count(output_dir: Path, traj_id: str) -> int:
@@ -250,3 +446,17 @@ def _read_archived_status(output_dir: Path, traj_id: str) -> dict | None:
             if status_path.exists():
                 return json.loads(status_path.read_text())
     return None
+
+
+def _read_all_archived_statuses(output_dir: Path, traj_id: str) -> list[dict]:
+    """Return every archived `status.json` dict for `traj_id`, ordered by archive timestamp."""
+    import json
+
+    base = output_dir / EPISODES_DIR
+    archived = []
+    for p in sorted(base.iterdir()):
+        if p.name.startswith(f"{traj_id}{ARCHIVED_MARKER}"):
+            status_path = p / STATUS_FILENAME
+            if status_path.exists():
+                archived.append(json.loads(status_path.read_text()))
+    return archived

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -144,11 +144,14 @@ class DebugAgent(Agent):
     def __init__(self, config: DebugAgentConfig):
         super().__init__(config)
         self.config = config
+        self._task_id: str | None = None
 
     def step(self, obs: Observation) -> AgentOutput:
-        # Initial observation embeds task_id; pull it out.
-        text = obs.contents[0].data if obs.contents else ""
-        task_id = text.replace("task_id=", "").strip()
+        # Initial observation embeds task_id; cache it across subsequent steps.
+        if self._task_id is None:
+            text = obs.contents[0].data if obs.contents else ""
+            self._task_id = text.replace("task_id=", "").strip()
+        task_id = self._task_id
         scenarios = self.config.scenarios[task_id]
         attempt = _next_attempt(self.config.counter_dir, task_id)
         # Saturate at the last scenario if attempts exceed the script length.
@@ -161,6 +164,9 @@ class DebugAgent(Agent):
         if behavior == "hang":
             time.sleep(self.config.hang_seconds)
             return AgentOutput(actions=[Action(name="final_step", arguments={})])
+        if behavior == "loop":
+            # Non-terminating action — drives the runner toward max_steps.
+            return AgentOutput(actions=[Action(name="click", arguments={"element_id": "x"})])
         raise ValueError(f"Unknown behavior: {behavior}")
 
 
@@ -196,7 +202,6 @@ def test_retry_machinery_end_to_end(tmp_dir: Path) -> None:
         step_timeout_s=1.5,
         cancel_grace_s=0.5,
         orphan_threshold_s=30.0,
-        max_retry_rounds=3,
     )
 
     storage = FileStorage(tmp_dir)
@@ -261,7 +266,7 @@ def test_mixed_state_recovery_via_ray(tmp_dir: Path) -> None:
 
     - `task_already_done`: COMPLETED status → never re-run.
     - `task_was_stuck`: stale RUNNING → swept to STALE → retried → COMPLETED.
-    - `task_never_started`: no status.json → retried (resume + retry_failed) → COMPLETED.
+    - `task_never_started`: no status.json → retried (resume) → COMPLETED.
     """
     scenarios = {
         "task_already_done": ["succeed"],  # won't actually be re-run
@@ -319,9 +324,8 @@ def test_mixed_state_recovery_via_ray(tmp_dir: Path) -> None:
     missing_traj_id = f"task_never_started_ep{episodes['task_never_started'].config.id}"
     # No status.json written for this one — exists as an episode_config only.
 
-    # New driver: resume picks up missing-status; retry_failed picks up STALE.
+    # New driver: resume picks up both the swept-STALE and the missing-status episode.
     exp.resume = True
-    exp.retry_failed = True
     result = run_with_ray(
         exp,
         n_cpus=2,
@@ -329,7 +333,6 @@ def test_mixed_state_recovery_via_ray(tmp_dir: Path) -> None:
         step_timeout_s=10.0,
         cancel_grace_s=1.0,
         orphan_threshold_s=10.0,
-        max_retry_rounds=0,
     )
 
     # task_already_done: untouched.
@@ -377,7 +380,7 @@ def test_run_sequentially_auto_retries_flaky_episode(tmp_dir: Path) -> None:
         max_retries=3,
     )
 
-    result = run_sequentially(exp, max_retry_rounds=2)
+    result = run_sequentially(exp)
 
     storage = FileStorage(tmp_dir)
     statuses = storage.list_episode_statuses()
@@ -396,12 +399,57 @@ def test_run_sequentially_auto_retries_flaky_episode(tmp_dir: Path) -> None:
     assert traj_id in result.trajectories
 
 
-def test_max_retry_rounds_zero_disables_auto_retry(tmp_dir: Path) -> None:
-    """max_retry_rounds=0 → a failing episode stays FAILED with no retry attempts.
+def test_max_steps_terminates_with_forced_eval(tmp_dir: Path) -> None:
+    """Hitting max_steps produces MAX_STEPS_REACHED + a real reward (forced evaluate).
 
-    Scenarios script "fail" forever; with max_retry_rounds=0 we expect exactly one
-    attempt (retry_count=0, no archives), confirming the auto-retry loop short-circuits
-    even though `max_retries=3` would otherwise allow retries.
+    The agent issues non-terminating actions, so the loop runs until `max_steps`
+    fires. Without our forced final-eval the trajectory would record reward=0;
+    the fix calls evaluate() once at end-of-loop so the reward reflects the task's
+    real assessment (DebugCubeTask returns 1.0). Status is MAX_STEPS_REACHED, which
+    is terminal but NOT retriable — a second resume run leaves it alone.
+    """
+    scenarios = {"task_loops": ["loop"]}
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=0.0,
+    )
+    exp = Experiment(
+        name="max_steps",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark=benchmark,
+        max_steps=2,
+        max_retries=3,
+    )
+
+    result = run_sequentially(exp)
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    assert len(statuses) == 1
+    traj_id, final = next(iter(statuses.items()))
+    assert final.status == "MAX_STEPS_REACHED", final
+    assert final.retry_count == 0
+    assert final.reward == 1.0  # from the forced evaluate call (DebugCubeTask returns 1.0)
+    assert _archive_count(tmp_dir, traj_id) == 0  # no retries
+
+    # The aggregated trajectory got a real reward, not 0.0.
+    assert traj_id in result.trajectories
+    assert result.trajectories[traj_id].last_env_step().reward == 1.0
+
+    # MAX_STEPS_REACHED is not retriable: a fresh resume returns nothing.
+    exp.resume = True
+    assert exp.get_episodes_to_run() == []
+
+
+def test_max_retries_zero_disables_auto_retry(tmp_dir: Path) -> None:
+    """max_retries=0 → a failing episode stays FAILED with no retry attempts.
+
+    The auto-retry loop only retries episodes with `retry_count < max_retries`.
+    Setting `max_retries=0` makes the cap bind immediately so the loop never runs
+    a second round.
     """
     scenarios = {"task_no_retry": ["fail"]}
     benchmark = make_debug_benchmark(scenarios)
@@ -415,10 +463,10 @@ def test_max_retry_rounds_zero_disables_auto_retry(tmp_dir: Path) -> None:
         output_dir=tmp_dir,
         agent_config=agent_config,
         benchmark=benchmark,
-        max_retries=3,
+        max_retries=0,
     )
 
-    result = run_sequentially(exp, max_retry_rounds=0)
+    result = run_sequentially(exp)
 
     storage = FileStorage(tmp_dir)
     statuses = storage.list_episode_statuses()

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -1,0 +1,252 @@
+"""End-to-end integration test for the episode-status retry mechanism.
+
+A single Ray-based run over a 4-task benchmark covers ~80% of the retry machinery:
+pre-claim, step-boundary heartbeat, driver-side stale-heartbeat kill, CANCELLED
+status, auto-retry rounds, retry_count cap, and per-attempt archives.
+
+Each task's "scenario" is a list of behaviours indexed by attempt number
+(0 = original, 1.. = retries):
+
+| Episode    | Scenarios                | Expected final | retry_count | archives |
+|------------|--------------------------|----------------|-------------|----------|
+| task_succeed | ["succeed"]            | COMPLETED      | 0           | 0        |
+| task_flaky   | ["fail","fail","ok"]   | COMPLETED      | 2           | 2        |
+| task_dead    | ["fail"]*4             | FAILED (cap)   | 3           | 3        |
+| task_hang    | ["hang","succeed"]     | COMPLETED      | 1           | 1        |
+"""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from pathlib import Path
+
+import pytest
+import ray
+from cube.benchmark import Benchmark as CubeBenchmark
+from cube.benchmark import BenchmarkMetadata
+from cube.core import Action, Observation
+from cube.task import Task as CubeTask
+from cube.task import TaskConfig as CubeTaskConfig
+from cube.task import TaskMetadata
+
+from cube_harness.agent import Agent, AgentConfig
+from cube_harness.core import AgentOutput
+from cube_harness.episode_status import STATUS_FILENAME
+from cube_harness.exp_runner import run_with_ray
+from cube_harness.experiment import Experiment
+from cube_harness.storage import ARCHIVED_MARKER, EPISODES_DIR, FileStorage
+from tests.conftest import MockToolConfig
+
+pytestmark = pytest.mark.slow
+
+
+SCENARIOS = {
+    "task_succeed": ["succeed"],
+    "task_flaky": ["fail", "fail", "succeed"],
+    "task_dead": ["fail", "fail", "fail", "fail"],
+    "task_hang": ["hang", "succeed"],
+}
+
+
+# --- Debug task / benchmark ---
+
+
+class DebugCubeTask(CubeTask):
+    """Cube task that exposes its own task_id in the initial observation.
+
+    The DebugAgent reads this to look up the per-task scripted scenario.
+    """
+
+    def reset(self) -> tuple[Observation, dict]:
+        return Observation.from_text(f"task_id={self.metadata.id}"), {"task_id": self.metadata.id}
+
+    def evaluate(self, obs: Observation | None = None) -> tuple[float, dict]:
+        return 1.0, {"success": True}
+
+
+class DebugCubeTaskConfig(CubeTaskConfig):
+    def make(self, runtime_context=None, container_backend=None) -> DebugCubeTask:
+        return DebugCubeTask(
+            metadata=TaskMetadata(id=self.task_id),
+            tool_config=self.tool_config or MockToolConfig(),
+        )
+
+
+class DebugBenchmark(CubeBenchmark):
+    benchmark_metadata = BenchmarkMetadata(
+        name="debug-retry",
+        version="0.1.0",
+        description="Scripted scenarios for retry-mechanism integration test",
+    )
+    task_metadata = {tid: TaskMetadata(id=tid) for tid in SCENARIOS}
+    task_config_class = DebugCubeTaskConfig
+
+    def _setup(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+# --- Debug agent ---
+
+
+def _next_attempt(counter_dir: str, task_id: str) -> int:
+    """Atomically read+increment a per-task attempt counter on disk.
+
+    Uses fcntl to serialise concurrent writers (no contention expected within a
+    single round, but cheap insurance against future parallelism bugs).
+    """
+    Path(counter_dir).mkdir(parents=True, exist_ok=True)
+    path = Path(counter_dir) / f"{task_id}.txt"
+    with open(path, "a+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.seek(0)
+            raw = f.read().strip()
+            current = int(raw) if raw else 0
+            f.seek(0)
+            f.truncate()
+            f.write(str(current + 1))
+            return current
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+class DebugAgentConfig(AgentConfig):
+    """Agent config carrying scenarios + counter dir.
+
+    Both fields are picklable plain data, so Ray can ship the config to workers.
+    """
+
+    counter_dir: str
+    hang_seconds: float = 60.0
+    name: str = "debug_agent"
+
+    def make(self, action_set=None, **kwargs) -> "DebugAgent":
+        return DebugAgent(config=self)
+
+
+class DebugAgent(Agent):
+    name = "DebugAgent"
+    description = "Scripted agent that reads scenarios per-task per-attempt"
+    input_content_types = ["text"]
+    output_content_types = ["action"]
+
+    def __init__(self, config: DebugAgentConfig):
+        super().__init__(config)
+        self.config = config
+
+    def step(self, obs: Observation) -> AgentOutput:
+        # Initial observation embeds task_id; pull it out.
+        text = obs.contents[0].data if obs.contents else ""
+        task_id = text.replace("task_id=", "").strip()
+        scenarios = SCENARIOS[task_id]
+        attempt = _next_attempt(self.config.counter_dir, task_id)
+        # Saturate at the last scenario if attempts exceed the script length.
+        behavior = scenarios[min(attempt, len(scenarios) - 1)]
+
+        if behavior == "succeed":
+            return AgentOutput(actions=[Action(name="final_step", arguments={})])
+        if behavior == "fail":
+            raise RuntimeError(f"scripted failure: {task_id} attempt {attempt}")
+        if behavior == "hang":
+            time.sleep(self.config.hang_seconds)
+            return AgentOutput(actions=[Action(name="final_step", arguments={})])
+        raise ValueError(f"Unknown behavior: {behavior}")
+
+
+# --- The test ---
+
+
+@pytest.fixture(autouse=True)
+def _ray_shutdown_between_tests():
+    yield
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+def test_retry_machinery_end_to_end(tmp_dir: Path) -> None:
+    """4-task Ray run exercises the full retry mechanism."""
+    counter_dir = str(tmp_dir / "_attempt_counters")
+    agent_config = DebugAgentConfig(counter_dir=counter_dir, hang_seconds=10.0)
+    benchmark = DebugBenchmark()
+
+    exp = Experiment(
+        name="retry_integration",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark=benchmark,
+        max_retries=3,
+    )
+
+    result = run_with_ray(
+        exp,
+        n_cpus=2,
+        ray_poll_timeout=0.5,
+        step_timeout_s=1.5,
+        cancel_grace_s=0.5,
+        orphan_threshold_s=30.0,
+        max_retry_rounds=3,
+    )
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    # All four episode dirs exist.
+    assert set(statuses.keys()) == {f"{tid}_ep{i}" for i, tid in enumerate(SCENARIOS)}
+
+    # task_succeed: COMPLETED on first try, retry_count 0, no archives.
+    s0 = statuses["task_succeed_ep0"]
+    assert s0.status == "COMPLETED", s0
+    assert s0.retry_count == 0
+    assert _archive_count(tmp_dir, "task_succeed_ep0") == 0
+
+    # task_flaky: 2 retries, finally COMPLETED. retry_count = 2 on the live attempt.
+    # 2 archived dirs (the two failed attempts).
+    s1 = statuses["task_flaky_ep1"]
+    assert s1.status == "COMPLETED", s1
+    assert s1.retry_count == 2
+    assert _archive_count(tmp_dir, "task_flaky_ep1") == 2
+
+    # task_dead: 4 attempts, all failed. retry_count = 3 (capped). 3 archives.
+    s2 = statuses["task_dead_ep2"]
+    assert s2.status == "FAILED", s2
+    assert s2.retry_count == 3
+    assert s2.error_type == "RuntimeError"
+    assert _archive_count(tmp_dir, "task_dead_ep2") == 3
+
+    # task_hang: first attempt CANCELLED via step-timeout, second succeeds.
+    # 1 archive (the cancelled attempt).
+    s3 = statuses["task_hang_ep3"]
+    assert s3.status == "COMPLETED", s3
+    assert s3.retry_count == 1
+    assert _archive_count(tmp_dir, "task_hang_ep3") == 1
+
+    # The CANCELLED attempt is preserved in the archive — verify error_type.
+    archived_status = _read_archived_status(tmp_dir, "task_hang_ep3")
+    assert archived_status is not None
+    assert archived_status["status"] == "CANCELLED", archived_status
+    assert archived_status["error_type"] == "StepTimeout"
+
+    # Aggregated result: 3 successful trajectories, 1 failure (task_dead).
+    assert "task_dead_ep2" in result.failures
+    assert {"task_succeed_ep0", "task_flaky_ep1", "task_hang_ep3"}.issubset(result.trajectories.keys())
+
+
+def _archive_count(output_dir: Path, traj_id: str) -> int:
+    base = output_dir / EPISODES_DIR
+    return sum(1 for p in base.iterdir() if p.name.startswith(f"{traj_id}{ARCHIVED_MARKER}"))
+
+
+def _read_archived_status(output_dir: Path, traj_id: str) -> dict | None:
+    """Read status.json from any archived dir for `traj_id` (returns the first found)."""
+    import json
+
+    base = output_dir / EPISODES_DIR
+    for p in base.iterdir():
+        if p.name.startswith(f"{traj_id}{ARCHIVED_MARKER}"):
+            status_path = p / STATUS_FILENAME
+            if status_path.exists():
+                return json.loads(status_path.read_text())
+    return None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1350,3 +1350,81 @@ class TestExperimentResultGetRecords:
         episodes = list(result)
         assert len(episodes) == 2
         assert all(isinstance(ep, EpisodeResult) for ep in episodes)
+
+
+class TestEpisodeStatusIO:
+    """Tests for status.json atomic write/read on FileStorage."""
+
+    def test_write_then_read_roundtrip(self, tmp_dir) -> None:
+        from cube_harness.episode_status import EpisodeStatus
+
+        storage = FileStorage(tmp_dir)
+        status = EpisodeStatus(
+            status="COMPLETED",
+            task_id="t1",
+            episode_id=0,
+            started_at=1.0,
+            ended_at=2.0,
+            last_heartbeat_at=2.0,
+            current_step=3,
+            reward=1.0,
+        )
+        storage.write_episode_status("t1_ep0", status)
+
+        loaded = storage.read_episode_status("t1_ep0")
+        assert loaded is not None
+        assert loaded.status == "COMPLETED"
+        assert loaded.task_id == "t1"
+        assert loaded.reward == 1.0
+        assert loaded.current_step == 3
+
+    def test_read_missing_returns_none(self, tmp_dir) -> None:
+        storage = FileStorage(tmp_dir)
+        assert storage.read_episode_status("does_not_exist") is None
+
+    def test_atomic_write_no_partial_file(self, tmp_dir) -> None:
+        """Writing always goes via .tmp + os.replace — a partial status.json is never observed."""
+        from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+
+        storage = FileStorage(tmp_dir)
+        status_path = storage._episode_status_path("t1_ep0")
+
+        status = EpisodeStatus(status="RUNNING", task_id="t1", episode_id=0, started_at=1.0)
+        storage.write_episode_status("t1_ep0", status)
+
+        siblings = list(status_path.parent.iterdir())
+        assert STATUS_FILENAME in [s.name for s in siblings]
+        assert not any(s.name.endswith(".tmp") for s in siblings)
+
+        status.status = "COMPLETED"
+        storage.write_episode_status("t1_ep0", status)
+        assert not any(s.name.endswith(".tmp") for s in status_path.parent.iterdir())
+        loaded = storage.read_episode_status("t1_ep0")
+        assert loaded is not None and loaded.status == "COMPLETED"
+
+    def test_list_episode_statuses(self, tmp_dir) -> None:
+        """list_episode_statuses returns statuses keyed by trajectory_id (skipping dirs without configs)."""
+        from cube_harness.episode_status import EpisodeStatus
+
+        storage = FileStorage(tmp_dir)
+        for tid, st in [("t1_ep0", "COMPLETED"), ("t2_ep0", "FAILED")]:
+            ep_dir = storage._episode_dir(tid)
+            ep_dir.mkdir(parents=True, exist_ok=True)
+            (ep_dir / "episode_config.json").write_text("{}")
+            storage.write_episode_status(
+                tid, EpisodeStatus(status=st, task_id=tid.split("_ep")[0], episode_id=0, started_at=0.0)
+            )
+        statuses = storage.list_episode_statuses()
+        assert set(statuses.keys()) == {"t1_ep0", "t2_ep0"}
+        assert statuses["t1_ep0"].status == "COMPLETED"
+        assert statuses["t2_ep0"].status == "FAILED"
+
+    def test_corrupt_status_returns_none(self, tmp_dir) -> None:
+        """A malformed status.json is treated as missing rather than raising."""
+        from cube_harness.episode_status import STATUS_FILENAME
+
+        storage = FileStorage(tmp_dir)
+        ep_dir = storage._episode_dir("t1_ep0")
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        (ep_dir / STATUS_FILENAME).write_text("not valid json")
+        assert storage.read_episode_status("t1_ep0") is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1458,3 +1458,31 @@ class TestEpisodeStatusIO:
         assert loaded is not None
         assert loaded.status == "COMPLETED"
         assert loaded.reward == 1.0
+
+    def test_archive_episode_renames_directory(self, tmp_dir: Path) -> None:
+        """archive_episode moves the episode dir to <id>.archived_<ts>/ and makes it invisible to readers."""
+        from cube_harness.episode_status import EpisodeStatus
+
+        storage = FileStorage(tmp_dir)
+        status = EpisodeStatus(status="FAILED", task_id="t1", episode_id=0, started_at=1.0)
+        storage.write_episode_status("t1_ep0", status)
+
+        episodes_dir = tmp_dir / "episodes"
+        assert (episodes_dir / "t1_ep0").exists()
+
+        storage.archive_episode("t1_ep0")
+
+        # Original directory is gone.
+        assert not (episodes_dir / "t1_ep0").exists()
+
+        # An archived copy exists.
+        archived = [d for d in episodes_dir.iterdir() if ".archived_" in d.name]
+        assert len(archived) == 1
+
+        # read_episode_status sees nothing (archived dir is excluded from _episode_dirs).
+        assert storage.read_episode_status("t1_ep0") is None
+
+    def test_archive_episode_noop_when_dir_missing(self, tmp_dir: Path) -> None:
+        """archive_episode on a non-existent trajectory_id does not raise."""
+        storage = FileStorage(tmp_dir)
+        storage.archive_episode("nonexistent_ep0")  # should not raise

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1428,3 +1428,33 @@ class TestEpisodeStatusIO:
         ep_dir.mkdir(parents=True, exist_ok=True)
         (ep_dir / STATUS_FILENAME).write_text("not valid json")
         assert storage.read_episode_status("t1_ep0") is None
+
+    def test_unknown_fields_ignored_for_forward_compat(self, tmp_dir) -> None:
+        """A status.json from a future version with extra fields still loads cleanly."""
+        from cube_harness.episode_status import STATUS_FILENAME
+
+        storage = FileStorage(tmp_dir)
+        ep_dir = storage._episode_dir("t1_ep0")
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        raw = {
+            "status": "COMPLETED",
+            "task_id": "t1",
+            "episode_id": 0,
+            "started_at": 1.0,
+            "ended_at": 2.0,
+            "last_heartbeat_at": 2.0,
+            "current_step": 0,
+            "reward": 1.0,
+            "had_step_errors": False,
+            "error_type": None,
+            "error_message": None,
+            "retry_count": 0,
+            "extra": {},
+            "future_v2_field": "should be ignored",
+            "another_future_field": 42,
+        }
+        (ep_dir / STATUS_FILENAME).write_text(json.dumps(raw))
+        loaded = storage.read_episode_status("t1_ep0")
+        assert loaded is not None
+        assert loaded.status == "COMPLETED"
+        assert loaded.reward == 1.0


### PR DESCRIPTION
## Problem

The current retry logic scans full trajectories to decide what to re-run. Three failure modes:

1. **Silent crash** — if a Ray worker dies (OOM, force-cancel, machine failure), no terminal status is written. The episode is silently dropped, neither retried nor counted as done.
2. **Recovered errors cause false retry** — a StepError the harness absorbed mid-episode still flags the trajectory for retry even though the loop completed normally.
3. **Status requires reading the payload** — deserializing thousands of trajectories to check retry eligibility is expensive and fragile.

## Proposed solution

Write a small `status.json` in each episode directory. Status is ground truth for retry; trajectory files are data.

**Statuses:** `RUNNING` → `COMPLETED` / `FAILED` / `CANCELLED`

**Heartbeat:** a background thread updates `last_heartbeat_at` every 30s. A stale heartbeat on a `RUNNING` episode = dead worker = eligible for retry. No Ray dashboard dependency.

**retry_count:** tracked in `status.json`, capped at `max_retries` (default 3) to prevent infinite loops.

The retry check becomes: read one small JSON file per episode directory. No trajectory deserialization.

## Files

- `openspec/changes/episode-status/proposal.md` — rationale, schema, alternatives considered
- `openspec/changes/episode-status/deltas.md` — precise ADDED/MODIFIED/REMOVED against episode, experiment, and storage specs

## Open questions for review

1. `max_retries` default: 3?
2. Heartbeat interval 30s / staleness threshold 2min?
3. Should `CANCELLED` be retried by default or only on explicit opt-in?

🤖 Generated with [Claude Code](https://claude.com/claude-code)