### PR TITLE
chore(cubes): migrate to cube-standard infra-init (PR #133)

### DIFF
--- a/cubes/arithmetic-cube/Makefile
+++ b/cubes/arithmetic-cube/Makefile
@@ -1,8 +1,12 @@
-.PHONY: test install
+.PHONY: install debug test
 
-test:
-	uv run python -m arithmetic_cube.debug
 
 install:
 	uv sync --all-extras
-	pip install -e .
+	uv pip install -e .
+
+debug:
+	uv run python -m arithmetic_cube.debug
+
+test:
+	uv run cube test arithmetic-cube

--- a/cubes/arithmetic-cube/pyproject.toml
+++ b/cubes/arithmetic-cube/pyproject.toml
@@ -14,6 +14,13 @@ arithmetic-cube = "arithmetic_cube.benchmark:ArithmeticBenchmarkConfig"
 requires = ["uv_build>=0.8,<0.9"]
 build-backend = "uv_build"
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/arithmetic-cube/pyproject.toml
+++ b/cubes/arithmetic-cube/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Simple arithmetic benchmark — submit the correct answer to math problems"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
 ]
 
 [project.entry-points."cube.benchmarks"]
@@ -13,13 +13,6 @@ arithmetic-cube = "arithmetic_cube.benchmark:ArithmeticBenchmarkConfig"
 [build-system]
 requires = ["uv_build>=0.8,<0.9"]
 build-backend = "uv_build"
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [tool.ruff]
 fix = true

--- a/cubes/arithmetic-cube/uv.lock
+++ b/cubes/arithmetic-cube/uv.lock
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cube-standard", specifier = ">=0.1.0rc7" }]
+requires-dist = [{ name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" }]
 
 [[package]]
 name = "certifi"
@@ -149,7 +149,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -161,10 +161,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [[package]]

--- a/cubes/arithmetic-cube/uv.lock
+++ b/cubes/arithmetic-cube/uv.lock
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" }]
+requires-dist = [{ name = "cube-standard", specifier = ">=0.1.0rc8" }]
 
 [[package]]
 name = "certifi"
@@ -148,8 +148,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -161,6 +161,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [[package]]

--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "MiniWob++ benchmark for cube"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
     "miniwob>=1.0",
     "cube-browser-tool"
 ]
@@ -18,13 +18,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/miniwob_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [tool.ruff]
 fix = true

--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -19,6 +19,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/miniwob_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/miniwob/src/miniwob_cube/benchmark.py
+++ b/cubes/miniwob/src/miniwob_cube/benchmark.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import ClassVar, Generator
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
+from cube.resource import InfraConfig
 from cube.task import TaskConfig
 
 from miniwob_cube.task import MiniWobTaskConfig, MiniWobTaskMetadata
@@ -20,8 +21,8 @@ logger = logging.getLogger(__name__)
 class MiniWobBenchmark(Benchmark["MiniWobBenchmarkConfig"]):
     """Runtime pair — owns the local HTTP server process serving MiniWob HTML."""
 
-    def __init__(self, config: "MiniWobBenchmarkConfig") -> None:
-        super().__init__(config)
+    def __init__(self, config: "MiniWobBenchmarkConfig", infra: InfraConfig | None = None) -> None:
+        super().__init__(config, infra=infra)
         self._server_process: subprocess.Popen | None = None
         self._stdout_file: TextIOWrapper | None = None
         self._stderr_file: TextIOWrapper | None = None

--- a/cubes/miniwob/uv.lock
+++ b/cubes/miniwob/uv.lock
@@ -221,7 +221,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -233,10 +233,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [[package]]
@@ -432,7 +428,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cube-browser-tool" },
-    { name = "cube-standard", specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "miniwob", specifier = ">=1.0" },
 ]
 

--- a/cubes/miniwob/uv.lock
+++ b/cubes/miniwob/uv.lock
@@ -220,8 +220,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -233,6 +233,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [[package]]
@@ -428,7 +432,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cube-browser-tool" },
-    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", specifier = ">=0.1.0rc8" },
     { name = "miniwob", specifier = ">=1.0" },
 ]
 

--- a/cubes/osworld-cube/pyproject.toml
+++ b/cubes/osworld-cube/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "OSWorld benchmark ported to the CUBE protocol"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
     "cube-computer-tool",
     "cube-vm-backend[docker]",
     "pillow>=9.0",
@@ -78,11 +78,6 @@ markers = [
 override-dependencies = ["protobuf>=6.33.5"]
 
 [tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop git pins once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 cube-computer-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-computer-tool" }
 cube-vm-backend = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-vm-backend" }
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }

--- a/cubes/osworld-cube/pyproject.toml
+++ b/cubes/osworld-cube/pyproject.toml
@@ -78,6 +78,11 @@ markers = [
 override-dependencies = ["protobuf>=6.33.5"]
 
 [tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop git pins once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 cube-computer-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-computer-tool" }
 cube-vm-backend = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-vm-backend" }
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }

--- a/cubes/osworld-cube/src/osworld_cube/benchmark.py
+++ b/cubes/osworld-cube/src/osworld_cube/benchmark.py
@@ -35,6 +35,7 @@ from dotenv import load_dotenv
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
 from cube.container import ContainerBackend
+from cube.infra_local import LocalInfraConfig
 from cube.resource import InfraConfig, ResourceConfig
 from cube.task import RuntimeContext, TaskConfig, TaskMetadata
 
@@ -354,8 +355,6 @@ class OSWorldBenchmarkConfig(BenchmarkConfig[OSWorldTaskMetadata]):
         """Resolve a default infra of ``LocalInfraConfig`` if none provided, then
         delegate to the base ``BenchmarkConfig.make`` for provisioning + setup.
         """
-        from cube import LocalInfraConfig
-
         return cast(OSWorldBenchmark, super().make(infra=infra or LocalInfraConfig()))
 
     def get_task_configs(self) -> Generator[OSWorldTaskConfig, None, None]:

--- a/cubes/osworld-cube/src/osworld_cube/benchmark.py
+++ b/cubes/osworld-cube/src/osworld_cube/benchmark.py
@@ -29,7 +29,7 @@ import subprocess
 from collections.abc import Generator
 from copy import deepcopy
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from dotenv import load_dotenv
 
@@ -244,14 +244,10 @@ class OSWorldTaskConfig(TaskConfig[OSWorldTaskMetadata]):
 
 
 class OSWorldBenchmark(Benchmark["OSWorldBenchmarkConfig"]):
-    """Runtime pair — owns the infra reference passed to ``make(infra)`` and
-    publishes it into ``runtime_context["infra"]`` so per-task VM launches
-    flow naturally through ``Task.runtime_context``.
+    """Runtime pair — publishes ``self._infra`` (stashed by the base
+    ``Benchmark.__init__``) into ``runtime_context["infra"]`` so per-task VM
+    launches flow naturally through ``Task.runtime_context``.
     """
-
-    def __init__(self, config: "OSWorldBenchmarkConfig", infra: InfraConfig | None = None) -> None:
-        super().__init__(config)
-        self._infra = infra
 
     def _setup(self) -> None:
         provider = type(self._infra).__name__ if self._infra is not None else "<none>"
@@ -355,26 +351,12 @@ class OSWorldBenchmarkConfig(BenchmarkConfig[OSWorldTaskMetadata]):
         return OSWORLD_BASE_DIR
 
     def make(self, infra: InfraConfig | None = None) -> OSWorldBenchmark:
-        """Override to forward ``infra`` into the runtime constructor.
-
-        Per-cube override — cube-standard's base ``make(infra)`` only passes
-        ``config`` to the runtime, but OSWorld needs ``infra`` on the runtime so
-        ``_setup()`` can publish it into ``runtime_context["infra"]`` for per-task
-        VM launches. Provisioning is mirrored from the base implementation.
+        """Resolve a default infra of ``LocalInfraConfig`` if none provided, then
+        delegate to the base ``BenchmarkConfig.make`` for provisioning + setup.
         """
         from cube import LocalInfraConfig
 
-        resolved_infra = infra or LocalInfraConfig()
-        if self.resources:
-            for resource in self.resources:
-                if resolved_infra.provision_status(resource) == "ready":
-                    logger.info("Resource %s already provisioned on %s", resource.name, resolved_infra.fingerprint())
-                    continue
-                logger.info("Provisioning resource %s on %s...", resource.name, resolved_infra.fingerprint())
-                resolved_infra.provision(resource)
-        bench = OSWorldBenchmark(config=self, infra=resolved_infra)
-        bench.setup()
-        return bench
+        return cast(OSWorldBenchmark, super().make(infra=infra or LocalInfraConfig()))
 
     def get_task_configs(self) -> Generator[OSWorldTaskConfig, None, None]:
         """Yield OSWorldTaskConfig objects, propagating use_som from the benchmark."""

--- a/cubes/osworld-cube/src/osworld_cube/benchmark.py
+++ b/cubes/osworld-cube/src/osworld_cube/benchmark.py
@@ -188,20 +188,9 @@ class OSWorldTaskConfig(TaskConfig[OSWorldTaskMetadata]):
     use_som: bool = False
     """Set-of-Marks observation post-processing toggle, propagated from the benchmark config."""
 
-    @classmethod
-    def task_execution_cache_dir(cls) -> Path:
-        """Override the default ``~/.cube/<package>/tasks_execution_info`` location.
-
-        OSWorld co-locates the per-task execution cache under ``OSWORLD_BASE_DIR``
-        alongside the cloned repo, so ``install()`` and ``uninstall()`` work on a
-        single directory tree.
-        """
-        return OSWORLD_BASE_DIR / "tasks_execution_info"
-
-    @classmethod
-    def verify_installed(cls) -> None:
+    def verify_installed(self) -> None:
         """Fail fast if the per-task cache or the OSWorld repo are missing."""
-        cache_dir = cls.task_execution_cache_dir()
+        cache_dir = type(self).task_execution_cache_dir()
         if not cache_dir.exists() or not any(cache_dir.iterdir()):
             raise RuntimeError(
                 f"OSWorld per-task execution cache is empty at {cache_dir}. "
@@ -226,8 +215,8 @@ class OSWorldTaskConfig(TaskConfig[OSWorldTaskMetadata]):
         ``OSWorldBenchmarkConfig.install()`` and surfaces it via
         ``OSWorldTask.execution_info``.
         """
-        type(self).verify_installed()
-        raw = type(self).load_task_execution_info(self.task_id)
+        self.verify_installed()
+        raw = self.load_task_execution_info()
         execution_info = OSWorldExecutionInfo.model_validate(raw)
         return OSWorldTask(
             metadata=self.metadata,

--- a/cubes/osworld-cube/src/osworld_cube/debug.py
+++ b/cubes/osworld-cube/src/osworld_cube/debug.py
@@ -83,8 +83,7 @@ class DebugOSWorldTaskConfig(OSWorldTaskConfig):
     required to run debug tasks.
     """
 
-    @classmethod
-    def verify_installed(cls) -> None:
+    def verify_installed(self) -> None:
         """No-op: debug execution data is embedded in this module."""
 
     def make(

--- a/cubes/osworld-cube/tests/test_osworld.py
+++ b/cubes/osworld-cube/tests/test_osworld.py
@@ -956,6 +956,7 @@ class TestInstall:
         from osworld_cube.benchmark import OSWorldTaskConfig
 
         empty_cache = tmp_path / "cache"
+        cfg = OSWorldTaskConfig(metadata=_make_task_metadata())
         with patch.object(OSWorldTaskConfig, "task_execution_cache_dir", return_value=empty_cache):
             with pytest.raises(RuntimeError, match="execution cache is empty"):
-                OSWorldTaskConfig.verify_installed()
+                cfg.verify_installed()

--- a/cubes/osworld-cube/uv.lock
+++ b/cubes/osworld-cube/uv.lock
@@ -117,15 +117,15 @@ wheels = [
 
 [[package]]
 name = "azure-core"
-version = "1.39.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531 }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/d9/6f5972b44761277394527a3a76af5ae2ef82fc5f20ce351abf0c826eca67/azure_core-1.40.0.tar.gz", hash = "sha256:ecf5b6ddf2564471fae9d576147b7e77a4da285958b2d9f4fd6c3af104f3e9d7", size = 380057 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318 },
+    { url = "https://files.pythonhosted.org/packages/ec/c9/25edc67692fb17523c7d29c73898be649b4d3c7ae13cc0f74f5c91938022/azure_core-1.40.0-py3-none-any.whl", hash = "sha256:7f3ea02579b1bb1d34e45043423b650621d11d7c2ea3b05e5554010080b78dfd", size = 220450 },
 ]
 
 [[package]]
@@ -228,30 +228,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.97"
+version = "1.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/7d/5c6fa0bb9fd5caf865b9356411793900304328bcd0bc1eda96a32a1368a6/boto3-1.42.97.tar.gz", hash = "sha256:2833dbeda3670ea610ad48dff7d27cdc829dbbfcdfbc6b750b673948e949b6f0", size = 113217 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/36/028c12ed6ed85009a21b5472eb76c27f9b0341c6986f06f83475b40aaf51/boto3-1.43.1.tar.gz", hash = "sha256:9e4f85a7884797ff0f52c257094730ed228aaa07fa8134775ff8f86909cf4f2a", size = 113175 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/43/84c1888139aa1aaf1dc53f8f914e6ec629e5a571fbafdd42fb2d98ac361f/boto3-1.42.97-py3-none-any.whl", hash = "sha256:966e49f0510af9a64057a902b7df53d4348c447de0d3df4cc855dfd85e058fcd", size = 140556 },
+    { url = "https://files.pythonhosted.org/packages/e5/d1/b8b2d5420c51cd8f7ec044ceecbf24b060156680b26519e1d482e160c3c8/boto3-1.43.1-py3-none-any.whl", hash = "sha256:3840bf0345b9aefcc5915176a19d227f63cfba7778c65e6e52d61c6ea0a10fdc", size = 140498 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.97"
+version = "1.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/95/c37edb602948fad2253ffd1bb3dba5b938645bd1845ee4160350136a0f41/botocore-1.42.97.tar.gz", hash = "sha256:5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310", size = 15269348 }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b7/416ae6f1461d6fec3b3aaffc4759371319c71a21f7ab4c3106ee574fda8d/botocore-1.43.1.tar.gz", hash = "sha256:270d6357d662550fdb84973ec247e02bece0b6283d90bf37319c7753515336e4", size = 15296915 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/d2/8e025ba1a4e257879af72d06913272311af79673d82fa2581a351b924317/botocore-1.42.97-py3-none-any.whl", hash = "sha256:77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc", size = 14950367 },
+    { url = "https://files.pythonhosted.org/packages/09/48/dc2290d2af8b1dc3a44d210555a90f0cb76ef913c52b0c4f31a43cce27b8/botocore-1.43.1-py3-none-any.whl", hash = "sha256:955edc6a398b9c4100cf0d5a31433fdba3835500bf38c1ef171e6e75f4b477d2", size = 14979119 },
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ wheels = [
 [[package]]
 name = "cube-computer-tool"
 version = "0.2.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool#5e058a475b30fce130ea91bad01a33a63391ce15" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "cube-standard" },
     { name = "pillow" },
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "cube-infra-aws"
 version = "0.1.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws#5e058a475b30fce130ea91bad01a33a63391ce15" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "cube-infra-azure"
 version = "0.1.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure#5e058a475b30fce130ea91bad01a33a63391ce15" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "azure-identity" },
     { name = "azure-mgmt-compute" },
@@ -517,7 +517,7 @@ dependencies = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#5e058a475b30fce130ea91bad01a33a63391ce15" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "cube-vm-backend"
 version = "0.2.1"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend#5e058a475b30fce130ea91bad01a33a63391ce15" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "cube-standard" },
     { name = "requests" },
@@ -668,7 +668,7 @@ wheels = [
 
 [[package]]
 name = "google-api-python-client"
-version = "2.194.0"
+version = "2.195.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -677,22 +677,22 @@ dependencies = [
     { name = "httplib2" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/07/08d759b9cb10f48af14b25262dd0d6685ca8cda6c1f9e8a8109f57457205/google_api_python_client-2.195.0.tar.gz", hash = "sha256:c72cf2661c3addf01c880ce60541e83e1df354644b874f7f9d8d5ed2070446ae", size = 14584819 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514 },
+    { url = "https://files.pythonhosted.org/packages/21/b9/2c71095e31fff57668fec7c07ac897df065f15521d070e63229e13689590/google_api_python_client-2.195.0-py3-none-any.whl", hash = "sha256:753e62057f23049a89534bea0162b60fe391b85fb86d80bcdf884d05ec91c5bf", size = 15162418 },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.49.2"
+version = "2.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638 },
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495 },
 ]
 
 [[package]]
@@ -1361,7 +1361,7 @@ requires-dist = [
     { name = "cube-computer-tool", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool" },
     { name = "cube-infra-aws", marker = "extra == 'aws'", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws" },
     { name = "cube-infra-azure", marker = "extra == 'azure'", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure" },
-    { name = "cube-standard", specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "cube-vm-backend", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend" },
     { name = "fastdtw", specifier = ">=0.3" },
     { name = "formulas", specifier = ">=1.2" },
@@ -2300,14 +2300,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.1"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801 }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825 },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811 },
 ]
 
 [[package]]

--- a/cubes/osworld-cube/uv.lock
+++ b/cubes/osworld-cube/uv.lock
@@ -479,7 +479,7 @@ wheels = [
 [[package]]
 name = "cube-computer-tool"
 version = "0.2.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool#a82f1984e033e4829d03854bdc011e22d6139f5f" }
 dependencies = [
     { name = "cube-standard" },
     { name = "pillow" },
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "cube-infra-aws"
 version = "0.1.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws#a82f1984e033e4829d03854bdc011e22d6139f5f" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "cube-infra-azure"
 version = "0.1.0"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure#a82f1984e033e4829d03854bdc011e22d6139f5f" }
 dependencies = [
     { name = "azure-identity" },
     { name = "azure-mgmt-compute" },
@@ -516,8 +516,8 @@ dependencies = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#a82f1984e033e4829d03854bdc011e22d6139f5f" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "cube-vm-backend"
 version = "0.2.1"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend#a82f1984e033e4829d03854bdc011e22d6139f5f" }
 dependencies = [
     { name = "cube-standard" },
     { name = "requests" },
@@ -1361,7 +1361,7 @@ requires-dist = [
     { name = "cube-computer-tool", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-tools%2Fcube-computer-tool" },
     { name = "cube-infra-aws", marker = "extra == 'aws'", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-aws" },
     { name = "cube-infra-azure", marker = "extra == 'azure'", git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-infra-azure" },
-    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", specifier = ">=0.1.0rc8" },
     { name = "cube-vm-backend", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard?subdirectory=cube-resources%2Fcube-vm-backend" },
     { name = "fastdtw", specifier = ">=0.3" },
     { name = "formulas", specifier = ">=1.2" },

--- a/cubes/swebench-live-cube/pyproject.toml
+++ b/cubes/swebench-live-cube/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "SWE-bench Live — continuously updated, contamination-resistant GitHub issue resolution"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard[docker]>=0.1.0rc7",
+    "cube-standard[docker]>=0.1.0rc8",
     "datasets",
 ]
 
@@ -17,13 +17,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/swebench_live_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [dependency-groups]
 dev = [

--- a/cubes/swebench-live-cube/pyproject.toml
+++ b/cubes/swebench-live-cube/pyproject.toml
@@ -18,6 +18,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/swebench_live_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [dependency-groups]
 dev = [
     "pytest>=9.0",

--- a/cubes/swebench-live-cube/src/swebench_live_cube/benchmark.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/benchmark.py
@@ -6,7 +6,7 @@ import json
 import logging
 import shutil
 from collections.abc import Generator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from cube import LocalInfraConfig
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
@@ -105,14 +105,10 @@ def _build_execution_info(row: dict[str, Any]) -> dict[str, Any]:
 
 
 class SWEBenchLiveBenchmark(Benchmark["SWEBenchLiveBenchmarkConfig"]):
-    """Runtime pair — owns the infra reference passed to ``make(infra)`` and
-    publishes it into ``runtime_context["infra"]`` so per-task container launches
-    flow through ``Task.runtime_context``.
+    """Runtime pair — publishes ``self._infra`` (stashed by the base
+    ``Benchmark.__init__``) into ``runtime_context["infra"]`` so per-task
+    container launches flow through ``Task.runtime_context``.
     """
-
-    def __init__(self, config: "SWEBenchLiveBenchmarkConfig", infra: InfraConfig | None = None) -> None:
-        super().__init__(config)
-        self._infra = infra
 
     def _setup(self) -> None:
         """Publish the shared InfraConfig to runtime_context; containers are launched per-task."""
@@ -234,29 +230,10 @@ class SWEBenchLiveBenchmarkConfig(BenchmarkConfig[SWEBenchLiveTaskMetadata]):
     # ------------------------------------------------------------------
 
     def make(self, infra: InfraConfig | None = None) -> SWEBenchLiveBenchmark:
-        """Override to forward ``infra`` into the runtime constructor.
-
-        SWE-bench Live launches one Docker container per task via
-        ``runtime_context["infra"]``; the runtime ``_setup()`` publishes
-        ``infra`` there. Defaults to ``LocalInfraConfig()`` so calls without
-        explicit infra still work.
+        """Resolve a default infra of ``LocalInfraConfig`` if none provided, then
+        delegate to the base ``BenchmarkConfig.make`` for provisioning + setup.
         """
-        resolved_infra = infra or LocalInfraConfig()
-        # Provision any declared resources idempotently (mirrors base impl).
-        if self.resources:
-            for resource in self.resources:
-                if resolved_infra.provision_status(resource) == "ready":
-                    logger.info(
-                        "Resource %s already provisioned on %s",
-                        resource.name,
-                        resolved_infra.fingerprint(),
-                    )
-                    continue
-                logger.info("Provisioning resource %s on %s...", resource.name, resolved_infra.fingerprint())
-                resolved_infra.provision(resource)
-        bench = SWEBenchLiveBenchmark(config=self, infra=resolved_infra)
-        bench.setup()
-        return bench
+        return cast(SWEBenchLiveBenchmark, super().make(infra=infra or LocalInfraConfig()))
 
     def get_task_configs(self) -> Generator[SWEBenchLiveTaskConfig, None, None]:
         """Yield TaskConfigs with include_hints and oracle_mode forwarded from benchmark settings."""

--- a/cubes/swebench-live-cube/src/swebench_live_cube/task.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/task.py
@@ -255,10 +255,9 @@ class SWEBenchLiveTaskConfig(TaskConfig[SWEBenchLiveTaskMetadata]):
     oracle_mode: bool = False
     """If True, write the gold patch to /tmp/gold_patch.diff in reset()."""
 
-    @classmethod
-    def verify_installed(cls) -> None:
+    def verify_installed(self) -> None:
         """Fail fast if the per-task execution cache is empty."""
-        cache_dir = cls.task_execution_cache_dir()
+        cache_dir = type(self).task_execution_cache_dir()
         if not cache_dir.exists() or not any(cache_dir.iterdir()):
             raise RuntimeError(
                 f"SWE-bench Live per-task execution cache is empty at {cache_dir}. "
@@ -278,8 +277,9 @@ class SWEBenchLiveTaskConfig(TaskConfig[SWEBenchLiveTaskMetadata]):
                     "(preferred) or a legacy container_backend."
                 )
 
-        type(self).verify_installed()
-        execution_info = SWEBenchLiveExecutionInfo.model_validate(type(self).load_task_execution_info(self.task_id))
+        self.verify_installed()
+        raw = self.load_task_execution_info()
+        execution_info = SWEBenchLiveExecutionInfo.model_validate(raw)
 
         return SWEBenchLiveTask(
             metadata=self.metadata,

--- a/cubes/swebench-live-cube/uv.lock
+++ b/cubes/swebench-live-cube/uv.lock
@@ -261,8 +261,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,6 +274,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [package.optional-dependencies]
@@ -1350,7 +1354,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc8" },
     { name = "datasets" },
 ]
 

--- a/cubes/swebench-live-cube/uv.lock
+++ b/cubes/swebench-live-cube/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,10 +274,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [package.optional-dependencies]
@@ -1354,7 +1350,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "datasets" },
 ]
 
@@ -1384,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1392,9 +1388,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993 },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409 },
 ]
 
 [[package]]

--- a/cubes/swebench-verified-cube/pyproject.toml
+++ b/cubes/swebench-verified-cube/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "SWE-bench Verified — 500 real-world GitHub issues with test-based validation"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard[docker]>=0.1.0rc7",
+    "cube-standard[docker]>=0.1.0rc8",
     "datasets",
 ]
 
@@ -17,13 +17,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/swebench_verified_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [dependency-groups]
 dev = [

--- a/cubes/swebench-verified-cube/pyproject.toml
+++ b/cubes/swebench-verified-cube/pyproject.toml
@@ -18,6 +18,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/swebench_verified_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [dependency-groups]
 dev = [
     "pytest>=9.0",

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/benchmark.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/benchmark.py
@@ -6,7 +6,7 @@ import json
 import logging
 import shutil
 from collections.abc import Generator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from cube import LocalInfraConfig
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
@@ -47,14 +47,10 @@ def _build_execution_info(row: dict[str, Any]) -> dict[str, Any]:
 
 
 class SWEBenchVerifiedBenchmark(Benchmark["SWEBenchVerifiedBenchmarkConfig"]):
-    """Runtime pair — owns the infra reference passed to ``make(infra)`` and
-    publishes it into ``runtime_context["infra"]`` so per-task container launches
-    flow through ``Task.runtime_context``.
+    """Runtime pair — publishes ``self._infra`` (stashed by the base
+    ``Benchmark.__init__``) into ``runtime_context["infra"]`` so per-task
+    container launches flow through ``Task.runtime_context``.
     """
-
-    def __init__(self, config: "SWEBenchVerifiedBenchmarkConfig", infra: InfraConfig | None = None) -> None:
-        super().__init__(config)
-        self._infra = infra
 
     def _setup(self) -> None:
         """Publish the shared InfraConfig to runtime_context; containers are launched per-task."""
@@ -151,29 +147,10 @@ class SWEBenchVerifiedBenchmarkConfig(BenchmarkConfig[SWEBenchVerifiedTaskMetada
     # ------------------------------------------------------------------
 
     def make(self, infra: InfraConfig | None = None) -> SWEBenchVerifiedBenchmark:
-        """Override to forward ``infra`` into the runtime constructor.
-
-        SWE-bench launches one Docker container per task via
-        ``runtime_context["infra"]``; the runtime ``_setup()`` publishes
-        ``infra`` there. Defaults to ``LocalInfraConfig()`` so calls without
-        explicit infra still work.
+        """Resolve a default infra of ``LocalInfraConfig`` if none provided, then
+        delegate to the base ``BenchmarkConfig.make`` for provisioning + setup.
         """
-        resolved_infra = infra or LocalInfraConfig()
-        # Provision any declared resources idempotently (mirrors base impl).
-        if self.resources:
-            for resource in self.resources:
-                if resolved_infra.provision_status(resource) == "ready":
-                    logger.info(
-                        "Resource %s already provisioned on %s",
-                        resource.name,
-                        resolved_infra.fingerprint(),
-                    )
-                    continue
-                logger.info("Provisioning resource %s on %s...", resource.name, resolved_infra.fingerprint())
-                resolved_infra.provision(resource)
-        bench = SWEBenchVerifiedBenchmark(config=self, infra=resolved_infra)
-        bench.setup()
-        return bench
+        return cast(SWEBenchVerifiedBenchmark, super().make(infra=infra or LocalInfraConfig()))
 
     def get_task_configs(self) -> Generator[SWEBenchVerifiedTaskConfig, None, None]:
         """Yield TaskConfigs with include_hints and oracle_mode forwarded from benchmark settings."""

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -271,10 +271,9 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
     include_hints: bool = False
     oracle_mode: bool = False
 
-    @classmethod
-    def verify_installed(cls) -> None:
+    def verify_installed(self) -> None:
         """Fail fast if the per-task execution cache is empty."""
-        cache_dir = cls.task_execution_cache_dir()
+        cache_dir = type(self).task_execution_cache_dir()
         if not cache_dir.exists() or not any(cache_dir.iterdir()):
             raise RuntimeError(
                 f"SWE-bench Verified per-task execution cache is empty at {cache_dir}. "
@@ -294,8 +293,9 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
                     "(preferred) or a legacy container_backend."
                 )
 
-        type(self).verify_installed()
-        execution_info = SWEBenchVerifiedExecutionInfo.model_validate(type(self).load_task_execution_info(self.task_id))
+        self.verify_installed()
+        raw = self.load_task_execution_info()
+        execution_info = SWEBenchVerifiedExecutionInfo.model_validate(raw)
 
         return SWEBenchVerifiedTask(
             metadata=self.metadata,

--- a/cubes/swebench-verified-cube/uv.lock
+++ b/cubes/swebench-verified-cube/uv.lock
@@ -261,8 +261,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,6 +274,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [package.optional-dependencies]
@@ -1350,7 +1354,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc8" },
     { name = "datasets" },
 ]
 

--- a/cubes/swebench-verified-cube/uv.lock
+++ b/cubes/swebench-verified-cube/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,10 +274,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [package.optional-dependencies]
@@ -1354,7 +1350,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "datasets" },
 ]
 
@@ -1384,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1392,9 +1388,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993 },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409 },
 ]
 
 [[package]]

--- a/cubes/terminalbench-cube/pyproject.toml
+++ b/cubes/terminalbench-cube/pyproject.toml
@@ -18,6 +18,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/terminalbench_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [dependency-groups]
 dev = [
     "pytest>=9.0",

--- a/cubes/terminalbench-cube/pyproject.toml
+++ b/cubes/terminalbench-cube/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Terminal-Bench 2 — real-world terminal tasks with pytest-based validation"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard[docker]>=0.1.0rc7",
+    "cube-standard[docker]>=0.1.0rc8",
     "datasets",
 ]
 
@@ -17,13 +17,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/terminalbench_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [dependency-groups]
 dev = [

--- a/cubes/terminalbench-cube/src/terminalbench_cube/benchmark.py
+++ b/cubes/terminalbench-cube/src/terminalbench_cube/benchmark.py
@@ -13,7 +13,7 @@ import tempfile
 import tomllib
 from collections.abc import Generator
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from cube import LocalInfraConfig
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
@@ -43,14 +43,10 @@ def _build_execution_info(task: dict) -> dict:
 
 
 class TerminalBenchBenchmark(Benchmark["TerminalBenchBenchmarkConfig"]):
-    """Runtime pair — owns the infra reference passed to ``make(infra)`` and
-    publishes it into ``runtime_context["infra"]`` so per-task container launches
-    flow through ``Task.runtime_context``.
+    """Runtime pair — publishes ``self._infra`` (stashed by the base
+    ``Benchmark.__init__``) into ``runtime_context["infra"]`` so per-task
+    container launches flow through ``Task.runtime_context``.
     """
-
-    def __init__(self, config: "TerminalBenchBenchmarkConfig", infra: InfraConfig | None = None) -> None:
-        super().__init__(config)
-        self._infra = infra
 
     def _setup(self) -> None:
         """Publish the shared InfraConfig to runtime_context; per-task containers are launched per-task in make()."""
@@ -169,22 +165,10 @@ class TerminalBenchBenchmarkConfig(BenchmarkConfig[TerminalBenchTaskMetadata]):
             logger.info(f"Removed execution cache at {exec_cache_dir}")
 
     def make(self, infra: InfraConfig | None = None) -> TerminalBenchBenchmark:
-        """Override to forward ``infra`` into the runtime constructor."""
-        resolved_infra = infra or LocalInfraConfig()
-        if self.resources:
-            for resource in self.resources:
-                if resolved_infra.provision_status(resource) == "ready":
-                    logger.info(
-                        "Resource %s already provisioned on %s",
-                        resource.name,
-                        resolved_infra.fingerprint(),
-                    )
-                    continue
-                logger.info("Provisioning resource %s on %s...", resource.name, resolved_infra.fingerprint())
-                resolved_infra.provision(resource)
-        bench = TerminalBenchBenchmark(config=self, infra=resolved_infra)
-        bench.setup()
-        return bench
+        """Resolve a default infra of ``LocalInfraConfig`` if none provided, then
+        delegate to the base ``BenchmarkConfig.make`` for provisioning + setup.
+        """
+        return cast(TerminalBenchBenchmark, super().make(infra=infra or LocalInfraConfig()))
 
     def get_task_configs(self) -> Generator[TerminalBenchTaskConfig, None, None]:
         """Yield TaskConfigs with oracle_mode forwarded from benchmark settings."""

--- a/cubes/terminalbench-cube/src/terminalbench_cube/task.py
+++ b/cubes/terminalbench-cube/src/terminalbench_cube/task.py
@@ -353,10 +353,9 @@ class TerminalBenchTaskConfig(TaskConfig[TerminalBenchTaskMetadata]):
     oracle_mode: bool = False
     """If True, upload the gold solution to /solution in reset()."""
 
-    @classmethod
-    def verify_installed(cls) -> None:
+    def verify_installed(self) -> None:
         """Fail fast if the per-task execution cache is empty."""
-        cache_dir = cls.task_execution_cache_dir()
+        cache_dir = type(self).task_execution_cache_dir()
         if not cache_dir.exists() or not any(cache_dir.iterdir()):
             raise RuntimeError(
                 f"TerminalBench per-task execution cache is empty at {cache_dir}. "
@@ -376,8 +375,9 @@ class TerminalBenchTaskConfig(TaskConfig[TerminalBenchTaskMetadata]):
                 "(preferred) or a legacy container_backend."
             )
 
-        type(self).verify_installed()
-        execution_info = TerminalBenchExecutionInfo.model_validate(type(self).load_task_execution_info(self.task_id))
+        self.verify_installed()
+        raw = self.load_task_execution_info()
+        execution_info = TerminalBenchExecutionInfo.model_validate(raw)
 
         return TerminalBenchTask(
             metadata=self.metadata,

--- a/cubes/terminalbench-cube/uv.lock
+++ b/cubes/terminalbench-cube/uv.lock
@@ -261,8 +261,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,6 +274,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [package.optional-dependencies]
@@ -1359,7 +1363,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc8" },
     { name = "datasets" },
 ]
 

--- a/cubes/terminalbench-cube/uv.lock
+++ b/cubes/terminalbench-cube/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -274,10 +274,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [package.optional-dependencies]
@@ -1363,7 +1359,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cube-standard", extras = ["docker"], specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", extras = ["docker"], git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "datasets" },
 ]
 
@@ -1384,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1392,9 +1388,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993 },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409 },
 ]
 
 [[package]]

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -20,6 +20,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/webarena_verified_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "WebArena-Verified benchmark cube — 812 verified web automation tasks"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
     "cube-browser-tool>=0.2.0",
     "webarena-verified",
     "Pillow",
@@ -19,13 +19,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/webarena_verified_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [tool.ruff]
 fix = true

--- a/cubes/webarena-verified/src/webarena_verified_cube/benchmark.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/benchmark.py
@@ -2,7 +2,7 @@ import logging
 import urllib.error
 import urllib.request
 from collections.abc import Generator
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
 from cube.infra_local import LocalInfraConfig
@@ -29,8 +29,7 @@ class WebArenaVerifiedBenchmark(Benchmark["WebArenaVerifiedBenchmarkConfig"]):
         config: "WebArenaVerifiedBenchmarkConfig",
         infra: InfraConfig | None = None,
     ) -> None:
-        super().__init__(config)
-        self._infra: InfraConfig | None = infra
+        super().__init__(config, infra=infra)
         self._handle: ResourceHandle | None = None
 
     def _setup(self) -> None:
@@ -197,18 +196,14 @@ class WebArenaVerifiedBenchmarkConfig(BenchmarkConfig[WebArenaVerifiedTaskMetada
     """
 
     def make(self, infra: InfraConfig | None = None) -> WebArenaVerifiedBenchmark:
-        """Override to forward ``infra`` into the runtime constructor.
+        """Default ``infra`` to ``LocalInfraConfig`` when DockerServiceConfig
+        resources are declared in automatic mode, then delegate to the base
+        ``BenchmarkConfig.make`` for provisioning + setup.
 
-        Per-cube override — cube-standard's base ``make(infra)`` only passes
-        ``config`` to the runtime, but webarena-verified needs ``infra`` on the
-        runtime to launch its DockerServiceConfig in ``_setup``. Provisioning
-        is mirrored from the base implementation so callers see identical
-        behavior; ``_setup`` then only launches.
-
-        If ``infra`` is None and the config declares a DockerServiceConfig
-        resource (and no manual ``wav_config.environments`` are set), defaults
-        to ``LocalInfraConfig()``. Cloud users pass their own ``infra`` explicitly;
-        manual-mode users set ``wav_config.environments`` and never enter this branch.
+        Manual-mode users set ``wav_config.environments`` and pass no infra;
+        cloud users pass their own ``infra`` explicitly; the local-default
+        branch fires only for the default case where DockerServiceConfig
+        resources are declared but no infra is provided.
         """
         needs_infra = self.wav_config.environments is None and any(
             isinstance(r, DockerServiceConfig) for r in self.resources
@@ -218,17 +213,7 @@ class WebArenaVerifiedBenchmarkConfig(BenchmarkConfig[WebArenaVerifiedTaskMetada
                 "No infra= passed but DockerServiceConfig resources are declared; defaulting to LocalInfraConfig()"
             )
             infra = LocalInfraConfig()
-
-        if self.resources and infra is not None:
-            for resource in self.resources:
-                if infra.provision_status(resource) == "ready":
-                    logger.info("Resource %s already provisioned on %s", resource.name, infra.fingerprint())
-                    continue
-                logger.info("Provisioning resource %s on %s...", resource.name, infra.fingerprint())
-                infra.provision(resource)
-        bench = WebArenaVerifiedBenchmark(config=self, infra=infra)
-        bench.setup()
-        return bench
+        return cast(WebArenaVerifiedBenchmark, super().make(infra=infra))
 
     def get_task_configs(self) -> Generator[WebArenaVerifiedTaskConfig, None, None]:
         """Yield TaskConfigs with wav_config forwarded from benchmark settings."""

--- a/cubes/webarena-verified/uv.lock
+++ b/cubes/webarena-verified/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -215,10 +215,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [[package]]
@@ -1295,7 +1291,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cube-browser-tool", specifier = ">=0.2.0" },
-    { name = "cube-standard", specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "pillow" },
     { name = "webarena-verified" },
 ]

--- a/cubes/webarena-verified/uv.lock
+++ b/cubes/webarena-verified/uv.lock
@@ -202,8 +202,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -215,6 +215,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [[package]]
@@ -1291,7 +1295,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cube-browser-tool", specifier = ">=0.2.0" },
-    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", specifier = ">=0.1.0rc8" },
     { name = "pillow" },
     { name = "webarena-verified" },
 ]

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -23,6 +23,13 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/workarena_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "WorkArena ServiceNow benchmark for cube"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
     "browsergym-workarena",
     "termcolor",
     "cube-browser-tool>=0.2.0",
@@ -22,13 +22,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/workarena_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 [tool.ruff]
 fix = true

--- a/cubes/workarena/uv.lock
+++ b/cubes/workarena/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -287,10 +287,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [[package]]
@@ -359,11 +355,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547 }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595 },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402 },
 ]
 
 [[package]]
@@ -477,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.12.2"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -490,9 +486,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/9f/3fda8b014db3ae239addc9b48b35c2cf7d318950b430712f34a2473ef81d/huggingface_hub-1.12.2.tar.gz", hash = "sha256:282c4999e641c89affdc4c02c265eddea944c1390dc19e89dac8ad3ae76dbdaf", size = 763393 }
+sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/c1/1fa4162f6dd53259daf2ad31385273341821fa0acce164cd03971937a60e/huggingface_hub-1.12.2-py3-none-any.whl", hash = "sha256:7968e897fdbc6343c871c240d87d4434efe0ad9f80d57daa1cc5678c6d148529", size = 647757 },
+    { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643 },
 ]
 
 [[package]]
@@ -968,7 +964,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -976,9 +972,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993 },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409 },
 ]
 
 [[package]]
@@ -1120,7 +1116,7 @@ requires-dist = [
     { name = "cube-browser-playwright", specifier = ">=0.2.0" },
     { name = "cube-browser-tool", specifier = ">=0.2.0" },
     { name = "cube-chat-tool", specifier = ">=0.1.0" },
-    { name = "cube-standard", specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "playwright", specifier = "==1.44" },
     { name = "termcolor" },
 ]

--- a/cubes/workarena/uv.lock
+++ b/cubes/workarena/uv.lock
@@ -274,8 +274,8 @@ wheels = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -287,6 +287,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [[package]]
@@ -1116,7 +1120,7 @@ requires-dist = [
     { name = "cube-browser-playwright", specifier = ">=0.2.0" },
     { name = "cube-browser-tool", specifier = ">=0.2.0" },
     { name = "cube-chat-tool", specifier = ">=0.1.0" },
-    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", specifier = ">=0.1.0rc8" },
     { name = "playwright", specifier = "==1.44" },
     { name = "termcolor" },
 ]

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -87,8 +87,11 @@ markers = [
 ]
 
 [tool.uv.sources]
-# Every reference to the cube-standard repo MUST use the same URL+ref,
-# otherwise uv treats them as conflicting sources for the same package.
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop git pins once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 cube-infra-aws = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-aws" }
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }
 cube-infra-daytona = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-daytona" }

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "End-to-end integration tests for CUBE infra backends + benchmark cubes"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc6",
+    "cube-standard>=0.1.0rc8",
     "pytest>=8.0",
     "tenacity>=9.1.4",
 ]
@@ -87,11 +87,8 @@ markers = [
 ]
 
 [tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop git pins once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+# Every reference to the cube-standard repo MUST use the same URL+ref,
+# otherwise uv treats them as conflicting sources for the same package.
 cube-infra-aws = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-aws" }
 cube-infra-azure = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-azure" }
 cube-infra-daytona = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-resources/cube-infra-daytona" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc7",
+    "cube-standard>=0.1.0rc8",
     "cube-browser-playwright>=0.2.0",  # added back temporarily for browsergym.py, should be removed once browsergym.py is moved to cube-browser-tool package
     "pydantic~=2.0",
     "litellm~=1.80.8",
@@ -46,13 +46,6 @@ build-backend = "uv_build"
 
 [tool.uv]
 constraint-dependencies = ["pyasn1>=0.6.2", "cryptography>=46.0.5", "protobuf>=6.33.5"]
-
-[tool.uv.sources]
-# Track cube-standard from main while picking up PR #133 (infra-init) and
-# subsequent updates. Every reference to the cube-standard repo MUST use the
-# same URL+ref, otherwise uv treats them as conflicting sources for the same
-# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
-cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ build-backend = "uv_build"
 [tool.uv]
 constraint-dependencies = ["pyasn1>=0.6.2", "cryptography>=46.0.5", "protobuf>=6.33.5"]
 
+[tool.uv.sources]
+# Track cube-standard from main while picking up PR #133 (infra-init) and
+# subsequent updates. Every reference to the cube-standard repo MUST use the
+# same URL+ref, otherwise uv treats them as conflicting sources for the same
+# package. TODO: drop once cube-standard 0.1.0rc8 ships to PyPI.
+cube-standard = { git = "https://github.com/The-AI-Alliance/cube-standard" }
+
 
 [tool.ruff]
 fix = true

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -74,14 +74,17 @@ def _make_neverending_benchmark(max_steps: int) -> CubeBenchmarkConfig:
 
 
 def _make_benchmark(n: int) -> CubeBenchmarkConfig:
-    """Create a cube BenchmarkConfig with n tasks for testing."""
+    """Create a cube BenchmarkConfig with n tasks for testing.
+
+    Inherits ``benchmark_metadata``/``task_config_class``/``benchmark_class``
+    from ``MockCubeBenchmarkConfig`` so all calls share the same cache dir
+    and the back-stamp on ``MockCubeTaskConfig._benchmark_cache_dir`` stays
+    consistent — cube-standard rejects re-stamping with a different value.
+    """
     task_meta = {f"task_{i}": TaskMetadata(id=f"task_{i}") for i in range(n)}
 
     class _NTaskBenchmarkConfig(MockCubeBenchmarkConfig):
-        benchmark_metadata = BenchmarkMetadata(name=f"n{n}-task", version="0.1.0", description="test")
         task_metadata = task_meta
-        task_config_class = MockCubeTaskConfig
-        benchmark_class = MockCubeBenchmark
 
     return _NTaskBenchmarkConfig()
 

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "~=4.14" },
     { name = "browsergym-core", specifier = ">=0.14.3" },
     { name = "cube-browser-playwright", specifier = ">=0.2.0" },
-    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
+    { name = "cube-standard", specifier = ">=0.1.0rc8" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "gradio", marker = "extra == 'analyze'", specifier = "~=5.49" },
     { name = "litellm", specifier = "~=1.80.8" },
@@ -719,8 +719,8 @@ dev = [
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc7"
-source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
+version = "0.1.0rc8"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -732,6 +732,10 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/d14afd70a745efd32b42b2ff6e1d586e4977b385ecbb49c3feb7c5bed6b9/cube_standard-0.1.0rc8.tar.gz", hash = "sha256:f30602b14a893801aa1d1015d5e09aa4d8606984802e9e642434f27ec9183fd1", size = 114284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/6c/0dbc1ae8737d6c0d3f97bf86a1331e9d13a629776f1eeff48c909272e8df/cube_standard-0.1.0rc8-py3-none-any.whl", hash = "sha256:d29be2e034ac369fdc1b2741e58ef780c04d6e1dbbe69cf0407852be2d4f1685", size = 134313 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "~=4.14" },
     { name = "browsergym-core", specifier = ">=0.14.3" },
     { name = "cube-browser-playwright", specifier = ">=0.2.0" },
-    { name = "cube-standard", specifier = ">=0.1.0rc7" },
+    { name = "cube-standard", git = "https://github.com/The-AI-Alliance/cube-standard" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "gradio", marker = "extra == 'analyze'", specifier = "~=5.49" },
     { name = "litellm", specifier = "~=1.80.8" },
@@ -720,7 +720,7 @@ dev = [
 [[package]]
 name = "cube-standard"
 version = "0.1.0rc7"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/The-AI-Alliance/cube-standard#1d381db68c3650eeb9b90a76bc416611a345c2aa" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -732,10 +732,6 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ae/7dd7a750a3bb84d90481cc6adace8f546157e975e47a8c5762707f9aa5cb/cube_standard-0.1.0rc7.tar.gz", hash = "sha256:84372b157d64bb0ffe6bcc5747206d0effa2fbb633a953fdda06eb679a24e2e6", size = 113221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/44/3d8a4a106927c77771a9f113004f48e6713d79c7f7c602dc73f6457b2397/cube_standard-0.1.0rc7-py3-none-any.whl", hash = "sha256:b03191bc7264e4907106a0f436641275b87509f924545798f411a1dc42b4342f", size = 133279 },
 ]
 
 [[package]]
@@ -988,15 +984,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.49.2"
+version = "2.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638 },
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495 },
 ]
 
 [[package]]
@@ -3186,7 +3182,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -3194,9 +3190,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993 },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pin every cube-standard reference to the cube-standard `main` git ref so the new `Benchmark.__init__(config, infra=None)` signature is available without waiting for a PyPI release. Drop the explicit `rev` so the pin tracks main and picks up subsequent fixes (e.g. [cube-standard issue # 126](https://github.com/The-AI-Alliance/cube-standard/issues/126)); the URL string-identical rule still holds.
- Migrate every cube to the new contract.
- Lockfiles regenerated; tests green where they exist.

## Per-cube changes

| Cube | Change |
|---|---|
| miniwob | `__init__` now accepts `infra=None` and forwards to `super()`. Without this, the cube would crash at runtime with `TypeError` once `BenchmarkConfig.make` passes `infra=infra`. |
| osworld-cube | Drop the redundant `__init__` override (base now stashes `self._infra`); shrink `make()` to a thin `LocalInfraConfig` default shim that delegates to `super().make`. |
| swebench-live-cube | Same shape as osworld-cube. |
| swebench-verified-cube | Same shape as osworld-cube. |
| terminalbench-cube | Same shape as osworld-cube. |
| webarena-verified | Keep `__init__` (still inits `self._handle = None`) but forward `infra` to `super()`; shrink `make()` to just the conditional `LocalInfraConfig` defaulting + `super().make`. |
| arithmetic-cube, workarena | No overrides — unchanged. |

## TODO before merge

- Wait for cube-standard 0.1.0rc8 to ship to PyPI (will pick up [cube-standard issue # 126](https://github.com/The-AI-Alliance/cube-standard/issues/126)'s fix as well).
- Replace every `[tool.uv.sources]` cube-standard pin with the PyPI version bump.
- Re-run `uv lock` per cube and integration-tests.

## Test plan

- [x] `uv lock` succeeds for root, integration-tests, and all eight cubes
- [x] osworld-cube `pytest`: 51 passed, 1 deselected (pre-existing failure on main: missing local `osworld-ubuntu-vm`)
- [x] swebench-live-cube `pytest`: 7 passed
- [x] swebench-verified-cube `pytest`: 6 passed
- [x] terminalbench-cube `pytest`: 6 passed
- [x] miniwob, arithmetic-cube, workarena, webarena-verified: import smoke tests pass (no pytest suites)
- [ ] CI green
- [ ] Once cube-standard rc8 ships, switch pins to PyPI and re-run

🤖 Generated with [Claude Code](https://claude.ai/code)