### PR TITLE
feat(trace): generalize ch-trace for coding episodes; add --eval flag

### DIFF
--- a/.claude/commands/meta-agent.md
+++ b/.claude/commands/meta-agent.md
@@ -42,6 +42,25 @@ Token cost, wall-clock time, parallelism, benchmark setup overhead. Worth fixing
 
 ---
 
+## Task Scouting (do this before picking tasks)
+
+Before running anything, check the signal quality of candidate tasks. A task with 400 noisy tests will score 0.0 even on a correct fix. Prefer tasks with 1–5 `fail_to_pass` tests — they give clean pass/fail signal.
+
+For **SWE-bench Verified** specifically:
+```python
+# Print task IDs sorted by fail_to_pass count (ascending = easier signal)
+uv run --with-editable cubes/swebench-verified-cube python3 - <<'EOF'
+import json
+from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmark
+b = SWEBenchVerifiedBenchmark()
+rows = [(tid, len(json.loads(b.load_task_execution_info(tid)["fail_to_pass"]))) for tid in list(b.task_metadata)[:50]]
+for tid, n in sorted(rows, key=lambda x: x[1])[:10]:
+    print(n, tid)
+EOF
+```
+
+---
+
 ## Debugging Strategy
 
 **Pick tasks that fail but should succeed.** Avoid tasks with fundamental ambiguity or that require capabilities the agent fundamentally lacks. A task that sometimes passes is a better target than one that never passes.
@@ -83,6 +102,11 @@ benchmark = MiniWobSubset(default_tool_config=tool_config, task_ids=task_ids)
 ```
 Empty list = all 125 tasks. List all IDs: `MiniWobBenchmark.task_metadata.keys()`.
 
+> **Footgun — `max_actions` vs `max_steps`**: `ReactAgentConfig.max_actions` (default 10) is
+> checked *agent-side* before `Experiment.max_steps`. If you raise `max_steps` in the recipe
+> without also raising `max_actions`, the agent will stop at turn 10 with reward 0 and no
+> eval call. Always set both to the same value for SWE-bench style tasks (30+ recommended).
+
 ---
 
 ## Reading Traces
@@ -91,8 +115,14 @@ Empty list = all 125 tasks. List all IDs: `MiniWobBenchmark.task_metadata.keys()
 ```bash
 ch-trace <episode_dir>
 # e.g. ch-trace ~/cube_harness_results/.../episodes/workarena.servicenow.create-incident_ep0
+
+# For coding benchmarks (SWE-bench etc.) also dump the test eval output:
+ch-trace <episode_dir> --eval
 ```
-Two lines per turn: action + result on line 1, page title + reward on line 2. Fast way to see what the agent did without opening a browser.
+Two lines per turn: action + result on line 1, context + reward on line 2. For browser tasks
+the context is the page title; for coding tasks it's the first non-empty line of the tool
+result (e.g. a pytest summary line). `--eval` additionally prints the `resolved` flag and
+full `fail_to_pass_output` from the last environment step.
 
 **Step 2 — experiment-level summary:**
 ```python

--- a/.claude/commands/meta-agent.md
+++ b/.claude/commands/meta-agent.md
@@ -42,25 +42,6 @@ Token cost, wall-clock time, parallelism, benchmark setup overhead. Worth fixing
 
 ---
 
-## Task Scouting (do this before picking tasks)
-
-Before running anything, check the signal quality of candidate tasks. A task with 400 noisy tests will score 0.0 even on a correct fix. Prefer tasks with 1–5 `fail_to_pass` tests — they give clean pass/fail signal.
-
-For **SWE-bench Verified** specifically:
-```python
-# Print task IDs sorted by fail_to_pass count (ascending = easier signal)
-uv run --with-editable cubes/swebench-verified-cube python3 - <<'EOF'
-import json
-from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmark
-b = SWEBenchVerifiedBenchmark()
-rows = [(tid, len(json.loads(b.load_task_execution_info(tid)["fail_to_pass"]))) for tid in list(b.task_metadata)[:50]]
-for tid, n in sorted(rows, key=lambda x: x[1])[:10]:
-    print(n, tid)
-EOF
-```
-
----
-
 ## Debugging Strategy
 
 **Pick tasks that fail but should succeed.** Avoid tasks with fundamental ambiguity or that require capabilities the agent fundamentally lacks. A task that sometimes passes is a better target than one that never passes.
@@ -105,7 +86,7 @@ Empty list = all 125 tasks. List all IDs: `MiniWobBenchmark.task_metadata.keys()
 > **Footgun — `max_actions` vs `max_steps`**: `ReactAgentConfig.max_actions` (default 10) is
 > checked *agent-side* before `Experiment.max_steps`. If you raise `max_steps` in the recipe
 > without also raising `max_actions`, the agent will stop at turn 10 with reward 0 and no
-> eval call. Always set both to the same value for SWE-bench style tasks (30+ recommended).
+> eval call. Always set both to the same value when raising above the default.
 
 ---
 
@@ -116,13 +97,13 @@ Empty list = all 125 tasks. List all IDs: `MiniWobBenchmark.task_metadata.keys()
 ch-trace <episode_dir>
 # e.g. ch-trace ~/cube_harness_results/.../episodes/workarena.servicenow.create-incident_ep0
 
-# For coding benchmarks (SWE-bench etc.) also dump the test eval output:
+# Also dump eval fields from the last environment step:
 ch-trace <episode_dir> --eval
 ```
 Two lines per turn: action + result on line 1, context + reward on line 2. For browser tasks
-the context is the page title; for coding tasks it's the first non-empty line of the tool
-result (e.g. a pytest summary line). `--eval` additionally prints the `resolved` flag and
-full `fail_to_pass_output` from the last environment step.
+the context is the page title; for coding/terminal tasks it's the first non-empty line of the
+tool result (e.g. a pytest summary line). `--eval` additionally prints eval fields from the
+last environment step — useful for test-based benchmarks.
 
 **Step 2 — experiment-level summary:**
 ```python

--- a/src/cube_harness/analyze/trace.py
+++ b/src/cube_harness/analyze/trace.py
@@ -5,11 +5,15 @@ did step by step without opening a browser.
 
 Usage:
     ch-trace <episode_dir>
+    ch-trace <episode_dir> --eval        # also dump eval output (e.g. SWE-bench test results)
     ch-trace experiments/workarena-l1/workarena.servicenow.create-incident_ep0
 
 Output: two lines per turn —
     T00 fill(bid=123, value='CHG…')           [Success  ]
          ServiceNow | Create Change Request    r=0.0
+
+    T00 bash(command='python -m pytest…')     [PASSED  ]
+         [100%] 5 passed in 0.3s              r=0.0
 
 Data model
 ----------
@@ -23,11 +27,15 @@ The observation's contents list is heterogeneous:
     - entries with a tool_call_id  →  the direct result string for the preceding action
     - entries without              →  raw page state (AXTree text, screenshot bytes, …)
 
-Page title is extracted from the AXTree text via the accessibility tree root label
-"RootWebArea '<title>'", which BrowserGym includes in every AXTree observation.
+Context line (line 2): for browser episodes the page title is extracted from the AXTree
+"RootWebArea '<title>'" label. For coding/terminal episodes the first non-empty line of
+the tool result is shown instead.
 
 Episode-level outcome (final reward, done, validation message) is read from
 episode.metadata.json, written by the harness after the episode ends.
+
+--eval prints eval fields (resolved, fail_to_pass_passed, test output) from the last
+EnvironmentOutput step — useful for SWE-bench and other test-based evaluations.
 """
 
 from __future__ import annotations
@@ -53,9 +61,15 @@ def _decompress(path: Path) -> dict[str, Any]:
     return msgpack.unpackb(dctx.decompress(data), raw=False)
 
 
-def _page_title(obs_output: dict[str, Any]) -> str:
-    """Extract page title from an EnvironmentOutput's obs contents."""
+def _context_line(obs_output: dict[str, Any]) -> str:
+    """Return a short context string for line 2.
+
+    Browser episodes: extract page title from AXTree "RootWebArea '<title>'" label.
+    Coding/terminal episodes: fall back to the first non-empty line of the tool result.
+    """
     contents = obs_output.get("obs", {}).get("contents", [])
+
+    # Browser path: look for AXTree root label
     for content in contents:
         if not isinstance(content, dict):
             continue
@@ -65,9 +79,18 @@ def _page_title(obs_output: dict[str, Any]) -> str:
         m = re.search(r"RootWebArea '([^']+)'", text)
         if m:
             title = m.group(1)
-            # Trim common ServiceNow suffix noise
             title = re.sub(r"\s*\|\s*ServiceNow$", "", title)
             return title[:60]
+
+    # Coding/terminal path: first non-empty line of any tool result
+    for c in contents:
+        if isinstance(c, dict) and c.get("tool_call_id"):
+            data = c.get("data", "") or ""
+            if isinstance(data, str):
+                for line in data.splitlines():
+                    line = line.strip()
+                    if line:
+                        return line[:60]
     return ""
 
 
@@ -80,7 +103,6 @@ def _action_summary(act_output: dict[str, Any]) -> str:
     a = actions[0]
     name = a.get("name", "?")
     args = a.get("arguments", {})
-    # Compact arg representation
     parts = []
     for k, v in args.items():
         if isinstance(v, str) and len(v) > 20:
@@ -90,7 +112,7 @@ def _action_summary(act_output: dict[str, Any]) -> str:
 
 
 def _result_from_obs(obs_output: dict[str, Any]) -> str:
-    """Extract action result string from the first content of an obs (tool_call_id response)."""
+    """Extract action result string from the first tool_call_id content in an obs."""
     contents = obs_output.get("obs", {}).get("contents", [])
     for c in contents:
         if isinstance(c, dict) and c.get("tool_call_id"):
@@ -112,10 +134,8 @@ def render_trace(ep_dir: Path, console: Console) -> None:
         console.print(f"[red]No step files in {steps_dir}[/red]")
         return
 
-    # Load all steps
     steps: list[dict[str, Any]] = [_decompress(f) for f in step_files]
 
-    # Read episode metadata for task_id
     meta_file = ep_dir / "episode.metadata.json"
     task_id = ep_dir.name
     if meta_file.exists():
@@ -137,18 +157,16 @@ def render_trace(ep_dir: Path, console: Console) -> None:
             obs_step = steps[i + 1] if i + 1 < len(steps) else {}
             obs_out = obs_step.get("output", {})
             result = _result_from_obs(obs_out)
-            page = _page_title(obs_out)
+            context = _context_line(obs_out)
             reward = obs_out.get("reward", 0.0)
             msg = (obs_out.get("info") or {}).get("message", "")
-            rows.append((turn, action_str, result, page, reward, msg))
+            rows.append((turn, action_str, result, context, reward, msg))
             turn += 1
             i += 2
         else:
             i += 1
 
-    # Two-line format: action+result on line 1, page+reward+msg on line 2
-    for t, action_str, result, page, reward, msg in rows:
-        # Result colour
+    for t, action_str, result, context, reward, msg in rows:
         if result.startswith("Failed") or result.startswith("[error"):
             res_style = "red"
         elif result == "Success":
@@ -163,7 +181,7 @@ def render_trace(ep_dir: Path, console: Console) -> None:
         line1.append(f"  [{result[:9]:9}]", style=res_style)
         line2 = Text()
         line2.append("     ", style="dim")
-        line2.append(f"{page[:44]:<44}", style="dim")
+        line2.append(f"{context[:44]:<44}", style="dim")
         line2.append("  r=", style="dim")
         line2.append(f"{reward:.1f}", style=rew_style)
         if msg:
@@ -171,7 +189,6 @@ def render_trace(ep_dir: Path, console: Console) -> None:
         console.print(line1)
         console.print(line2)
 
-    # Print final reward from metadata
     if meta_file.exists():
         meta = json.loads(meta_file.read_text())
         final_reward = meta.get("reward_info", {}).get("reward", "?")
@@ -179,6 +196,66 @@ def render_trace(ep_dir: Path, console: Console) -> None:
         msg = meta.get("reward_info", {}).get("message", "")
         status = "[green]✓ SOLVED[/green]" if final_reward == 1.0 else "[red]✗ FAILED[/red]"
         console.print(f"\n{status}  reward={final_reward}  done={done}  msg={msg!r}\n")
+
+
+def render_eval(ep_dir: Path, console: Console) -> None:
+    """Dump eval fields from the last EnvironmentOutput step (SWE-bench and similar).
+
+    Prints resolved, fail_to_pass_passed, pass_to_pass_passed flags and the full
+    test output captured during evaluation.
+    """
+    steps_dir = ep_dir / "steps"
+    if not steps_dir.exists():
+        console.print(f"[red]No steps/ directory in {ep_dir}[/red]")
+        return
+
+    step_files = sorted(steps_dir.glob("*.msgpack.zst"))
+    if not step_files:
+        console.print(f"[red]No step files in {steps_dir}[/red]")
+        return
+
+    steps: list[dict[str, Any]] = [_decompress(f) for f in step_files]
+
+    # Walk from the end — eval info lands in the last EnvironmentOutput
+    info: dict[str, Any] = {}
+    for step in reversed(steps):
+        output = step.get("output", {})
+        if "AgentOutput" not in output.get("_type", ""):
+            info = output.get("info") or {}
+            if info:
+                break
+
+    if not info:
+        console.print("[yellow]No eval info found in episode steps.[/yellow]")
+        return
+
+    resolved = info.get("resolved")
+    f2p_passed = info.get("fail_to_pass_passed")
+    p2p_passed = info.get("pass_to_pass_passed")
+
+    if resolved is None and f2p_passed is None:
+        console.print("[yellow]No eval fields in last step info (not a test-based task?).[/yellow]")
+        return
+
+    console.print("\n[bold]Eval result:[/bold]")
+    for label, val in [
+        ("resolved            ", resolved),
+        ("fail_to_pass_passed ", f2p_passed),
+        ("pass_to_pass_passed ", p2p_passed),
+    ]:
+        if val is not None:
+            style = "green" if val else "red"
+            console.print(f"  {label} [{style}]{val}[/{style}]")
+
+    f2p_output = info.get("fail_to_pass_output", "")
+    if f2p_output:
+        console.print("\n[bold]fail_to_pass output:[/bold]")
+        console.print(f2p_output)
+
+    p2p_output = info.get("pass_to_pass_output", "")
+    if p2p_output:
+        console.print("\n[bold]pass_to_pass output:[/bold]")
+        console.print(p2p_output)
 
 
 def main() -> None:
@@ -190,6 +267,11 @@ def main() -> None:
     )
     parser.add_argument("episode_dir", help="Path to episode directory (contains steps/)")
     parser.add_argument("--no-color", action="store_true", help="Disable color output")
+    parser.add_argument(
+        "--eval",
+        action="store_true",
+        help="Also dump eval fields (resolved, test output) from the last environment step",
+    )
     args = parser.parse_args()
 
     ep_dir = Path(args.episode_dir).expanduser().resolve()
@@ -199,3 +281,5 @@ def main() -> None:
 
     console = Console(highlight=False, no_color=args.no_color)
     render_trace(ep_dir, console)
+    if args.eval:
+        render_eval(ep_dir, console)

--- a/src/cube_harness/analyze/trace.py
+++ b/src/cube_harness/analyze/trace.py
@@ -5,7 +5,7 @@ did step by step without opening a browser.
 
 Usage:
     ch-trace <episode_dir>
-    ch-trace <episode_dir> --eval        # also dump eval output (e.g. SWE-bench test results)
+    ch-trace <episode_dir> --eval        # also dump eval fields from last environment step
     ch-trace experiments/workarena-l1/workarena.servicenow.create-incident_ep0
 
 Output: two lines per turn —
@@ -34,8 +34,7 @@ the tool result is shown instead.
 Episode-level outcome (final reward, done, validation message) is read from
 episode.metadata.json, written by the harness after the episode ends.
 
---eval prints eval fields (resolved, fail_to_pass_passed, test output) from the last
-EnvironmentOutput step — useful for SWE-bench and other test-based evaluations.
+--eval prints all fields from the last EnvironmentOutput's info dict.
 """
 
 from __future__ import annotations
@@ -68,8 +67,6 @@ def _context_line(obs_output: dict[str, Any]) -> str:
     Coding/terminal episodes: fall back to the first non-empty line of the tool result.
     """
     contents = obs_output.get("obs", {}).get("contents", [])
-
-    # Browser path: look for AXTree root label
     for content in contents:
         if not isinstance(content, dict):
             continue
@@ -78,11 +75,8 @@ def _context_line(obs_output: dict[str, Any]) -> str:
             continue
         m = re.search(r"RootWebArea '([^']+)'", text)
         if m:
-            title = m.group(1)
-            title = re.sub(r"\s*\|\s*ServiceNow$", "", title)
+            title = re.sub(r"\s*\|\s*ServiceNow$", "", m.group(1))
             return title[:60]
-
-    # Coding/terminal path: first non-empty line of any tool result
     for c in contents:
         if isinstance(c, dict) and c.get("tool_call_id"):
             data = c.get("data", "") or ""
@@ -199,11 +193,7 @@ def render_trace(ep_dir: Path, console: Console) -> None:
 
 
 def render_eval(ep_dir: Path, console: Console) -> None:
-    """Dump eval fields from the last EnvironmentOutput step (SWE-bench and similar).
-
-    Prints resolved, fail_to_pass_passed, pass_to_pass_passed flags and the full
-    test output captured during evaluation.
-    """
+    """Dump all fields from the last EnvironmentOutput step's info dict."""
     steps_dir = ep_dir / "steps"
     if not steps_dir.exists():
         console.print(f"[red]No steps/ directory in {ep_dir}[/red]")
@@ -216,7 +206,6 @@ def render_eval(ep_dir: Path, console: Console) -> None:
 
     steps: list[dict[str, Any]] = [_decompress(f) for f in step_files]
 
-    # Walk from the end — eval info lands in the last EnvironmentOutput
     info: dict[str, Any] = {}
     for step in reversed(steps):
         output = step.get("output", {})
@@ -226,36 +215,22 @@ def render_eval(ep_dir: Path, console: Console) -> None:
                 break
 
     if not info:
-        console.print("[yellow]No eval info found in episode steps.[/yellow]")
+        console.print("[yellow]No eval fields found in last environment step.[/yellow]")
         return
 
-    resolved = info.get("resolved")
-    f2p_passed = info.get("fail_to_pass_passed")
-    p2p_passed = info.get("pass_to_pass_passed")
-
-    if resolved is None and f2p_passed is None:
-        console.print("[yellow]No eval fields in last step info (not a test-based task?).[/yellow]")
-        return
-
-    console.print("\n[bold]Eval result:[/bold]")
-    for label, val in [
-        ("resolved            ", resolved),
-        ("fail_to_pass_passed ", f2p_passed),
-        ("pass_to_pass_passed ", p2p_passed),
-    ]:
-        if val is not None:
+    console.print("\n[bold]Eval info:[/bold]")
+    blocks: list[tuple[str, str]] = []
+    for key, val in info.items():
+        if isinstance(val, bool):
             style = "green" if val else "red"
-            console.print(f"  {label} [{style}]{val}[/{style}]")
-
-    f2p_output = info.get("fail_to_pass_output", "")
-    if f2p_output:
-        console.print("\n[bold]fail_to_pass output:[/bold]")
-        console.print(f2p_output)
-
-    p2p_output = info.get("pass_to_pass_output", "")
-    if p2p_output:
-        console.print("\n[bold]pass_to_pass output:[/bold]")
-        console.print(p2p_output)
+            console.print(f"  {key:<30} [{style}]{val}[/{style}]")
+        elif isinstance(val, str) and ("\n" in val or len(val) > 80):
+            blocks.append((key, val))
+        else:
+            console.print(f"  {key:<30} {val!r}")
+    for key, val in blocks:
+        console.print(f"\n[bold]{key}:[/bold]")
+        console.print(val)
 
 
 def main() -> None:
@@ -270,7 +245,7 @@ def main() -> None:
     parser.add_argument(
         "--eval",
         action="store_true",
-        help="Also dump eval fields (resolved, test output) from the last environment step",
+        help="Also dump eval fields from the last environment step's info dict",
     )
     args = parser.parse_args()
 

--- a/src/cube_harness/analyze/trace.py
+++ b/src/cube_harness/analyze/trace.py
@@ -61,11 +61,7 @@ def _decompress(path: Path) -> dict[str, Any]:
 
 
 def _context_line(obs_output: dict[str, Any]) -> str:
-    """Return a short context string for line 2.
-
-    Browser episodes: extract page title from AXTree "RootWebArea '<title>'" label.
-    Coding/terminal episodes: fall back to the first non-empty line of the tool result.
-    """
+    """Page title for browser episodes; first non-empty tool-result line for coding/terminal."""
     contents = obs_output.get("obs", {}).get("contents", [])
     for content in contents:
         if not isinstance(content, dict):
@@ -116,19 +112,24 @@ def _result_from_obs(obs_output: dict[str, Any]) -> str:
     return ""
 
 
-def render_trace(ep_dir: Path, console: Console) -> None:
-    """Render a compact two-line-per-turn trace for a single episode directory."""
+def _load_steps(ep_dir: Path, console: Console) -> list[dict[str, Any]] | None:
+    """Load all step files from ep_dir/steps/; print error and return None on failure."""
     steps_dir = ep_dir / "steps"
     if not steps_dir.exists():
         console.print(f"[red]No steps/ directory in {ep_dir}[/red]")
-        return
-
+        return None
     step_files = sorted(steps_dir.glob("*.msgpack.zst"))
     if not step_files:
         console.print(f"[red]No step files in {steps_dir}[/red]")
-        return
+        return None
+    return [_decompress(f) for f in step_files]
 
-    steps: list[dict[str, Any]] = [_decompress(f) for f in step_files]
+
+def render_trace(ep_dir: Path, console: Console) -> None:
+    """Render a compact two-line-per-turn trace for a single episode directory."""
+    steps = _load_steps(ep_dir, console)
+    if steps is None:
+        return
 
     meta_file = ep_dir / "episode.metadata.json"
     task_id = ep_dir.name
@@ -194,17 +195,9 @@ def render_trace(ep_dir: Path, console: Console) -> None:
 
 def render_eval(ep_dir: Path, console: Console) -> None:
     """Dump all fields from the last EnvironmentOutput step's info dict."""
-    steps_dir = ep_dir / "steps"
-    if not steps_dir.exists():
-        console.print(f"[red]No steps/ directory in {ep_dir}[/red]")
+    steps = _load_steps(ep_dir, console)
+    if steps is None:
         return
-
-    step_files = sorted(steps_dir.glob("*.msgpack.zst"))
-    if not step_files:
-        console.print(f"[red]No step files in {steps_dir}[/red]")
-        return
-
-    steps: list[dict[str, Any]] = [_decompress(f) for f in step_files]
 
     info: dict[str, Any] = {}
     for step in reversed(steps):


### PR DESCRIPTION
## Summary

- `ch-trace` now works for coding/terminal episodes: shows first non-empty tool-result line as context instead of AXTree page title
- New `--eval` flag dumps all fields from the last environment step's `info` dict (useful for debugging eval scores)
- Extracted `_load_steps()` helper to eliminate duplicated step-loading logic between `render_trace()` and `render_eval()`
- Collapsed `_context_line()` docstring to one line per project style

> Note: replaces #318 which was accidentally merged into `feat/meta-agent-1-scaffolding` instead of `main`.

## Test plan

- [ ] `ch-trace <swebench-episode-dir>` — shows tool result lines instead of blank context
- [ ] `ch-trace <browser-episode-dir>` — page title still shown (AXTree path unchanged)
- [ ] `ch-trace <episode-dir> --eval` — dumps eval info dict fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)