### PR TITLE
fix(swebench): drop ContainerBackend annotation from make() override

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -231,7 +231,7 @@ class SWEBenchVerifiedTaskConfig(TaskConfig):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
+        container_backend=None,
     ) -> SWEBenchVerifiedTask:
         if runtime_context is None or "infra" not in runtime_context:
             raise ValueError("SWEBenchVerifiedTaskConfig.make() requires runtime_context['infra']")


### PR DESCRIPTION
## Summary

- `container_backend` parameter in `SWEBenchVerifiedTaskConfig.make()` was type-annotated with `ContainerBackend` but the type was never imported, causing a `NameError` at class definition time
- `ContainerBackend` is deprecated — importing it is the wrong fix
- The parameter body usage was already dropped in a previous commit; only the annotation remained
- Keeping the untyped `container_backend=None` preserves backwards compat with callers in `episode.py` that still pass it as a kwarg

## Test plan
- [ ] `uv run python -c "import swebench_verified_cube"` passes locally
- [ ] CI: integration test collection no longer errors on `NameError: name 'ContainerBackend' is not defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)