### PR TITLE
xray: resolve agent_name property and benchmark_metadata ClassVar from configs

### DIFF
--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -25,7 +25,6 @@ from cube.core import EnvironmentOutput
 from PIL import Image
 
 from cube_harness import EXP_DIR
-from cube_harness.agent import AgentConfig
 from cube_harness.analyze import inspect_results, xray_utils
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.storage import FileStorage
@@ -139,7 +138,7 @@ class XRayState:
         """Read experiment_config.json and store per-storage config JSON strings.
 
         Populates _storage_configs[id(storage)] with (agent_config_json, exp_config_json)
-        and _backfill_names[id(storage)] with the agent class short name for backwards compat.
+        and _backfill_names[id(storage)] with the resolved AgentConfig.agent_name.
 
         Falls back to the first episode_configs/*.json when experiment_config.json
         is absent (e.g. experiments run before save_config() was added).
@@ -169,13 +168,7 @@ class XRayState:
                         break
                 except Exception:
                     continue
-        derived_name: str | None = None
-        if agent_cfg:
-            try:
-                derived_name = AgentConfig.model_validate(dict(agent_cfg)).agent_name
-            except Exception:
-                agent_type = agent_cfg.get("_type", "")
-                derived_name = agent_type.split(".")[-1] if agent_type else None
+        derived_name = xray_utils.agent_name_from_config(agent_cfg) or None
         self._backfill_names[id(storage)] = derived_name
         self._storage_configs[id(storage)] = (
             json.dumps(agent_cfg, indent=2) if agent_cfg else None,

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -378,9 +378,12 @@ def parse_exp_config(exp_cfg: dict) -> dict[str, str]:
     identifiers from a serialized Experiment config. Used by both the experiments
     selector table (xray_utils) and the XRay viewer state (xray.XRayState) so the
     agent identifier shown in every UI surface comes from the same logic.
+
+    Accepts both the current (`benchmark_config`) and the pre-split (`benchmark`)
+    key names so historical experiment dirs still resolve a benchmark name.
     """
     agent_cfg = exp_cfg.get("agent_config") or {}
-    bench_cfg = exp_cfg.get("benchmark_config") or {}
+    bench_cfg = exp_cfg.get("benchmark_config") or exp_cfg.get("benchmark") or {}
     return {
         "agent": agent_name_from_config(agent_cfg),
         "model": (agent_cfg.get("llm_config") or {}).get("model_name") or "",

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -341,17 +341,28 @@ def agent_name_from_config(agent_cfg: dict) -> str:
 
     `agent_name` is a `@property` on AgentConfig (not a Pydantic field), so it is
     NOT present in the JSON dump. We re-instantiate the concrete subclass via
-    TypedBaseModel's `_type` dispatch and read the property. Falls back to the
-    class short name when the type can't be imported (e.g. agent package missing
-    locally).
+    TypedBaseModel's `_type` dispatch and read the property. When the module is
+    unavailable locally (e.g. an experiment was produced on a branch that defines
+    a custom agent) we synthesize a name that follows the common
+    `<AgentName>-<model_name>` convention used by built-in agents — both so the
+    column stays informative and so multi-experiment loads remain
+    distinguishable when they only differ in model.
     """
     if not agent_cfg:
         return ""
     try:
         return AgentConfig.model_validate(dict(agent_cfg)).agent_name
     except Exception as exc:
-        logger.debug("Could not instantiate AgentConfig (%s); falling back to _type", exc)
-        return (agent_cfg.get("_type") or "").rsplit(".", 1)[-1]
+        logger.debug("Could not instantiate AgentConfig (%s); synthesizing fallback name", exc)
+        cls_name = (agent_cfg.get("_type") or "").rsplit(".", 1)[-1]
+        # Drop the trailing "Config" so e.g. Genny2Config -> Genny2, matching the
+        # display convention of agent classes whose .agent_name we couldn't reach.
+        if cls_name.endswith("Config"):
+            cls_name = cls_name[: -len("Config")]
+        model = (agent_cfg.get("llm_config") or {}).get("model_name") or ""
+        if cls_name and model:
+            return f"{cls_name}-{model}".replace("/", "_")
+        return cls_name or model
 
 
 def benchmark_name_from_config(bench_cfg: dict) -> str:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -15,10 +15,12 @@ import time
 from pathlib import Path
 from typing import Any
 
+from cube.benchmark import BenchmarkConfig
 from cube.core import EnvironmentOutput
 from PIL import Image
 from pydantic import BaseModel
 
+from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
 from cube_harness.episode_status import TERMINAL_STATUSES as _EPISODE_TERMINAL_STATUSES
@@ -334,6 +336,58 @@ def _parse_exp_date(dir_path: Path) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def agent_name_from_config(agent_cfg: dict) -> str:
+    """Resolve `AgentConfig.agent_name` from a serialized agent_config dict.
+
+    `agent_name` is a `@property` on AgentConfig (not a Pydantic field), so it is
+    NOT present in the JSON dump. We re-instantiate the concrete subclass via
+    TypedBaseModel's `_type` dispatch and read the property. Falls back to the
+    class short name when the type can't be imported (e.g. agent package missing
+    locally).
+    """
+    if not agent_cfg:
+        return ""
+    try:
+        return AgentConfig.model_validate(dict(agent_cfg)).agent_name
+    except Exception as exc:
+        logger.debug("Could not instantiate AgentConfig (%s); falling back to _type", exc)
+        return (agent_cfg.get("_type") or "").rsplit(".", 1)[-1]
+
+
+def benchmark_name_from_config(bench_cfg: dict) -> str:
+    """Resolve `BenchmarkConfig.benchmark_metadata.name` from a benchmark_config dict.
+
+    `benchmark_metadata` is a `ClassVar` on BenchmarkConfig subclasses (declared at
+    class definition time), so it is NOT serialized. We re-instantiate via `_type`
+    dispatch and read the class-level metadata. Falls back to the class short name
+    when the type can't be imported.
+    """
+    if not bench_cfg:
+        return ""
+    try:
+        return BenchmarkConfig.model_validate(dict(bench_cfg)).benchmark_metadata.name
+    except Exception as exc:
+        logger.debug("Could not instantiate BenchmarkConfig (%s); falling back to _type", exc)
+        return (bench_cfg.get("_type") or "").rsplit(".", 1)[-1]
+
+
+def parse_exp_config(exp_cfg: dict) -> dict[str, str]:
+    """Return {agent, model, benchmark} display strings from a parsed experiment_config dict.
+
+    Single source of truth for extracting human-readable agent/model/benchmark
+    identifiers from a serialized Experiment config. Used by both the experiments
+    selector table (xray_utils) and the XRay viewer state (xray.XRayState) so the
+    agent identifier shown in every UI surface comes from the same logic.
+    """
+    agent_cfg = exp_cfg.get("agent_config") or {}
+    bench_cfg = exp_cfg.get("benchmark_config") or {}
+    return {
+        "agent": agent_name_from_config(agent_cfg),
+        "model": (agent_cfg.get("llm_config") or {}).get("model_name") or "",
+        "benchmark": benchmark_name_from_config(bench_cfg),
+    }
+
+
 def _parse_experiment_config(exp_dir: Path) -> dict[str, str]:
     """Return {agent, model, benchmark} from experiment_config.json.
 
@@ -341,24 +395,18 @@ def _parse_experiment_config(exp_dir: Path) -> dict[str, str]:
     experiment_config.json is absent (e.g. synthetic test data).
     """
     config_path = exp_dir / "experiment_config.json"
-    agent = model = benchmark = ""
+    info = {"agent": "", "model": "", "benchmark": ""}
 
     if config_path.exists():
         try:
             with open(config_path) as f:
                 cfg = json.load(f)
-            agent_cfg = cfg.get("agent_config", {})
-            agent = agent_cfg.get("agent_name") or agent_cfg.get("name") or ""
-            if not agent:
-                agent = (agent_cfg.get("_type") or "").rsplit(".", 1)[-1]
-            model = (agent_cfg.get("llm_config") or {}).get("model_name") or ""
-            bm_meta = (cfg.get("benchmark_config") or {}).get("benchmark_metadata") or {}
-            benchmark = bm_meta.get("name") or ""
+            info = parse_exp_config(cfg)
         except Exception as exc:
             logger.debug("Failed to parse experiment_config.json at %s: %s", config_path, exc)
 
-    if not agent:
-        # Fallback: read agent_name from first episode metadata
+    if not info["agent"]:
+        # Fallback: read agent_name from first episode metadata (legacy / synthetic data)
         episodes_dir = exp_dir / "episodes"
         if episodes_dir.exists():
             for ep_dir in episodes_dir.iterdir():
@@ -369,11 +417,12 @@ def _parse_experiment_config(exp_dir: Path) -> dict[str, str]:
                             data = json.load(f)
                         agent = data.get("metadata", {}).get("agent_name", "")
                         if agent:
+                            info["agent"] = agent
                             break
                     except Exception as exc:
                         logger.debug("Failed to parse %s: %s", meta, exc)
 
-    return {"agent": agent, "model": model, "benchmark": benchmark}
+    return info
 
 
 GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runner's kill threshold

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -227,6 +227,26 @@ class TestGetExperimentsTableRows:
         row = next(r for r in rows if r["experiment"] == "exp_a")
         assert row["agent"] == "react_agent"
 
+    def test_agent_uses_agent_name_property_not_class(self, tmp_path: Path) -> None:
+        """`AgentConfig.agent_name` is a @property — it isn't in the JSON dump.
+
+        The experiments table must still surface it (e.g. "ReactAgent-gpt-4o") rather
+        than the class short name ("ReactAgentConfig"). Same fix powers the agent tab
+        identifier so multi-experiment loads stay distinct.
+        """
+        from cube_harness.agents.react import ReactAgentConfig
+        from cube_harness.llm import LLMConfig
+
+        cfg = ReactAgentConfig(llm_config=LLMConfig(model_name="gpt-4o"))
+        exp_dir = tmp_path / "exp_react"
+        (exp_dir / "episodes").mkdir(parents=True)
+        (exp_dir / "experiment_config.json").write_text(
+            json.dumps({"agent_config": json.loads(cfg.model_dump_json(serialize_as_any=True))})
+        )
+        rows = xray_utils.get_experiments_table_rows(tmp_path)
+        row = next(r for r in rows if r["experiment"] == "exp_react")
+        assert row["agent"] == "ReactAgent-gpt-4o"
+
     def test_status_cell_from_status_json(self, tmp_path: Path) -> None:
         now = time.time()
         status_data = [


### PR DESCRIPTION
## Summary

- The experiments selector table read `agent_cfg[\"agent_name\"]` and `benchmark_config[\"benchmark_metadata\"][\"name\"]` straight from the JSON dump, but neither survives serialization: `agent_name` is a `@property` on `AgentConfig` and `benchmark_metadata` is a `ClassVar` on `BenchmarkConfig`. The agent column fell back to the class short name (e.g. `GennyConfig` instead of `Genny-azure_gpt-5.4`) and the benchmark column was always empty.
- Centralized resolution in `xray_utils` (`agent_name_from_config`, `benchmark_name_from_config`, `parse_exp_config`) which re-instantiate the concrete subclass via `TypedBaseModel`'s `_type` dispatch and read the property / ClassVar.
- Both surfaces — the experiments table and the `XRayState` backfill that keys the agent tab — now route through the same helper, so multi-experiment loads stay distinct and the displayed name matches `.agent_name` across the UI.

Verified on a real Genny run: agent column now shows `Genny-azure_gpt-5.4` and benchmark column shows `swebench-verified-cube` (previously `GennyConfig` and empty).

## Test plan

- [x] `pytest tests/test_xray_utils.py tests/test_xray_e2e.py` — 193 passed
- [x] `make lint` clean
- [x] New regression test `test_agent_uses_agent_name_property_not_class` constructs a real `ReactAgentConfig`, dumps to JSON, and asserts the table reads `ReactAgent-gpt-4o`
- [ ] Manual: load a multi-experiment dir in xray, confirm distinct agent rows and populated benchmark column

🤖 Generated with [Claude Code](https://claude.com/claude-code)