### PR TITLE
fix(meta-agent): restore --eval flag and coding/terminal trace doc

### DIFF
--- a/.claude/commands/meta-agent.md
+++ b/.claude/commands/meta-agent.md
@@ -107,8 +107,14 @@ Empty list = all 125 tasks. List all IDs: `MiniWobBenchmark.task_metadata.keys()
 ```bash
 ch-trace <episode_dir>
 # e.g. ch-trace ~/cube_harness_results/.../episodes/workarena.servicenow.create-incident_ep0
+
+# Also dump eval fields from the last environment step:
+ch-trace <episode_dir> --eval
 ```
-Two lines per turn: action + result on line 1, page title + reward on line 2. Fast way to see what the agent did without opening a browser.
+Two lines per turn: action + result on line 1, context + reward on line 2. For browser tasks
+the context is the page title; for coding/terminal tasks it's the first non-empty line of the
+tool result (e.g. a pytest summary line). `--eval` additionally prints eval fields from the
+last environment step — useful for test-based benchmarks.
 
 **Step 2 — experiment-level summary:**
 ```python


### PR DESCRIPTION
## Summary

PR #340 accidentally overwrote the ch-trace section that #339 had updated, because #340 was built from a branch predating #339. Restores the two changes:

- `--eval` flag usage in the code block
- Updated description: context is page title for browser, first tool-result line for coding/terminal; `--eval` dumps eval fields from last env step

One-line diff otherwise; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)