### PR TITLE
test: pin that permanent LLM errors must not be retried

### DIFF
--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -21,6 +21,7 @@ import fcntl
 import time
 from pathlib import Path
 
+import litellm
 import pytest
 import ray
 from cube.benchmark import Benchmark as CubeBenchmark
@@ -173,6 +174,12 @@ class DebugAgent(Agent):
         if behavior == "loop":
             # Non-terminating action — drives the runner toward max_steps.
             return AgentOutput(actions=[Action(name="click", arguments={"element_id": "x"})])
+        if behavior == "bad_model":
+            raise litellm.NotFoundError(
+                message="model 'gpt-5-mini-typo-this-model-does-not-exist' does not exist",
+                model="gpt-5-mini-typo-this-model-does-not-exist",
+                llm_provider="openai",
+            )
         raise ValueError(f"Unknown behavior: {behavior}")
 
 
@@ -483,6 +490,46 @@ def test_max_retries_zero_disables_auto_retry(tmp_dir: Path) -> None:
     assert final.status == "FAILED"
     assert final.retry_count == 0
     assert _archive_count(tmp_dir, traj_id) == 0  # only one attempt was ever made
+    assert traj_id in result.failures
+
+
+def test_bad_model_does_not_waste_retries(tmp_dir: Path) -> None:
+    """A permanent LLM provider error (e.g. typo'd model name) must not be retried.
+
+    Today every exception raised inside the episode loop becomes status=FAILED, which
+    is in RETRIABLE_STATUSES. So a permanent error like `litellm.NotFoundError`
+    ("model does not exist") gets retried max_retries times — wasting compute, money,
+    and wall-clock with zero chance of success. This test pins the desired behaviour:
+    permanent provider errors should terminate the episode with retry_count=0.
+    """
+    scenarios = {"task_bad_model": ["bad_model"]}
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=0.0,
+    )
+    exp = Experiment(
+        name="bad_model_retry_waste",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark_config=benchmark,
+        max_retries=3,
+    )
+
+    result = run_sequentially(exp)
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    traj_id, final = next(iter(statuses.items()))
+
+    assert final.status == "FAILED"
+    assert final.error_type == "NotFoundError"
+    assert final.retry_count == 0, (
+        f"permanent provider error was retried {final.retry_count} times; "
+        f"the harness must classify NotFoundError as non-retriable"
+    )
+    assert _archive_count(tmp_dir, traj_id) == 0
     assert traj_id in result.failures
 
 


### PR DESCRIPTION
## Summary
- Adds a failing test (`test_bad_model_does_not_waste_retries`) that demonstrates the harness retries permanent LLM provider errors (e.g. `litellm.NotFoundError` from a typo'd model name) up to `max_retries` times, with zero chance of success.
- The test pins the desired behaviour: permanent provider errors should terminate the episode with `retry_count=0`. Today it fails at `retry_count=3`.

## Why this matters
`episode_status.RETRIABLE_STATUSES` is `{FAILED, CANCELLED, STALE}` and `episode.py` blindly tags every exception as `FAILED`. So a recipe like:

```python
LLMConfig(model_name="gpt-5-mini-typo-this-model-does-not-exist")
Experiment(..., max_retries=3)
run_with_ray(exp, max_retry_rounds=3)
```

burns `max_retries * max_retry_rounds` worker slots before giving up, on an error that will never resolve.

## Suggested follow-up (not in this PR)
Introduce a non-retriable error classification (e.g. `NotFoundError`, `BadRequestError`, `AuthenticationError`, `ContentPolicyViolationError`) and a terminal `INVALID_CONFIG` status. The `_run_loop` except branch should set that status instead of `FAILED` when `type(e).__name__` matches.

## Test plan
- [x] `uv run pytest tests/test_retry_integration.py::test_bad_model_does_not_waste_retries` — confirms it fails on current `main` with the assertion `3 == 0`.
- [ ] Once a fix lands, the same command should pass.