### PR TITLE
fix(eval_log): BenchmarkSubset.n_tasks now reflects subset size, not full catalog

### DIFF
--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -277,7 +277,9 @@ class BenchmarkSubset(TypedBaseModel):
     def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset":
         """Derive BenchmarkSubset from a cube BenchmarkConfig object."""
         name = benchmark_config.benchmark_metadata.name
-        n_tasks = len(benchmark_config.task_metadata)
+        # task_metadata is a ClassVar (full catalog); get_task_configs() respects
+        # any subset filter applied via subset_from_list / subset_from_glob.
+        n_tasks = sum(1 for _ in benchmark_config.get_task_configs())
         return cls(name=name, n_tasks=n_tasks)
 
 


### PR DESCRIPTION
## Summary

`BenchmarkSubset.n_tasks` was always reporting the full benchmark catalog size — e.g. 500 for swebench-verified and 1895 for swebench-live — even when running a 50-task subset.

**Root cause:** `benchmark_metadata.task_metadata` is a `ClassVar` in cube-standard. It holds the full catalog regardless of any subset filter applied via `subset_from_list` or `subset_from_glob`. The previous code called `len(benchmark_config.task_metadata)` which always returned the total.

**Fix:** Use `get_task_configs()` instead — it respects the instance-level `task_ids` filter and yields only the tasks that will actually run.

```python
# Before
n_tasks = len(benchmark_config.task_metadata)  # always full catalog (500, 1895, …)

# After
n_tasks = sum(1 for _ in benchmark_config.get_task_configs())  # respects subset
```

## Test plan

- [x] `make lint` clean
- [x] Verified manually: full config → 500, `subset_from_list(2 tasks)` → 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)