### PR TITLE
Fix osworld

### DIFF
--- a/cubes/osworld-cube/scripts/create_task_metadata.py
+++ b/cubes/osworld-cube/scripts/create_task_metadata.py
@@ -5,6 +5,11 @@ This is a developer tool. Run it after cloning (or updating) the OSWorld repo
 to regenerate the shipped package resource. The output file is committed to
 the repository - end users never need to run this script.
 
+Only lightweight public fields are written (instruction, domain, test_sets,
+snapshot, os_type, related_apps). Heavy execution data (config, evaluator) is
+written by OSWorldBenchmarkConfig.install() into the per-task execution cache
+and is never committed.
+
 The script clones the repo automatically if it is not already present.
 
 Usage:

--- a/recipes/osworld/eval_azure_osworld.py
+++ b/recipes/osworld/eval_azure_osworld.py
@@ -20,7 +20,7 @@ import sys
 
 from cube_infra_azure import AzureInfraConfig
 from dotenv import load_dotenv
-from osworld_cube.benchmark import OSWorldBenchmark
+from osworld_cube.benchmark import OSWorldBenchmarkConfig
 from osworld_cube.computer import ComputerConfig
 
 from cube_harness import make_experiment_output_dir
@@ -99,24 +99,19 @@ def main(debug: bool) -> None:
         observe_after_action=True,
     )
 
-    benchmark = OSWorldBenchmark(
-        default_tool_config=tool_config,
+    benchmark_config = OSWorldBenchmarkConfig(
+        tool_config=tool_config,
         use_som=False,
-        infra=INFRA,
     )
-    benchmark.install()
-    benchmark.setup()
-    benchmark = benchmark.named_subset("test_small")
-
-    # Provision all resources the benchmark needs (idempotent — no-ops if already ready).
-    for resource in benchmark.resources:
-        INFRA.provision(resource)
+    OSWorldBenchmarkConfig.install()
+    benchmark_config = benchmark_config.named_subset("test_small")
 
     exp = Experiment(
         name="osworld_azure_gpt5_mini",
         output_dir=output_dir,
         agent_config=agent_config,
-        benchmark=benchmark,
+        benchmark_config=benchmark_config,
+        infra=INFRA,
         max_steps=15,
     )
 

--- a/recipes/osworld/eval_osworld.py
+++ b/recipes/osworld/eval_osworld.py
@@ -18,7 +18,7 @@ Usage:
 
 import sys
 
-from osworld_cube.benchmark import OSWorldBenchmark
+from osworld_cube.benchmark import OSWorldBenchmarkConfig
 from osworld_cube.computer import ComputerConfig
 
 from cube_harness import make_experiment_output_dir
@@ -83,19 +83,18 @@ def main(debug: bool) -> None:
         observe_after_action=True,
     )
 
-    benchmark = OSWorldBenchmark(
-        default_tool_config=tool_config,
+    benchmark_config = OSWorldBenchmarkConfig(
+        tool_config=tool_config,
         use_som=False,
     )
-    benchmark.install()
-    benchmark.setup()
-    benchmark = benchmark.named_subset("test_small")
+    OSWorldBenchmarkConfig.install()
+    benchmark_config = benchmark_config.named_subset("test_small")
 
     exp = Experiment(
         name="osworld_genny_gpt5",
         output_dir=output_dir,
         agent_config=agent_config,
-        benchmark=benchmark,
+        benchmark_config=benchmark_config,
         max_steps=15,
     )
 

--- a/recipes/osworld/haiku.py
+++ b/recipes/osworld/haiku.py
@@ -24,7 +24,7 @@ Usage:
 import sys
 from datetime import datetime
 
-from osworld_cube.benchmark import OSWorldBenchmark
+from osworld_cube.benchmark import OSWorldBenchmarkConfig
 from osworld_cube.computer import ComputerConfig
 
 from cube_harness import make_experiment_output_dir
@@ -119,21 +119,20 @@ def main(debug: bool) -> None:
         observe_after_action=True,
     )
 
-    benchmark = OSWorldBenchmark(
-        default_tool_config=tool_config,
+    benchmark_config = OSWorldBenchmarkConfig(
+        tool_config=tool_config,
         use_som=False,
     )
-    benchmark.install()
-    benchmark.setup()
-    benchmark = benchmark.named_subset("test_small")
-    keep_ids = [tid for tid in benchmark.task_metadata if tid not in GDRIVE_TASK_IDS]
-    benchmark = benchmark.subset_from_list(keep_ids)
+    OSWorldBenchmarkConfig.install()
+    benchmark_config = benchmark_config.named_subset("test_small")
+    keep_ids = [tid for tid in benchmark_config.tasks() if tid not in GDRIVE_TASK_IDS]
+    benchmark_config = benchmark_config.subset_from_list(keep_ids)
 
     exp = Experiment(
         name="osworld_genny_haiku_3obs_100actions_v2",
         output_dir=output_dir,
         agent_config=agent_config,
-        benchmark=benchmark,
+        benchmark_config=benchmark_config,
         max_steps=100,
     )
 


### PR DESCRIPTION
## Fix osworld recipes for the rc7 BenchmarkConfig + Benchmark split

The osworld cube migrated to `BenchmarkConfig` + `Benchmark` in #324, but the three osworld recipes still use the pre-split API. They no longer construct or run. This PR adapts them to the rc7 contract. Also includes a docstring tweak on `create_task_metadata.py` to match the post-`install()`-split layout.

### What changed in every recipe (`eval_osworld.py`, `eval_azure_osworld.py`, `haiku.py`)

| Before | After |
|---|---|
| `from osworld_cube.benchmark import OSWorldBenchmark` | `from osworld_cube.benchmark import OSWorldBenchmarkConfig` |
| `OSWorldBenchmark(default_tool_config=…, infra=…)` | `OSWorldBenchmarkConfig(tool_config=…)` (`infra` no longer a config field) |
| `benchmark.install()` (instance method) | `OSWorldBenchmarkConfig.install()` (classmethod) |
| `benchmark.setup()` | gone — `BenchmarkConfig.make(infra)` does it; the harness owns `make` |
| `benchmark = benchmark.named_subset(...)` | `benchmark_config = benchmark_config.named_subset(...)` |
| `Experiment(benchmark=benchmark)` | `Experiment(benchmark_config=benchmark_config)` |

### Additionally in `eval_azure_osworld.py`
- Drops the manual `for resource in benchmark.resources: INFRA.provision(resource)` loop — `BenchmarkConfig.make(infra)` provisions declared resources idempotently.
- Adds `infra=INFRA` to the `Experiment` so the harness threads it into `make(infra)`.

### Additionally in `haiku.py`
- `benchmark.task_metadata` → `benchmark_config.tasks()` for the GDrive filter (read-side method on the config instead of poking the ClassVar).

### `cubes/osworld-cube/scripts/create_task_metadata.py`
Docstring-only: spells out that the script writes only lightweight public fields, while heavy execution data goes through `OSWorldBenchmarkConfig.install()`. No code change.

### Validation
- All three recipes import cleanly and `Experiment(...)` validates with the new fields.
- `haiku.py`'s `benchmark_config.tasks()` returns the same keys as the old `task_metadata` since no filter is in flight before that call.

### Commits
- `82d86e0` fix osworld recipes
- `c18d6f2` upd docs (docstring on create_task_metadata.py)