### PR TITLE
feat(cubes): migrate swebench-verified, swebench-live, terminalbench to BenchmarkConfig

### DIFF
--- a/openspec/changes/swe-cube-benchmarkconfig-migration/deltas.md
+++ b/openspec/changes/swe-cube-benchmarkconfig-migration/deltas.md
@@ -1,0 +1,39 @@
+# Deltas — SWE cube BenchmarkConfig migration
+
+No cube-harness specs are modified by this change — all spec contracts (`debug_harness.py`
+behaviour, recipe patterns) are already correct in the specs; the cubes were simply not
+compliant with them.
+
+Two clarifications are surfaced for **cube-standard** specs and tracked there:
+
+---
+
+## Upstream delta 1 — `testing/spec.md`: `get_debug_benchmark()` must be a pure factory
+
+The testing spec correctly states that `get_debug_benchmark()` returns a `BenchmarkConfig`
+and that the harness owns `config.install()` / `config.make()`. The **must-not** side
+was implicit. Proposed addition to cube-standard:
+
+> `get_debug_benchmark()` **MUST NOT** call `install()`, `setup()`, or any other lifecycle
+> method. The function is a pure factory. Side effects here double-install when the harness
+> also calls `install()`, and calling `.setup()` on the returned `BenchmarkConfig` will
+> raise `AttributeError` (that method lives on `Benchmark`, not `BenchmarkConfig`).
+
+---
+
+## Upstream delta 2 — `benchmark/spec.md`: migration guide
+
+Add a "Migrating from pre-split cubes" subsection to cube-standard's benchmark spec as a
+canonical recipe for cube authors. Steps:
+
+1. Rename existing class → `FooBenchmarkConfig(BenchmarkConfig[FooTaskMetadata])`. Move all
+   ClassVars, user fields, `install()`, `uninstall()`, `get_task_configs()` here. Add
+   `benchmark_class: ClassVar[type[Benchmark]] = FooBenchmark`.
+2. Create `FooBenchmark(Benchmark["FooBenchmarkConfig"])` with only `_setup()` and `close()`.
+   Access user fields via `self.config.<field>`.
+3. Update `get_task_configs()`: stamp `metadata=tm` on each yielded `TaskConfig` (not `task_id=tm.id`).
+4. Update `task.py`: replace `BenchmarkClass.task_metadata[self.task_id]` with `self.metadata`.
+   Remove the benchmark import and the deprecated `container_backend` parameter from `make()`.
+5. Update `debug.py`: return a bare `BenchmarkConfig` — no `install()`, no `setup()`.
+6. Update `pyproject.toml` entry point to name `FooBenchmarkConfig`.
+7. Update `__init__.py` to export `FooBenchmarkConfig`.

--- a/openspec/changes/swe-cube-benchmarkconfig-migration/proposal.md
+++ b/openspec/changes/swe-cube-benchmarkconfig-migration/proposal.md
@@ -1,0 +1,227 @@
+# SWE cube migration: BenchmarkConfig split + generic types + debug contract
+
+**Status:** Proposed
+**Date:** 2026-04-30
+**Scope:** `swebench-verified-cube`, `swebench-live-cube`, `terminalbench-cube`
+**Branch:** `feat/benchmark-config` (cube-harness)
+**Requires:** cube-standard `nico_fix` PR #124 (generic `TaskConfig` / `BenchmarkConfig` / `Benchmark`) — already pinned as the cube-standard rev in `pyproject.toml`
+**Related:** cube-standard archived `2026-04-24-benchmark-config`, `2026-04-27-typed-task-execution-info`
+
+---
+
+## Context
+
+Three changes landed in cube-standard that together define the new cube contract:
+
+| cube-standard change | What it introduced |
+|-----|----|
+| PR #118 — `feat/benchmark-config` | `BenchmarkConfig` / `Benchmark` split. `BenchmarkConfig` is the serialisable registry and entry-point target; owns `install()`, `get_task_configs()`. `Benchmark` is pure runtime. |
+| PR #121 — `feat/typed-task-execution-info` | Typed `TaskExecutionInfo` slot replaces `extra_info: dict`; `metadata` field stamped on `TaskConfig` by `get_task_configs()` so workers never import `BenchmarkConfig`. |
+| PR #124 — `nico_fix` (open) | `Task`, `TaskConfig`, `BenchmarkConfig`, `Benchmark` made generic via PEP 695. Cubes write `class FooTaskConfig(TaskConfig[FooTaskMetadata]):` — no `# type: ignore` re-annotations. |
+
+All three SWE cubes pre-date these changes and violate the current spec.
+
+---
+
+## Pre-conditions confirmed
+
+| Item | Status |
+|------|--------|
+| cube-standard `feat/benchmark-config` merged (PR #118, Apr 28) | ✅ |
+| cube-standard `nico_fix` pinned in cube-harness `pyproject.toml` (commit `7711c73`) | ✅ |
+| `swe_agent_recipe` PR merged — deleted 3 old-style hello_* recipes (commit `40b45513`) | ✅ |
+| Infra pattern already correct (`InfraConfig`, `cleanup_stale()`, `launch_task_container()`) | ✅ |
+| No unit tests exist for any of the three cubes | ⚠️ gap — addressed here |
+
+---
+
+## Problem inventory (identical across all three cubes)
+
+| # | Violation | All three? |
+|---|-----------|:----------:|
+| 1 | `Benchmark` class holds ClassVars (`benchmark_metadata`, `task_metadata`, `task_config_class`) — must be on `BenchmarkConfig` | ✗ |
+| 2 | `Benchmark` class holds user fields (`infra`, `oracle_mode`, `include_hints`) — must be on `BenchmarkConfig` | ✗ |
+| 3 | `install()` / `uninstall()` / `get_task_configs()` on `Benchmark` — must be on `BenchmarkConfig` | ✗ |
+| 4 | `get_task_configs()` emits `task_id=tm.id` — must stamp `metadata=tm` | ✗ |
+| 5 | `task.py` circular import: `BenchmarkClass.task_metadata[self.task_id]` — eliminated by stamping | ✗ |
+| 6 | Entry point names `Benchmark` — must name `BenchmarkConfig` | ✗ |
+| 7 | `debug.py` calls `install()` + `setup()` inside `get_debug_benchmark()` — pure factory required | ✗ |
+| 8 | `task.py make()` keeps deprecated `container_backend` param | swebench-live + terminalbench pass it to Task; swebench-verified declares but doesn't use it |
+| 9 | No unit tests | ✗ |
+
+**Additionally (cube-harness shared):**
+- `debug_harness.py` calls `bench.setup()` after `get_debug_benchmark()` — will break once cubes return `BenchmarkConfig` (which has no `.setup()`)
+
+---
+
+## Per-cube differences
+
+| Aspect | swebench-verified | swebench-live | terminalbench |
+|--------|:-----------------:|:-------------:|:-------------:|
+| User fields on Config | `include_hints`, `oracle_mode`, `infra` | `include_hints`, `oracle_mode`, `infra` | `oracle_mode`, `infra` |
+| `container_backend` in `make()` | declared unused — drop signature | fallback path + passed to Task — remove both | fallback path + passed to Task — remove both |
+| `ContainerBackend` import in `task.py` | not imported | imported, now unused — remove | imported, now unused — remove |
+
+---
+
+## Migration pattern
+
+### `benchmark.py` — split into Config + Benchmark
+
+```python
+class SWEBenchVerifiedBenchmark(Benchmark["SWEBenchVerifiedBenchmarkConfig"]):
+
+    def _setup(self) -> None:
+        self.config.infra.cleanup_stale()
+        self._runtime_context["infra"] = self.config.infra
+
+    def close(self) -> None:
+        pass
+
+
+class SWEBenchVerifiedBenchmarkConfig(BenchmarkConfig[SWEBenchVerifiedTaskMetadata]):
+
+    benchmark_metadata: ClassVar[BenchmarkMetadata] = BenchmarkMetadata(...)
+    task_metadata: ClassVar[dict[str, SWEBenchVerifiedTaskMetadata]]
+    task_config_class: ClassVar[type[TaskConfig]] = SWEBenchVerifiedTaskConfig
+    benchmark_class: ClassVar[type[Benchmark]] = SWEBenchVerifiedBenchmark
+
+    include_hints: bool = False
+    oracle_mode: bool = False
+    infra: InfraConfig = Field(default_factory=LocalInfraConfig)
+
+    @classmethod
+    def install(cls) -> None: ...
+
+    @classmethod
+    def uninstall(cls) -> None: ...
+
+    def get_task_configs(self) -> Generator[TaskConfig, None, None]:
+        for tm in self.tasks().values():
+            yield SWEBenchVerifiedTaskConfig(
+                metadata=tm,                   # ← stamp; not task_id=tm.id
+                tool_config=self.tool_config,
+                seed=None,
+                include_hints=self.include_hints,
+                oracle_mode=self.oracle_mode,
+            )
+```
+
+Note: `infra` is accessed via `self.config.infra` inside `_setup()` — `Benchmark` has no fields of its own.
+
+### `task.py` — drop circular import, drop deprecated param
+
+```python
+class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
+
+    include_hints: bool = False
+    oracle_mode: bool = False
+
+    def make(self, runtime_context: RuntimeContext | None = None) -> SWEBenchVerifiedTask:
+        if runtime_context is None or "infra" not in runtime_context:
+            raise ValueError("requires runtime_context['infra']")
+
+        exec_info = self.load_task_execution_info(self.task_id)
+        metadata = self.metadata.model_copy(         # ← self.metadata, no import
+            update={"extra_info": {**exec_info,
+                                   "include_hints": self.include_hints,
+                                   "oracle_mode": self.oracle_mode}}
+        )
+        return SWEBenchVerifiedTask(
+            metadata=metadata,
+            tool_config=self.tool_config or SWEBenchToolConfig(),
+            runtime_context=runtime_context,
+        )
+```
+
+### `debug.py` — pure factory
+
+```python
+def get_debug_benchmark(infra: InfraConfig | None = None) -> SWEBenchVerifiedBenchmarkConfig:
+    return SWEBenchVerifiedBenchmarkConfig(
+        infra=infra or LocalInfraConfig(),
+        oracle_mode=True,
+    ).subset_from_list(list(_TASK_ACTIONS))
+```
+
+No `install()`, no `setup()`. The harness owns both.
+
+### `debug_harness.py` — call `install()` + `make()` instead of `setup()`
+
+```python
+# integration-tests/cube_integration_tests/debug_harness.py
+
+config = cube_debug_module.get_debug_benchmark(infra=infra)
+config.install()
+benchmark = config.make()
+task_configs = [tc for tc in config.get_task_configs() if tc.task_id == task_id]
+tc = task_configs[0]
+task = tc.make(runtime_context=benchmark._runtime_context)
+```
+
+### `pyproject.toml`
+
+```toml
+swebench-verified-cube = "swebench_verified_cube.benchmark:SWEBenchVerifiedBenchmarkConfig"
+```
+
+### `__init__.py`
+
+```python
+from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmark, SWEBenchVerifiedBenchmarkConfig
+```
+
+---
+
+## Files changed
+
+Per cube (×3):
+
+| File | Change |
+|------|--------|
+| `benchmark.py` | Split into `BenchmarkConfig` + `Benchmark`; use generic types |
+| `task.py` | Drop `container_backend`; remove circular import; use `self.metadata` |
+| `debug.py` | Pure factory — drop `install()` and `setup()` |
+| `__init__.py` | Add `BenchmarkConfig` export |
+| `pyproject.toml` | Entry point → `BenchmarkConfig` class |
+| `tests/test_benchmark.py` (new) | Unit tests — no Docker required |
+
+Shared:
+
+| File | Change |
+|------|--------|
+| `recipes/swe_agent_recipe.py` | Update 3 instantiation sites to `BenchmarkConfig` |
+| `integration-tests/cube_integration_tests/debug_harness.py` | `bench.setup()` → `config.install()` + `config.make()` |
+
+**Total: 16 files, ~350–400 lines changed.**
+
+---
+
+## Unit test plan
+
+Five Docker-free tests per cube (`tests/test_benchmark.py`):
+
+| Test | What it validates |
+|------|-------------------|
+| `test_config_roundtrip` | `model_dump()` → `model_validate()` round-trips cleanly |
+| `test_task_metadata_loaded` | ClassVar populated at import; correct task count (500 / 1895 / 89) |
+| `test_get_task_configs_stamps_metadata` | Every emitted `TaskConfig.metadata.id` matches the task |
+| `test_subset_from_list` | Scopes to exactly the requested task IDs |
+| `test_debug_benchmark_type` | `get_debug_benchmark()` returns a `BenchmarkConfig` instance |
+
+Existing `integration-tests/test_debug_matrix.py` covers e2e and does not need to change.
+
+---
+
+## Commit plan
+
+```
+feat(swebench-verified): migrate to BenchmarkConfig split + generic types
+feat(swebench-live): migrate to BenchmarkConfig split + generic types
+feat(terminalbench): migrate to BenchmarkConfig split + generic types
+test: add unit tests for swebench-verified, swebench-live, terminalbench
+fix(recipe): update swe_agent_recipe to BenchmarkConfig classes
+fix(debug-harness): call install()+make() instead of setup()
+```
+
+See [deltas.md](deltas.md) for the two spec clarifications.


### PR DESCRIPTION
## Summary

- Adds `openspec/changes/swe-cube-benchmarkconfig-migration/` — migration plan and spec deltas
- Implementation follows in subsequent commits on this branch

## What this PR will do

Migrates three SWE cubes from the pre-split `Benchmark`-only pattern to the current cube-standard contract (`BenchmarkConfig` + `Benchmark` split, generic types, stamped metadata). Requires cube-standard `nico_fix` (PR #124), already pinned in `pyproject.toml`.

**9 violations fixed across all three cubes:**
1. ClassVars moved from `Benchmark` → `BenchmarkConfig`
2. User fields (`infra`, `oracle_mode`, `include_hints`) moved to `BenchmarkConfig`
3. `install()` / `get_task_configs()` moved to `BenchmarkConfig`
4. `get_task_configs()` stamps `metadata=tm` (was `task_id=tm.id`)
5. Circular import in `task.py` eliminated (replaced by `self.metadata`)
6. Entry points updated to name `BenchmarkConfig` class
7. `debug.py` made a pure factory — no `install()` / `setup()`
8. Deprecated `container_backend` param removed from `task.py make()`
9. Unit tests added (5 Docker-free tests per cube)

**Shared files also updated:**
- `recipes/swe_agent_recipe.py` — 3 instantiation sites
- `integration-tests/cube_integration_tests/debug_harness.py` — `bench.setup()` → `config.install()` + `config.make()`

## This commit (openspec only)

The plan is in `openspec/changes/swe-cube-benchmarkconfig-migration/proposal.md`. Implementation commits follow.

## Test plan

- [ ] `pytest cubes/swebench-verified-cube/tests/` (new unit tests, no Docker)
- [ ] `pytest cubes/swebench-live-cube/tests/` (new unit tests, no Docker)
- [ ] `pytest cubes/terminalbench-cube/tests/` (new unit tests, no Docker)
- [ ] `cube test swebench-verified-cube` (requires Docker + installed cube)
- [ ] Integration matrix: `swebench_verified × local`, `swebench_live × local`, `terminalbench × local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)