### PR TITLE
fix(harness): retry/queue robustness — config archive, XRay sweeps, experiment heartbeat

### DIFF
--- a/openspec/specs/analyze/spec.md
+++ b/openspec/specs/analyze/spec.md
@@ -35,7 +35,24 @@ CLI-style inspection helpers used by the viewer and exported for ad-hoc scripts.
 
 ### `xray_utils` (`cube_harness.analyze.xray_utils`)
 Formatting and data-extraction helpers (HTML rendering, trace fragments, step
-summaries).
+summaries), plus the **dead-driver detection** the viewer uses to decide whether
+orphaned in-flight episodes can be safely swept:
+
+- `_driver_alive(exp_status, exp_dir) -> bool` — mode-aware liveness check.
+  - `None` exp_status → True (no `experiment_status.json` → pre-heartbeat
+    experiment, assume alive for backward compat).
+  - status `COMPLETED` / `INTERRUPTED` → False.
+  - status `RUNNING` with fresh experiment heartbeat (within `GHOST_TIMEOUT`) → True.
+  - status `RUNNING` with stale experiment heartbeat AND `mode == "sequential"` →
+    fall back to per-episode heartbeats (driver may be mid-episode).
+- `_promote_ghost_episodes(exp_dir)` — best-effort sweep run on every UI refresh:
+  - RUNNING + ray (or no exp_status) → promote when per-episode heartbeat is older
+    than `GHOST_TIMEOUT` (`should_sweep_running_to_stale` predicate).
+  - RUNNING + sequential + driver_dead → promote immediately (driver IS the
+    worker; both dead).
+  - QUEUED + driver_dead → promote (no worker will ever pick it up if the
+    scheduler is gone). QUEUED is **never** promoted when the driver is alive —
+    in a large parallel batch, tasks legitimately wait hours for a slot.
 
 ## UI model
 
@@ -46,7 +63,11 @@ follows it. Navigation moves between environment steps. For UI step N:
 
 ## Invariants
 
-1. Read-only — the viewer never writes to experiment dirs.
+1. Read-only for *trajectory* data — the viewer never modifies trajectories,
+   logs, or configs. The single exception is `_promote_ghost_episodes` writing
+   `STALE` into `status.json` files for in-flight episodes whose driver is
+   provably dead (see `xray_utils` above). This is gated by
+   `experiment_status.json` so the viewer cannot accidentally kill live work.
 2. Handles V2 (episodes/) and V1 (jsonl) layouts via `FileStorage`.
 3. Background loading: a worker thread populates `trajectories` incrementally;
    stale threads self-abort by comparing `_bg_gen`.

--- a/openspec/specs/analyze/spec.md
+++ b/openspec/specs/analyze/spec.md
@@ -35,17 +35,9 @@ CLI-style inspection helpers used by the viewer and exported for ad-hoc scripts.
 
 ### `xray_utils` (`cube_harness.analyze.xray_utils`)
 Formatting and data-extraction helpers (HTML rendering, trace fragments, step
-summaries), plus the **dead-driver detection** the viewer uses to decide whether
-orphaned in-flight episodes can be safely swept:
+summaries), plus `_promote_ghost_episodes(exp_dir)` — best-effort sweep run on
+every UI refresh:
 
-- `_driver_alive(exp_status, exp_dir) -> bool` — mode-aware liveness check.
-  - `None` exp_status → True (no `experiment_status.json` → pre-heartbeat
-    experiment, assume alive for backward compat).
-  - status `COMPLETED` / `INTERRUPTED` → False.
-  - status `RUNNING` with fresh experiment heartbeat (within `GHOST_TIMEOUT`) → True.
-  - status `RUNNING` with stale experiment heartbeat AND `mode == "sequential"` →
-    fall back to per-episode heartbeats (driver may be mid-episode).
-- `_promote_ghost_episodes(exp_dir)` — best-effort sweep run on every UI refresh:
   - RUNNING + ray (or no exp_status) → promote when per-episode heartbeat is older
     than `GHOST_TIMEOUT` (`should_sweep_running_to_stale` predicate).
   - RUNNING + sequential + driver_dead → promote immediately (driver IS the
@@ -53,6 +45,12 @@ orphaned in-flight episodes can be safely swept:
   - QUEUED + driver_dead → promote (no worker will ever pick it up if the
     scheduler is gone). QUEUED is **never** promoted when the driver is alive —
     in a large parallel batch, tasks legitimately wait hours for a slot.
+
+The "is the driver alive?" decision lives with the type it queries: see
+`is_driver_alive(exp_status, exp_dir, *, timeout_s)` in
+`cube_harness.experiment_status` for the mode-aware logic. Same shape as
+`should_sweep_running_to_stale` for episode statuses — predicate over the
+status object, callable from any consumer (viewer, monitoring, reports).
 
 ## UI model
 

--- a/openspec/specs/episode/spec.md
+++ b/openspec/specs/episode/spec.md
@@ -60,10 +60,16 @@ Computed at end-of-episode and stored in `Trajectory.summary_stats`. Includes
 ## Main loop semantics
 
 1. Enter `tracer.episode(task_id, experiment=exp_name)` span
-2. `task_config.make(runtime_context=..., container_backend=...)` → live Task
-3. `setup_fn()` → first `EnvironmentOutput` from `task.reset()`
-4. Save initial trajectory + episode_config on disk
-5. While not done and turns < max_steps:
+2. `_open_status` writes RUNNING `status.json` with `current_step=0`. This is the
+   **phase signal** the runner's `_kill_stale_workers` reads — `current_step == 0`
+   means setup hasn't completed yet, so the setup-phase budget applies.
+3. `task_config.make(runtime_context=..., container_backend=...)` → live Task
+4. `setup_fn()` → first `EnvironmentOutput` from `task.reset()`
+5. Save initial trajectory + episode_config on disk
+6. While not done and turns < max_steps:
+   - Heartbeat: write `status.json` with `current_step = turns + 1` and fresh
+     `last_heartbeat_at`. Heartbeat write is **fail-open** (logs warning, does
+     not abort the run on transient I/O errors).
    - `agent.step(obs)` → `AgentOutput`
      - On exception: save the failed agent step, re-raise (trajectory is preserved)
    - Append agent step to trajectory + save incrementally
@@ -71,8 +77,8 @@ Computed at end-of-episode and stored in `Trajectory.summary_stats`. Includes
    - `step_fn(agent_output.actions)` → `EnvironmentOutput`
      - On exception: save failed env step (with prior obs), re-raise
    - Append env step + save
-6. `finally`: call `task.close()` and `tracer.shutdown()`
-7. Compute `summary_stats`, persist final trajectory, return
+7. `finally`: call `task.close()` and `tracer.shutdown()`
+8. Compute `summary_stats`, persist final trajectory, return
 
 Final episode status is `OK` if `final_reward > 0`, else `ERROR` (sets OTel span status).
 

--- a/openspec/specs/experiment/spec.md
+++ b/openspec/specs/experiment/spec.md
@@ -33,6 +33,7 @@ class Experiment(TypedBaseModel):
         step_timeout_s: float = 1800.0,
         cancel_grace_s: float = 120.0,
         orphan_threshold_s: float = 3600.0,
+        process_start_s: float | None = None,    # current driver's wall-clock start
     ) -> list[Episode]
     def save_config(self) -> None        # writes experiment_config.json
     @classmethod
@@ -61,7 +62,15 @@ may omit `benchmark`; the resulting episodes carry no `runtime_context` and no
 `MAX_STEPS_REACHED` (terminal, non-retriable) are always skipped.
 
 When `resume=True`, `sweep_stale_statuses` runs first so orphaned `RUNNING`/`QUEUED`
-entries become `STALE` and are eligible for retry.
+entries become `STALE` and are eligible for retry. The runner threads its own
+`process_start_s` into the sweep so RUNNING episodes whose heartbeat predates the
+new process are force-swept regardless of heartbeat age — fixes the kill-and-retry
+race where a freshly killed worker still has a recent heartbeat.
+
+The shared "is this RUNNING worker dead?" predicate
+(`should_sweep_running_to_stale` in `episode_status.py`) is the single source of
+truth used by both `sweep_stale_statuses` (runner-side) and
+`_promote_ghost_episodes` (XRay-side).
 
 ### `ExpResult`
 ```python
@@ -75,22 +84,35 @@ class ExpResult(TypedBaseModel):
 
 ### Runners
 
-#### `run_sequentially(exp, debug_limit=None, otlp_endpoint=None, model=None, agent_name=None) -> ExpResult`
-Runs episodes one at a time. `debug_limit` caps the list (useful for `make debug`).
+#### `run_sequentially(exp, debug_limit=None, *, step_timeout_s=1800.0, cancel_grace_s=120.0, orphan_threshold_s=3600.0, max_retry_rounds=3, otlp_endpoint=None, model=None, agent_name=None) -> ExpResult`
+Runs episodes one at a time in-process. `debug_limit` caps the list (useful for
+`make debug`). The driver IS the worker — `experiment_status.json` is heartbeated
+*between* episodes, so a long episode can leave the experiment heartbeat stale even
+though the driver is alive (XRay falls back to per-episode heartbeats in this case).
 
-#### `run_with_ray(exp, n_cpus=4, ray_poll_timeout=2.0, episode_timeout=3600.0, otlp_endpoint=None, model=None, agent_name=None) -> ExpResult`
-Parallel via Ray `@remote`. Initializes Ray with dashboard enabled. `episode_timeout`
-(seconds) cancels stuck episodes — graceful for `_CANCEL_GRACE_PERIOD_S=60`, force
-after.
+#### `run_with_ray(exp, *, n_cpus=4, ray_poll_timeout=2.0, step_timeout_s=1800.0, setup_timeout_s=7200.0, cancel_grace_s=120.0, orphan_threshold_s=3600.0, max_retry_rounds=3, otlp_endpoint=None, model=None, agent_name=None) -> ExpResult`
+Parallel via Ray `@remote`. Initializes Ray with dashboard enabled.
+
+Driver-side step timeout is enforced in `_kill_stale_workers` by reading each
+active episode's `status.json` and comparing `now - last_heartbeat_at` against a
+**phase-aware budget**: episodes still in setup (`current_step == 0`) get
+`setup_timeout_s` (default `4 × step_timeout_s = 7200s`; container scheduling /
+toolkit queuing can be slow); episodes inside the agent loop get the full
+`step_timeout_s`. Workers exceeding their budget are `ray.cancel(force=True)`-ed
+and stamped `CANCELLED` with `error_type="SetupTimeout"` or `"StepTimeout"`.
 
 Both runners:
 1. Enter `tracer.benchmark(exp.name)` span
-2. `exp.save_config()`
-3. `with exp.benchmark_config.make(exp.infra) as benchmark:` — `make` provisions
+2. Enter `_experiment_lifecycle(exp.output_dir, mode=...)` — writes RUNNING to
+   `experiment_status.json` on enter, COMPLETED (or INTERRUPTED on exception) on
+   exit. The driver heartbeats the file: every ~30 s in Ray mode (from the
+   `_poll_ray` loop), and before each `episode.run()` in sequential mode.
+3. `exp.save_config()`
+4. `with exp.benchmark_config.make(exp.infra) as benchmark:` — `make` provisions
    declared resources, instantiates the runtime pair, and calls `setup()`. The
    context manager guarantees `close()` on exit.
-4. Call the internal `_run_*_impl` with the live `benchmark`
-5. `tracer.shutdown()`
+5. Call the internal `_run_*_impl` with the live `benchmark`
+6. `tracer.shutdown()`
 
 Per-episode stdout/stderr is redirected to `<output_dir>/episodes/<traj_id>/logs/`
 via `redirect_output_to_log` from `episode_logs.py`.
@@ -107,6 +129,12 @@ via `redirect_output_to_log` from `episode_logs.py`.
    every run. `make()` calls `setup()` internally, and the context manager calls
    `close()` on exit — resource cleanup is guaranteed on exceptions.
 4. Ray disrupts signal handling (Ctrl+C) — known limitation, no fix yet.
+5. `experiment_status.json` (sibling of `experiment_config.json`) is written by
+   the driver, never by Ray workers. Its lifecycle is RUNNING on entry →
+   COMPLETED on clean return → INTERRUPTED on exception. Heartbeats update
+   `last_heartbeat_at` and counters (`completed`, `failed`). Old experiments
+   without this file behave as before — XRay treats "no file" as "driver alive"
+   for backward compat.
 
 ## Contracts for implementers
 
@@ -124,7 +152,13 @@ via `redirect_output_to_log` from `episode_logs.py`.
   environments.
 - Ray workers inherit `env_vars` from `get_trace_env_vars()` — if you need extra env
   vars in workers, they must be added explicitly (not automatic from the driver).
-- Episode timeouts use the Ray dashboard API (`list_tasks`). If the dashboard is
-  unreachable, timeouts are silently skipped that cycle — logs a debug message.
-- Cancellation is best-effort: graceful cancel waits `_CANCEL_GRACE_PERIOD_S` seconds,
-  then force-kills. An episode that hangs in a C extension may not respect cancel.
+- Episode timeouts are enforced by reading per-episode `status.json` heartbeats
+  from disk (filesystem-driven, no Ray dashboard dependency). Workers exceeding
+  their phase-aware budget are `ray.cancel(force=True)`-ed.
+- Cancellation is best-effort: `cancel_grace_s` (default 120s) is added to the
+  budget before the kill. An episode that hangs in a C extension may not respect
+  cancel.
+- `_promote_ghost_episodes` (XRay) only sweeps QUEUED → STALE when
+  `experiment_status.json` reports the driver dead — never on every refresh.
+  Sequential mode falls back to per-episode heartbeats to avoid false-positive
+  promotions during long episodes.

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -26,6 +26,7 @@ from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
 from cube_harness.episode_status import TERMINAL_STATUSES as _EPISODE_TERMINAL_STATUSES
 from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 from cube_harness.llm import LLMCall
 
 logger = logging.getLogger(__name__)
@@ -444,38 +445,78 @@ GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runne
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
 
 
+def _driver_alive(exp_dir: Path) -> bool:
+    """Return True if the experiment driver appears to be alive.
+
+    Reads `experiment_status.json`.  Returns True when the file is absent (old
+    experiments without a status file — we can't tell, so we don't promote).
+
+    Mode-aware liveness:
+    - "ray": trusts the experiment heartbeat alone (driver polls every ~30 s).
+    - "sequential": falls back to episode-level heartbeats when the experiment
+      heartbeat is stale, because the driver heartbeats *between* episodes, not
+      inside episode.run(), so a long-running episode makes the experiment
+      heartbeat appear old even when the driver is alive.
+    """
+    exp_status = ExperimentStatus.read(exp_dir / EXPERIMENT_STATUS_FILENAME)
+    if exp_status is None:
+        return True  # no status file → assume alive (pre-heartbeat experiment)
+    if exp_status.status in ("COMPLETED", "INTERRUPTED"):
+        return False
+    now = time.time()
+    if now - exp_status.last_heartbeat_at <= GHOST_TIMEOUT:
+        return True  # fresh experiment heartbeat
+    if exp_status.mode == "sequential":
+        # Stale experiment heartbeat but sequential mode: check episode heartbeats.
+        # A live RUNNING episode means the driver is mid-episode and alive.
+        episodes_dir = exp_dir / "episodes"
+        if episodes_dir.exists():
+            for ep_dir in episodes_dir.iterdir():
+                if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
+                    continue
+                ep_status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
+                if ep_status is None or ep_status.status != "RUNNING":
+                    continue
+                ep_hb = ep_status.last_heartbeat_at or ep_status.started_at
+                if now - ep_hb <= GHOST_TIMEOUT:
+                    return True
+    return False
+
+
 def _promote_ghost_episodes(exp_dir: Path) -> None:
-    """Write STALE into status.json for RUNNING episodes whose heartbeat has gone silent.
+    """Write STALE into status.json for in-flight episodes whose driver is dead.
 
-    Fixes experiments where the runner crashed without marking episodes terminal.
-    This lets the cache machinery treat the experiment as finished so it can be frozen.
-
-    Only RUNNING episodes are promoted — QUEUED episodes are legitimately waiting for
-    a Ray worker slot and must not be touched here.  In a large batch (e.g. 89 tasks,
-    --n-parallel 10) the last tasks can sit QUEUED for many hours; promoting them from
-    the viewer would silently kill tasks that the runner is about to dispatch.
-    QUEUED orphan cleanup is handled exclusively by sweep_stale_statuses() in
-    experiment.py, which runs either at resume-time or on runner shutdown.
+    RUNNING episodes: promoted when their heartbeat has been silent for > GHOST_TIMEOUT.
+    QUEUED episodes: promoted only when the driver is confirmed dead via
+    `experiment_status.json` — prevents silently killing tasks that are legitimately
+    waiting for a Ray worker slot in a large batch.
     """
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
         return
+    driver_dead = not _driver_alive(exp_dir)
     now = time.time()
     for ep_dir in episodes_dir.iterdir():
         if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
             continue
         status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
-        if status is None or status.status != "RUNNING":
+        if status is None:
             continue
-        hb = status.last_heartbeat_at or status.started_at
-        if now - hb > GHOST_TIMEOUT:
-            status.status = "STALE"
-            if status.ended_at is None:
-                status.ended_at = hb
-            try:
-                status.write(ep_dir / STATUS_FILENAME)
-            except OSError:
-                pass  # best-effort: race with runner archiving the dir is harmless
+        is_stale = False
+        if status.status == "RUNNING":
+            hb = status.last_heartbeat_at or status.started_at
+            is_stale = now - hb > GHOST_TIMEOUT
+        elif status.status == "QUEUED" and driver_dead:
+            is_stale = True
+        if not is_stale:
+            continue
+        status.status = "STALE"
+        if status.ended_at is None:
+            status.ended_at = status.last_heartbeat_at or status.started_at
+        try:
+            status.write(ep_dir / STATUS_FILENAME)
+        except OSError:
+            pass  # best-effort: race with runner archiving the dir is harmless
 
 
 def _all_episodes_terminal(exp_dir: Path) -> bool:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -445,10 +445,17 @@ _XRAY_CACHE_FILENAME = ".xray_summary.json"
 
 
 def _promote_ghost_episodes(exp_dir: Path) -> None:
-    """Write STALE into status.json for RUNNING/QUEUED episodes whose heartbeat is dead.
+    """Write STALE into status.json for RUNNING episodes whose heartbeat has gone silent.
 
     Fixes experiments where the runner crashed without marking episodes terminal.
     This lets the cache machinery treat the experiment as finished so it can be frozen.
+
+    Only RUNNING episodes are promoted — QUEUED episodes are legitimately waiting for
+    a Ray worker slot and must not be touched here.  In a large batch (e.g. 89 tasks,
+    --n-parallel 10) the last tasks can sit QUEUED for many hours; promoting them from
+    the viewer would silently kill tasks that the runner is about to dispatch.
+    QUEUED orphan cleanup is handled exclusively by sweep_stale_statuses() in
+    experiment.py, which runs either at resume-time or on runner shutdown.
     """
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
@@ -458,7 +465,7 @@ def _promote_ghost_episodes(exp_dir: Path) -> None:
         if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
             continue
         status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
-        if status is None or status.status not in ("RUNNING", "QUEUED"):
+        if status is None or status.status != "RUNNING":
             continue
         hb = status.last_heartbeat_at or status.started_at
         if now - hb > GHOST_TIMEOUT:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 from cube_harness.agent import AgentConfig
 from cube_harness.analyze.stats import reward_mean_stderr
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
-from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus, should_sweep_running_to_stale
 from cube_harness.episode_status import TERMINAL_STATUSES as _EPISODE_TERMINAL_STATUSES
 from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
 from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
@@ -445,20 +445,17 @@ GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runne
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
 
 
-def _driver_alive(exp_dir: Path) -> bool:
+def _driver_alive(exp_status: ExperimentStatus | None, exp_dir: Path) -> bool:
     """Return True if the experiment driver appears to be alive.
 
-    Reads `experiment_status.json`.  Returns True when the file is absent (old
-    experiments without a status file — we can't tell, so we don't promote).
-
-    Mode-aware liveness:
+    Takes the already-read `ExperimentStatus` (None = file absent → assume alive,
+    covers pre-heartbeat experiments). Mode-aware:
     - "ray": trusts the experiment heartbeat alone (driver polls every ~30 s).
     - "sequential": falls back to episode-level heartbeats when the experiment
       heartbeat is stale, because the driver heartbeats *between* episodes, not
       inside episode.run(), so a long-running episode makes the experiment
-      heartbeat appear old even when the driver is alive.
+      heartbeat look stale even when the driver is alive.
     """
-    exp_status = ExperimentStatus.read(exp_dir / EXPERIMENT_STATUS_FILENAME)
     if exp_status is None:
         return True  # no status file → assume alive (pre-heartbeat experiment)
     if exp_status.status in ("COMPLETED", "INTERRUPTED"):
@@ -467,7 +464,7 @@ def _driver_alive(exp_dir: Path) -> bool:
     if now - exp_status.last_heartbeat_at <= GHOST_TIMEOUT:
         return True  # fresh experiment heartbeat
     if exp_status.mode == "sequential":
-        # Stale experiment heartbeat but sequential mode: check episode heartbeats.
+        # Stale experiment heartbeat in sequential mode: check episode heartbeats.
         # A live RUNNING episode means the driver is mid-episode and alive.
         episodes_dir = exp_dir / "episodes"
         if episodes_dir.exists():
@@ -486,15 +483,17 @@ def _driver_alive(exp_dir: Path) -> bool:
 def _promote_ghost_episodes(exp_dir: Path) -> None:
     """Write STALE into status.json for in-flight episodes whose driver is dead.
 
-    RUNNING episodes: promoted when their heartbeat has been silent for > GHOST_TIMEOUT.
-    QUEUED episodes: promoted only when the driver is confirmed dead via
-    `experiment_status.json` — prevents silently killing tasks that are legitimately
-    waiting for a Ray worker slot in a large batch.
+    RUNNING + ray mode: promoted by per-episode heartbeat age (GHOST_TIMEOUT).
+    RUNNING + sequential mode + driver dead: promoted immediately — driver is the
+      worker, so process death kills both.
+    QUEUED + driver dead: promoted regardless of mode — no worker will ever pick
+      these up if the scheduler that queued them is gone.
     """
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
         return
-    driver_dead = not _driver_alive(exp_dir)
+    exp_status = ExperimentStatus.read(exp_dir / EXPERIMENT_STATUS_FILENAME)
+    driver_dead = not _driver_alive(exp_status, exp_dir)
     now = time.time()
     for ep_dir in episodes_dir.iterdir():
         if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
@@ -504,8 +503,15 @@ def _promote_ghost_episodes(exp_dir: Path) -> None:
             continue
         is_stale = False
         if status.status == "RUNNING":
-            hb = status.last_heartbeat_at or status.started_at
-            is_stale = now - hb > GHOST_TIMEOUT
+            if driver_dead and exp_status is not None and exp_status.mode == "sequential":
+                is_stale = True  # driver == worker; both dead
+            else:
+                is_stale = should_sweep_running_to_stale(
+                    status,
+                    now=now,
+                    step_timeout_s=DEFAULT_STEP_TIMEOUT_S,
+                    cancel_grace_s=DEFAULT_CANCEL_GRACE_S,
+                )
         elif status.status == "QUEUED" and driver_dead:
             is_stale = True
         if not is_stale:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -26,7 +26,7 @@ from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus, should_sweep_running_to_stale
 from cube_harness.episode_status import TERMINAL_STATUSES as _EPISODE_TERMINAL_STATUSES
 from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
-from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus, is_driver_alive
 from cube_harness.llm import LLMCall
 
 logger = logging.getLogger(__name__)
@@ -445,41 +445,6 @@ GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runne
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
 
 
-def _driver_alive(exp_status: ExperimentStatus | None, exp_dir: Path) -> bool:
-    """Return True if the experiment driver appears to be alive.
-
-    Takes the already-read `ExperimentStatus` (None = file absent → assume alive,
-    covers pre-heartbeat experiments). Mode-aware:
-    - "ray": trusts the experiment heartbeat alone (driver polls every ~30 s).
-    - "sequential": falls back to episode-level heartbeats when the experiment
-      heartbeat is stale, because the driver heartbeats *between* episodes, not
-      inside episode.run(), so a long-running episode makes the experiment
-      heartbeat look stale even when the driver is alive.
-    """
-    if exp_status is None:
-        return True  # no status file → assume alive (pre-heartbeat experiment)
-    if exp_status.status in ("COMPLETED", "INTERRUPTED"):
-        return False
-    now = time.time()
-    if now - exp_status.last_heartbeat_at <= GHOST_TIMEOUT:
-        return True  # fresh experiment heartbeat
-    if exp_status.mode == "sequential":
-        # Stale experiment heartbeat in sequential mode: check episode heartbeats.
-        # A live RUNNING episode means the driver is mid-episode and alive.
-        episodes_dir = exp_dir / "episodes"
-        if episodes_dir.exists():
-            for ep_dir in episodes_dir.iterdir():
-                if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
-                    continue
-                ep_status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
-                if ep_status is None or ep_status.status != "RUNNING":
-                    continue
-                ep_hb = ep_status.last_heartbeat_at or ep_status.started_at
-                if now - ep_hb <= GHOST_TIMEOUT:
-                    return True
-    return False
-
-
 def _promote_ghost_episodes(exp_dir: Path) -> None:
     """Write STALE into status.json for in-flight episodes whose driver is dead.
 
@@ -493,7 +458,7 @@ def _promote_ghost_episodes(exp_dir: Path) -> None:
     if not episodes_dir.exists():
         return
     exp_status = ExperimentStatus.read(exp_dir / EXPERIMENT_STATUS_FILENAME)
-    driver_dead = not _driver_alive(exp_status, exp_dir)
+    driver_dead = not is_driver_alive(exp_status, exp_dir, timeout_s=GHOST_TIMEOUT)
     now = time.time()
     for ep_dir in episodes_dir.iterdir():
         if not ep_dir.is_dir() or ".archived_" in ep_dir.name:

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -213,7 +213,12 @@ class Episode:
                     # Heartbeat 2: start of each turn, before agent.step() and step_fn().
                     ep_status.last_heartbeat_at = time.time()
                     ep_status.current_step = turns + 1
-                    self.storage.write_episode_status(trajectory_id, ep_status)
+                    try:
+                        self.storage.write_episode_status(trajectory_id, ep_status)
+                    except Exception:
+                        logger.warning(
+                            "Failed to write heartbeat for %s step %d", trajectory_id, turns + 1, exc_info=True
+                        )
 
                     with tracer.step(f"turn_{turns}") as span:
                         ts = time.time()

--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -99,6 +99,30 @@ class EpisodeStatus:
         os.replace(tmp, path)
 
 
+def should_sweep_running_to_stale(
+    status: EpisodeStatus,
+    *,
+    now: float,
+    step_timeout_s: float,
+    cancel_grace_s: float,
+    process_start_s: float | None = None,
+) -> bool:
+    """Return True iff a RUNNING episode's worker appears dead and should become STALE.
+
+    Two cases:
+    - heartbeat predates `process_start_s` — worker is provably from a dead prior process.
+    - heartbeat age > `step_timeout_s + cancel_grace_s` — worker died without writing a
+      terminal status.
+
+    Returns False when `last_heartbeat_at` is None (episode never left QUEUED; no worker).
+    """
+    if status.last_heartbeat_at is None:
+        return False
+    if process_start_s is not None and status.last_heartbeat_at < process_start_s:
+        return True
+    return now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s
+
+
 def next_retry_count(prior: "EpisodeStatus | None") -> int:
     """Return the retry_count for a new attempt, given the prior status (if any).
 

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 # Default timeouts shared with xray_utils for ghost-episode detection.
 DEFAULT_STEP_TIMEOUT_S: float = 9000.0
+DEFAULT_SETUP_TIMEOUT_S: float = 600.0
 DEFAULT_CANCEL_GRACE_S: float = 120.0
 
 
@@ -92,6 +93,7 @@ def run_with_ray(
     n_cpus: int = 4,
     ray_poll_timeout: float = 2.0,
     step_timeout_s: float = DEFAULT_STEP_TIMEOUT_S,
+    setup_timeout_s: float = DEFAULT_SETUP_TIMEOUT_S,
     cancel_grace_s: float = DEFAULT_CANCEL_GRACE_S,
     orphan_threshold_s: float = 3600.0,
     max_retry_rounds: int = 3,
@@ -115,6 +117,7 @@ def run_with_ray(
                 n_cpus=n_cpus,
                 ray_poll_timeout=ray_poll_timeout,
                 step_timeout_s=step_timeout_s,
+                setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
                 max_retry_rounds=max_retry_rounds,
@@ -135,6 +138,7 @@ def _run_with_retries(
     n_cpus: int,
     ray_poll_timeout: float,
     step_timeout_s: float,
+    setup_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
     max_retry_rounds: int,
@@ -155,6 +159,7 @@ def _run_with_retries(
                 n_cpus=n_cpus,
                 ray_poll_timeout=ray_poll_timeout,
                 step_timeout_s=step_timeout_s,
+                setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
             )
@@ -188,10 +193,12 @@ def _run_with_ray_impl(
     n_cpus: int,
     ray_poll_timeout: float,
     step_timeout_s: float,
+    setup_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
 ) -> ExpResult:
     """Run a single Ray round: pre-claim, submit, poll with step-timeout, sweep stale on shutdown."""
+    process_start_s = time.time()
     exp.save_config()
     output_dir = exp.output_dir
     storage = FileStorage(output_dir)
@@ -221,6 +228,7 @@ def _run_with_ray_impl(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                process_start_s=process_start_s,
             )
 
             # Pre-claim every episode before any Ray submission so a concurrent runner
@@ -239,6 +247,7 @@ def _run_with_ray_impl(
                 storage,
                 ray_poll_timeout=ray_poll_timeout,
                 step_timeout_s=step_timeout_s,
+                setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
             )
             exp.print_stats(results)
@@ -252,6 +261,7 @@ def _run_with_ray_impl(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                process_start_s=process_start_s,
             )
 
 
@@ -262,6 +272,7 @@ def _poll_ray(
     *,
     ray_poll_timeout: float,
     step_timeout_s: float,
+    setup_timeout_s: float,
     cancel_grace_s: float,
 ) -> ExpResult:
     """Wait on Ray refs, collecting trajectories/failures and force-killing workers with stale heartbeats."""
@@ -300,6 +311,7 @@ def _poll_ray(
             storage,
             results,
             step_timeout_s=step_timeout_s,
+            setup_timeout_s=setup_timeout_s,
             cancel_grace_s=cancel_grace_s,
         )
     return results
@@ -312,13 +324,15 @@ def _kill_stale_workers(
     results: ExpResult,
     *,
     step_timeout_s: float,
+    setup_timeout_s: float,
     cancel_grace_s: float,
 ) -> None:
     """Read each active episode's status.json; force-kill workers with stale heartbeats.
 
-    A worker that has not advanced its heartbeat in `step_timeout_s + cancel_grace_s`
-    is presumed stuck. The driver force-cancels it, writes a `CANCELLED` status with
-    `error_type="StepTimeout"`, and removes the ref from the in-progress list.
+    Uses a phase-aware budget: episodes still in setup (current_step == 0) are given
+    `setup_timeout_s`; episodes that have entered the agent loop get the full `step_timeout_s`.
+    This lets setup hangs (container boot, env reset) be detected quickly without
+    shortening the budget for legitimate long-running agent steps.
     """
     now = time.time()
     to_remove: list[ray.ObjectRef] = []
@@ -330,11 +344,12 @@ def _kill_stale_workers(
         if status is None or status.status != "RUNNING" or status.last_heartbeat_at is None:
             continue
         age = now - status.last_heartbeat_at
-        if age <= step_timeout_s + cancel_grace_s:
+        budget = setup_timeout_s if status.current_step == 0 else step_timeout_s
+        if age <= budget + cancel_grace_s:
             continue
+        phase = "setup" if status.current_step == 0 else f"step {status.current_step}"
         logger.error(
-            f"Episode {traj_id} step {status.current_step} stalled for {age:.0f}s "
-            f"(>{step_timeout_s + cancel_grace_s:.0f}s) — force killing"
+            f"Episode {traj_id} {phase} stalled for {age:.0f}s (>{budget + cancel_grace_s:.0f}s) — force killing"
         )
         try:
             ray.cancel(ref, force=True)
@@ -351,8 +366,8 @@ def _kill_stale_workers(
             continue
         status.status = "CANCELLED"
         status.ended_at = now
-        status.error_type = "StepTimeout"
-        status.error_message = f"Step {status.current_step} exceeded {step_timeout_s:.0f}s"
+        status.error_type = "SetupTimeout" if status.current_step == 0 else "StepTimeout"
+        status.error_message = f"{phase} exceeded {budget:.0f}s"
         storage.write_episode_status(traj_id, status)
         results.failures[traj_id] = status.error_message
         to_remove.append(ref)
@@ -453,6 +468,7 @@ def _run_sequentially_impl(
     orphan_threshold_s: float,
 ) -> ExpResult:
     """Run a single sequential round in-process, returning trajectories and failures for this round."""
+    process_start_s = time.time()
     exp.save_config()
     storage = FileStorage(exp.output_dir)
     with exp.benchmark_config.make(exp.infra) as benchmark:
@@ -461,6 +477,7 @@ def _run_sequentially_impl(
             step_timeout_s=step_timeout_s,
             cancel_grace_s=cancel_grace_s,
             orphan_threshold_s=orphan_threshold_s,
+            process_start_s=process_start_s,
         )
         if debug_limit is not None:
             logger.info(f"Running only first {debug_limit} episodes for debugging")

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Default timeouts shared with xray_utils for ghost-episode detection.
 DEFAULT_STEP_TIMEOUT_S: float = 9000.0
-DEFAULT_SETUP_TIMEOUT_S: float = 600.0
+DEFAULT_SETUP_TIMEOUT_S: float = 4 * DEFAULT_STEP_TIMEOUT_S  # container scheduling can queue
 DEFAULT_CANCEL_GRACE_S: float = 120.0
 
 # How often the driver updates experiment_status.json in Ray mode.

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -280,7 +280,7 @@ def _poll_ray(
         for task_ref in done:
             traj_id = ref_to_traj_id[task_ref]
             try:
-                traj: Trajectory = ray.get(task_ref)
+                traj: Trajectory = ray.get(task_ref, timeout=step_timeout_s + cancel_grace_s)
                 logger.info(
                     "Completed trajectory %s with %d steps (%d agent steps, %d environment steps)",
                     traj_id,

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -5,7 +5,10 @@ import os
 import socket
 import sys
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Literal
 from uuid import uuid4
 
 import ray
@@ -65,6 +68,44 @@ def _trajectory_id(episode: Episode) -> str:
     return trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
 
 
+@contextmanager
+def _experiment_lifecycle(exp_dir: Path, mode: Literal["ray", "sequential"]) -> Iterator[tuple[ExperimentStatus, Path]]:
+    """Manage `experiment_status.json` from RUNNING through terminal write.
+
+    Writes RUNNING on entry. On normal exit, writes COMPLETED; on exception,
+    writes INTERRUPTED. Both initial and terminal writes log a warning on
+    failure rather than swallowing silently — these bracket the run, so a
+    failure here is something an operator should see.
+    """
+    now = time.time()
+    exp_status = ExperimentStatus(
+        status="RUNNING",
+        mode=mode,
+        pid=os.getpid(),
+        host=socket.gethostname(),
+        started_at=now,
+        last_heartbeat_at=now,
+        total_episodes=0,
+    )
+    exp_status_path = exp_dir / EXPERIMENT_STATUS_FILENAME
+    try:
+        exp_status.write(exp_status_path)
+    except Exception:
+        logger.warning("Failed to write initial experiment status", exc_info=True)
+    completed = False
+    try:
+        yield exp_status, exp_status_path
+        completed = True
+    finally:
+        exp_status.status = "COMPLETED" if completed else "INTERRUPTED"
+        exp_status.ended_at = time.time()
+        exp_status.last_heartbeat_at = exp_status.ended_at
+        try:
+            exp_status.write(exp_status_path)
+        except Exception:
+            logger.warning("Failed to write terminal experiment status", exc_info=True)
+
+
 def _pre_claim(storage: Storage, episode: Episode) -> None:
     """Write `QUEUED` for an episode before submitting it to Ray.
 
@@ -115,25 +156,12 @@ def run_with_ray(
         model=model,
         agent_name=agent_name,
     )
-    now = time.time()
-    exp_status = ExperimentStatus(
-        status="RUNNING",
-        mode="ray",
-        pid=os.getpid(),
-        host=socket.gethostname(),
-        started_at=now,
-        last_heartbeat_at=now,
-        total_episodes=0,
-    )
-    exp_status_path = exp.output_dir / EXPERIMENT_STATUS_FILENAME
     try:
-        exp_status.write(exp_status_path)
-    except Exception:
-        logger.warning("Failed to write initial experiment status", exc_info=True)
-    _completed = False
-    try:
-        with tracer.benchmark(exp.name):
-            result = _run_with_retries(
+        with (
+            tracer.benchmark(exp.name),
+            _experiment_lifecycle(exp.output_dir, mode="ray") as (exp_status, exp_status_path),
+        ):
+            return _run_with_retries(
                 exp,
                 n_cpus=n_cpus,
                 ray_poll_timeout=ray_poll_timeout,
@@ -145,16 +173,7 @@ def run_with_ray(
                 exp_status=exp_status,
                 exp_status_path=exp_status_path,
             )
-        _completed = True
-        return result
     finally:
-        exp_status.status = "COMPLETED" if _completed else "INTERRUPTED"
-        exp_status.ended_at = time.time()
-        exp_status.last_heartbeat_at = exp_status.ended_at
-        try:
-            exp_status.write(exp_status_path)
-        except Exception:
-            logger.warning("Failed to write terminal experiment status", exc_info=True)
         tracer.shutdown()
 
 
@@ -279,11 +298,7 @@ def _run_with_ray_impl(
                 ref = run_episode.remote(episode)
                 ref_to_traj_id[ref] = _trajectory_id(episode)
             exp_status.total_episodes = len(storage.list_episode_configs())
-            exp_status.last_heartbeat_at = time.time()
-            try:
-                exp_status.write(exp_status_path)
-            except Exception:
-                pass
+            exp_status.heartbeat(exp_status_path)
             logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
             results = _poll_ray(
                 exp,
@@ -367,15 +382,21 @@ def _poll_ray(
         # Heartbeat experiment_status.json so XRay knows this driver is alive.
         now = time.time()
         if now - last_exp_hb >= _EXP_HEARTBEAT_INTERVAL_S:
-            exp_status.last_heartbeat_at = now
-            exp_status.completed = len(results.trajectories)
-            exp_status.failed = len(results.failures)
-            try:
-                exp_status.write(exp_status_path)
-            except Exception:
-                pass
+            exp_status.heartbeat(
+                exp_status_path,
+                completed=len(results.trajectories),
+                failed=len(results.failures),
+            )
             last_exp_hb = now
 
+    # Final heartbeat flushes counters before the lifecycle writes the terminal
+    # status. Without this, the last batch of completions (or any work shorter
+    # than `_EXP_HEARTBEAT_INTERVAL_S`) would be lost from the on-disk record.
+    exp_status.heartbeat(
+        exp_status_path,
+        completed=len(results.trajectories),
+        failed=len(results.failures),
+    )
     return results
 
 
@@ -457,25 +478,12 @@ def run_sequentially(
         model=model,
         agent_name=agent_name,
     )
-    now = time.time()
-    exp_status = ExperimentStatus(
-        status="RUNNING",
-        mode="sequential",
-        pid=os.getpid(),
-        host=socket.gethostname(),
-        started_at=now,
-        last_heartbeat_at=now,
-        total_episodes=0,
-    )
-    exp_status_path = exp.output_dir / EXPERIMENT_STATUS_FILENAME
     try:
-        exp_status.write(exp_status_path)
-    except Exception:
-        logger.warning("Failed to write initial experiment status", exc_info=True)
-    _completed = False
-    try:
-        with tracer.benchmark(exp.name):
-            result = _run_sequentially_with_retries(
+        with (
+            tracer.benchmark(exp.name),
+            _experiment_lifecycle(exp.output_dir, mode="sequential") as (exp_status, exp_status_path),
+        ):
+            return _run_sequentially_with_retries(
                 exp,
                 debug_limit=debug_limit,
                 step_timeout_s=step_timeout_s,
@@ -485,16 +493,7 @@ def run_sequentially(
                 exp_status=exp_status,
                 exp_status_path=exp_status_path,
             )
-        _completed = True
-        return result
     finally:
-        exp_status.status = "COMPLETED" if _completed else "INTERRUPTED"
-        exp_status.ended_at = time.time()
-        exp_status.last_heartbeat_at = exp_status.ended_at
-        try:
-            exp_status.write(exp_status_path)
-        except Exception:
-            logger.warning("Failed to write terminal experiment status", exc_info=True)
         tracer.shutdown()
 
 
@@ -580,11 +579,7 @@ def _run_sequentially_impl(
             _pre_claim(storage, episode)
 
         exp_status.total_episodes = len(storage.list_episode_configs())
-        exp_status.last_heartbeat_at = time.time()
-        try:
-            exp_status.write(exp_status_path)
-        except Exception:
-            pass
+        exp_status.heartbeat(exp_status_path)
 
         results = ExpResult(
             tasks_num=len(episodes),
@@ -595,13 +590,11 @@ def _run_sequentially_impl(
             traj_id = _trajectory_id(episode)
             log_file = get_log_path(exp.output_dir, traj_id)
             # Heartbeat before each episode.run() so XRay can detect a dead driver.
-            exp_status.completed = len(results.trajectories)
-            exp_status.failed = len(results.failures)
-            exp_status.last_heartbeat_at = time.time()
-            try:
-                exp_status.write(exp_status_path)
-            except Exception:
-                pass
+            exp_status.heartbeat(
+                exp_status_path,
+                completed=len(results.trajectories),
+                failed=len(results.failures),
+            )
             with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
                 try:
                     trajectory = episode.run()
@@ -609,5 +602,13 @@ def _run_sequentially_impl(
                 except Exception as e:
                     logger.exception(f"Episode {traj_id} failed")
                     results.failures[traj_id] = str(e)
+        # Flush final counters before the lifecycle's terminal write — the
+        # in-loop heartbeat fires *before* each episode, so the last episode's
+        # outcome is otherwise missing from the on-disk record.
+        exp_status.heartbeat(
+            exp_status_path,
+            completed=len(results.trajectories),
+            failed=len(results.failures),
+        )
         exp.print_stats(results)
         return results

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -2,8 +2,10 @@
 
 import logging
 import os
+import socket
 import sys
 import time
+from pathlib import Path
 from uuid import uuid4
 
 import ray
@@ -13,6 +15,7 @@ from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage, Storage
 
@@ -23,6 +26,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_STEP_TIMEOUT_S: float = 9000.0
 DEFAULT_SETUP_TIMEOUT_S: float = 600.0
 DEFAULT_CANCEL_GRACE_S: float = 120.0
+
+# How often the driver updates experiment_status.json in Ray mode.
+_EXP_HEARTBEAT_INTERVAL_S: float = 30.0
 
 
 def _warn_if_ephemeral_venv() -> None:
@@ -109,10 +115,25 @@ def run_with_ray(
         model=model,
         agent_name=agent_name,
     )
-
+    now = time.time()
+    exp_status = ExperimentStatus(
+        status="RUNNING",
+        mode="ray",
+        pid=os.getpid(),
+        host=socket.gethostname(),
+        started_at=now,
+        last_heartbeat_at=now,
+        total_episodes=0,
+    )
+    exp_status_path = exp.output_dir / EXPERIMENT_STATUS_FILENAME
+    try:
+        exp_status.write(exp_status_path)
+    except Exception:
+        logger.warning("Failed to write initial experiment status", exc_info=True)
+    _completed = False
     try:
         with tracer.benchmark(exp.name):
-            return _run_with_retries(
+            result = _run_with_retries(
                 exp,
                 n_cpus=n_cpus,
                 ray_poll_timeout=ray_poll_timeout,
@@ -121,8 +142,19 @@ def run_with_ray(
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
                 max_retry_rounds=max_retry_rounds,
+                exp_status=exp_status,
+                exp_status_path=exp_status_path,
             )
+        _completed = True
+        return result
     finally:
+        exp_status.status = "COMPLETED" if _completed else "INTERRUPTED"
+        exp_status.ended_at = time.time()
+        exp_status.last_heartbeat_at = exp_status.ended_at
+        try:
+            exp_status.write(exp_status_path)
+        except Exception:
+            logger.warning("Failed to write terminal experiment status", exc_info=True)
         tracer.shutdown()
 
 
@@ -142,6 +174,8 @@ def _run_with_retries(
     cancel_grace_s: float,
     orphan_threshold_s: float,
     max_retry_rounds: int,
+    exp_status: ExperimentStatus,
+    exp_status_path: Path,
 ) -> ExpResult:
     """Run the experiment, then keep re-running retriable failures until none remain.
 
@@ -162,6 +196,8 @@ def _run_with_retries(
                 setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                exp_status=exp_status,
+                exp_status_path=exp_status_path,
             )
             aggregated.tasks_num = max(aggregated.tasks_num, round_result.tasks_num)
             aggregated.trajectories.update(round_result.trajectories)
@@ -196,6 +232,8 @@ def _run_with_ray_impl(
     setup_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
+    exp_status: ExperimentStatus,
+    exp_status_path: Path,
 ) -> ExpResult:
     """Run a single Ray round: pre-claim, submit, poll with step-timeout, sweep stale on shutdown."""
     process_start_s = time.time()
@@ -240,6 +278,12 @@ def _run_with_ray_impl(
             for episode in episodes:
                 ref = run_episode.remote(episode)
                 ref_to_traj_id[ref] = _trajectory_id(episode)
+            exp_status.total_episodes = len(storage.list_episode_configs())
+            exp_status.last_heartbeat_at = time.time()
+            try:
+                exp_status.write(exp_status_path)
+            except Exception:
+                pass
             logger.info(f"Start {len(episodes)} episodes in parallel using Ray with {n_cpus} workers")
             results = _poll_ray(
                 exp,
@@ -249,6 +293,8 @@ def _run_with_ray_impl(
                 step_timeout_s=step_timeout_s,
                 setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
+                exp_status=exp_status,
+                exp_status_path=exp_status_path,
             )
             exp.print_stats(results)
             return results
@@ -274,11 +320,14 @@ def _poll_ray(
     step_timeout_s: float,
     setup_timeout_s: float,
     cancel_grace_s: float,
+    exp_status: ExperimentStatus,
+    exp_status_path: Path,
 ) -> ExpResult:
     """Wait on Ray refs, collecting trajectories/failures and force-killing workers with stale heartbeats."""
     results = ExpResult(tasks_num=len(ref_to_traj_id), config=exp.config, exp_id=f"{exp.name}_{uuid4().hex}")
     completed = 0
     episodes_in_progress = list(ref_to_traj_id.keys())
+    last_exp_hb = time.time()
     while len(episodes_in_progress) > 0:
         done, episodes_in_progress = ray.wait(
             episodes_in_progress,
@@ -314,6 +363,19 @@ def _poll_ray(
             setup_timeout_s=setup_timeout_s,
             cancel_grace_s=cancel_grace_s,
         )
+
+        # Heartbeat experiment_status.json so XRay knows this driver is alive.
+        now = time.time()
+        if now - last_exp_hb >= _EXP_HEARTBEAT_INTERVAL_S:
+            exp_status.last_heartbeat_at = now
+            exp_status.completed = len(results.trajectories)
+            exp_status.failed = len(results.failures)
+            try:
+                exp_status.write(exp_status_path)
+            except Exception:
+                pass
+            last_exp_hb = now
+
     return results
 
 
@@ -395,18 +457,44 @@ def run_sequentially(
         model=model,
         agent_name=agent_name,
     )
-
+    now = time.time()
+    exp_status = ExperimentStatus(
+        status="RUNNING",
+        mode="sequential",
+        pid=os.getpid(),
+        host=socket.gethostname(),
+        started_at=now,
+        last_heartbeat_at=now,
+        total_episodes=0,
+    )
+    exp_status_path = exp.output_dir / EXPERIMENT_STATUS_FILENAME
+    try:
+        exp_status.write(exp_status_path)
+    except Exception:
+        logger.warning("Failed to write initial experiment status", exc_info=True)
+    _completed = False
     try:
         with tracer.benchmark(exp.name):
-            return _run_sequentially_with_retries(
+            result = _run_sequentially_with_retries(
                 exp,
                 debug_limit=debug_limit,
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
                 max_retry_rounds=max_retry_rounds,
+                exp_status=exp_status,
+                exp_status_path=exp_status_path,
             )
+        _completed = True
+        return result
     finally:
+        exp_status.status = "COMPLETED" if _completed else "INTERRUPTED"
+        exp_status.ended_at = time.time()
+        exp_status.last_heartbeat_at = exp_status.ended_at
+        try:
+            exp_status.write(exp_status_path)
+        except Exception:
+            logger.warning("Failed to write terminal experiment status", exc_info=True)
         tracer.shutdown()
 
 
@@ -418,6 +506,8 @@ def _run_sequentially_with_retries(
     cancel_grace_s: float,
     orphan_threshold_s: float,
     max_retry_rounds: int,
+    exp_status: ExperimentStatus,
+    exp_status_path: Path,
 ) -> ExpResult:
     """Run sequential rounds back-to-back until no retriable failures remain.
 
@@ -434,6 +524,8 @@ def _run_sequentially_with_retries(
                 step_timeout_s=step_timeout_s,
                 cancel_grace_s=cancel_grace_s,
                 orphan_threshold_s=orphan_threshold_s,
+                exp_status=exp_status,
+                exp_status_path=exp_status_path,
             )
             aggregated.tasks_num = max(aggregated.tasks_num, round_result.tasks_num)
             aggregated.trajectories.update(round_result.trajectories)
@@ -466,6 +558,8 @@ def _run_sequentially_impl(
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
+    exp_status: ExperimentStatus,
+    exp_status_path: Path,
 ) -> ExpResult:
     """Run a single sequential round in-process, returning trajectories and failures for this round."""
     process_start_s = time.time()
@@ -485,6 +579,13 @@ def _run_sequentially_impl(
         for episode in episodes:
             _pre_claim(storage, episode)
 
+        exp_status.total_episodes = len(storage.list_episode_configs())
+        exp_status.last_heartbeat_at = time.time()
+        try:
+            exp_status.write(exp_status_path)
+        except Exception:
+            pass
+
         results = ExpResult(
             tasks_num=len(episodes),
             config=exp.config,
@@ -493,6 +594,14 @@ def _run_sequentially_impl(
         for episode in episodes:
             traj_id = _trajectory_id(episode)
             log_file = get_log_path(exp.output_dir, traj_id)
+            # Heartbeat before each episode.run() so XRay can detect a dead driver.
+            exp_status.completed = len(results.trajectories)
+            exp_status.failed = len(results.failures)
+            exp_status.last_heartbeat_at = time.time()
+            try:
+                exp_status.write(exp_status_path)
+            except Exception:
+                pass
             with redirect_output_to_log(log_file, append=False, tee=True, log_format=LOG_FORMAT):
                 try:
                     trajectory = episode.run()

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -97,6 +97,7 @@ class Experiment(TypedBaseModel):
         step_timeout_s: float = 1800.0,
         cancel_grace_s: float = 120.0,
         orphan_threshold_s: float = 3600.0,
+        process_start_s: float | None = None,
     ) -> list[Episode]:
         """Return episodes to run based on `resume`.
 
@@ -130,6 +131,7 @@ class Experiment(TypedBaseModel):
             step_timeout_s=step_timeout_s,
             cancel_grace_s=cancel_grace_s,
             orphan_threshold_s=orphan_threshold_s,
+            process_start_s=process_start_s,
         )
 
         statuses = storage.list_episode_statuses()
@@ -291,10 +293,15 @@ def sweep_stale_statuses(
     step_timeout_s: float,
     cancel_grace_s: float,
     orphan_threshold_s: float,
+    process_start_s: float | None = None,
 ) -> list[str]:
     """Mark in-flight episodes whose worker is dead as `STALE`.
 
-    Two cases:
+    Three cases:
+    - `RUNNING` with `last_heartbeat_at` predating `process_start_s` (worker is from a
+      prior, now-dead process — force-sweep regardless of heartbeat age). Fixes the
+      kill-and-retry race where a freshly killed worker has a recent heartbeat that
+      would otherwise pass the age threshold.
     - `RUNNING` with `last_heartbeat_at` older than `step_timeout_s + cancel_grace_s`
       (worker died mid-episode without writing a terminal status).
     - `QUEUED` with `started_at` older than `orphan_threshold_s` (driver pre-claimed
@@ -308,7 +315,10 @@ def sweep_stale_statuses(
     for trajectory_id, status in storage.list_episode_statuses().items():
         is_stale = False
         if status.status == "RUNNING" and status.last_heartbeat_at is not None:
-            if now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s:
+            if process_start_s is not None and status.last_heartbeat_at < process_start_s:
+                # Heartbeat predates this process — worker is provably dead.
+                is_stale = True
+            elif now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s:
                 is_stale = True
         elif status.status == "QUEUED":
             if now - status.started_at > orphan_threshold_s:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -17,7 +17,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
 from cube_harness.episode import MAX_STEPS, Episode
 from cube_harness.episode_logs import trajectory_log_id
-from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus
+from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus, should_sweep_running_to_stale
 from cube_harness.eval_log import EvalLog, ExperimentRecord
 from cube_harness.storage import FileStorage
 
@@ -314,12 +314,14 @@ def sweep_stale_statuses(
     swept: list[str] = []
     for trajectory_id, status in storage.list_episode_statuses().items():
         is_stale = False
-        if status.status == "RUNNING" and status.last_heartbeat_at is not None:
-            if process_start_s is not None and status.last_heartbeat_at < process_start_s:
-                # Heartbeat predates this process — worker is provably dead.
-                is_stale = True
-            elif now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s:
-                is_stale = True
+        if status.status == "RUNNING":
+            is_stale = should_sweep_running_to_stale(
+                status,
+                now=now,
+                step_timeout_s=step_timeout_s,
+                cancel_grace_s=cancel_grace_s,
+                process_start_s=process_start_s,
+            )
         elif status.status == "QUEUED":
             if now - status.started_at > orphan_threshold_s:
                 is_stale = True

--- a/src/cube_harness/experiment_status.py
+++ b/src/cube_harness/experiment_status.py
@@ -18,6 +18,8 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Literal
 
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+
 logger = logging.getLogger(__name__)
 
 EXPERIMENT_STATUS_FILENAME = "experiment_status.json"
@@ -108,3 +110,49 @@ class ExperimentStatus:
             self.write(path)
         except Exception:
             logger.debug("Heartbeat write failed for %s", path, exc_info=True)
+
+
+def is_driver_alive(
+    exp_status: ExperimentStatus | None,
+    exp_dir: Path,
+    *,
+    timeout_s: float,
+) -> bool:
+    """Heuristic check: does the experiment driver appear to be alive?
+
+    Takes the already-read `ExperimentStatus` (None = file absent → assume alive,
+    covers pre-heartbeat experiments and the initial migration window). Mode-aware:
+
+    - "ray": trusts the experiment heartbeat alone (driver polls every ~30 s, so
+      a heartbeat older than `timeout_s` means the driver crashed).
+    - "sequential": falls back to per-episode heartbeats when the experiment
+      heartbeat is stale, because the driver heartbeats *between* episodes — a
+      long-running episode makes the experiment heartbeat look stale even though
+      the driver is alive inside `episode.run()`.
+
+    `timeout_s` is the staleness threshold for the heartbeat. Callers should pass
+    a value at least an order of magnitude larger than `_EXP_HEARTBEAT_INTERVAL_S`
+    in `exp_runner.py` to avoid false positives during short network/disk hiccups.
+    """
+    if exp_status is None:
+        return True  # no status file → assume alive (pre-heartbeat experiment)
+    if exp_status.status in ("COMPLETED", "INTERRUPTED"):
+        return False
+    now = time.time()
+    if now - exp_status.last_heartbeat_at <= timeout_s:
+        return True  # fresh experiment heartbeat
+    if exp_status.mode == "sequential":
+        # Stale experiment heartbeat in sequential mode: check per-episode heartbeats.
+        # A live RUNNING episode means the driver is mid-episode and alive.
+        episodes_dir = exp_dir / "episodes"
+        if episodes_dir.exists():
+            for ep_dir in episodes_dir.iterdir():
+                if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
+                    continue
+                ep_status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
+                if ep_status is None or ep_status.status != "RUNNING":
+                    continue
+                ep_hb = ep_status.last_heartbeat_at or ep_status.started_at
+                if now - ep_hb <= timeout_s:
+                    return True
+    return False

--- a/src/cube_harness/experiment_status.py
+++ b/src/cube_harness/experiment_status.py
@@ -1,0 +1,83 @@
+"""Experiment-level status file, heartbeated by the runner driver process.
+
+`experiment_status.json` sits at the root of `output_dir` alongside
+`experiment_config.json`. It is written by the runner (not by Ray workers)
+so the XRay viewer can determine whether the experiment driver is still alive
+— and, if it is not, promote orphaned QUEUED episodes to STALE.
+
+See also: `episode_status.py` for the per-episode equivalent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Literal
+
+EXPERIMENT_STATUS_FILENAME = "experiment_status.json"
+
+
+@dataclass
+class ExperimentStatus:
+    """Lifecycle snapshot of an entire experiment run, written by the driver.
+
+    Fields
+    ------
+    status
+        Terminal statuses are written once at shutdown; RUNNING is heartbeated.
+    mode
+        "ray"        — driver runs a Ray cluster; heartbeat comes from the
+                       poll loop in _poll_ray (every ~30 s).
+        "sequential" — driver IS the worker; heartbeat is updated before each
+                       episode.run() call, so it may lag by one episode's
+                       wall-clock time. XRay must fall back to episode-level
+                       heartbeats before declaring the driver dead.
+    pid / host
+        Used for informational display and to detect cross-machine restarts.
+    ray_dashboard_url
+        Populated in "ray" mode when the dashboard URL is available;
+        None otherwise.
+    completed / failed / stale
+        Running counters, updated alongside the heartbeat.
+    """
+
+    status: Literal["RUNNING", "COMPLETED", "INTERRUPTED"]
+    mode: Literal["ray", "sequential"]
+    pid: int
+    host: str
+    started_at: float
+    last_heartbeat_at: float
+    total_episodes: int
+    completed: int = 0
+    failed: int = 0
+    stale: int = 0
+    ray_dashboard_url: str | None = None
+    ended_at: float | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ExperimentStatus":
+        """Parse, dropping unknown keys for forward compatibility."""
+        data = json.loads(raw)
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    @classmethod
+    def read(cls, path: Path) -> "ExperimentStatus | None":
+        if not path.exists():
+            return None
+        try:
+            return cls.from_json(path.read_text())
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+
+    def write(self, path: Path) -> None:
+        """Atomic write: tmp sibling + os.replace() so partial files are never observed."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(self.to_json())
+        os.replace(tmp, path)

--- a/src/cube_harness/experiment_status.py
+++ b/src/cube_harness/experiment_status.py
@@ -11,10 +11,14 @@ See also: `episode_status.py` for the per-episode equivalent.
 from __future__ import annotations
 
 import json
+import logging
 import os
+import time
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Literal
+
+logger = logging.getLogger(__name__)
 
 EXPERIMENT_STATUS_FILENAME = "experiment_status.json"
 
@@ -81,3 +85,26 @@ class ExperimentStatus:
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(self.to_json())
         os.replace(tmp, path)
+
+    def heartbeat(
+        self,
+        path: Path,
+        *,
+        completed: int | None = None,
+        failed: int | None = None,
+    ) -> None:
+        """Update `last_heartbeat_at` (and optionally counters) and write best-effort.
+
+        Heartbeat writes are best-effort — a transient I/O error must not abort the
+        run. XRay tolerates a missed write because it reads the file on demand and
+        the next heartbeat will overwrite atomically.
+        """
+        self.last_heartbeat_at = time.time()
+        if completed is not None:
+            self.completed = completed
+        if failed is not None:
+            self.failed = failed
+        try:
+            self.write(path)
+        except Exception:
+            logger.debug("Heartbeat write failed for %s", path, exc_info=True)

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -171,7 +171,16 @@ class FileStorage:
 
     def _archive_episode(self, ep_dir: Path) -> None:
         archived = ep_dir.parent / f"{ep_dir.name}{ARCHIVED_MARKER}{time.time()}"
+        # Preserve episode_config.json so the retry pipeline still discovers this
+        # episode via _episode_config_dirs(). The config is written once at
+        # experiment prep time (Experiment.prepare_episodes) and is not re-saved
+        # on retry, so the archive must not destroy it.
+        config_src = ep_dir / "episode_config.json"
+        config_bytes = config_src.read_bytes() if config_src.exists() else None
         ep_dir.rename(archived)
+        if config_bytes is not None:
+            ep_dir.mkdir()
+            (ep_dir / "episode_config.json").write_bytes(config_bytes)
         logger.info(f"Archived {ep_dir.name} -> {archived.name}")
 
     def archive_episode(self, trajectory_id: str) -> None:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -917,6 +917,7 @@ class TestKillStaleWorkersRaceGuard:
                 storage,
                 results,
                 step_timeout_s=1.0,
+                setup_timeout_s=1.0,
                 cancel_grace_s=1.0,
             )
 
@@ -954,6 +955,7 @@ class TestKillStaleWorkersRaceGuard:
                 storage,
                 results,
                 step_timeout_s=1.0,
+                setup_timeout_s=1.0,
                 cancel_grace_s=1.0,
             )
 
@@ -962,7 +964,7 @@ class TestKillStaleWorkersRaceGuard:
         written: EpisodeStatus = mock_write.call_args[0][1]
         assert written.status == "CANCELLED"
         assert written.error_type == "StepTimeout"
-        assert "Step 5 exceeded" in written.error_message
+        assert "step 5 exceeded" in written.error_message
         # Recorded as a failure.
         assert traj_id in results.failures
         assert fake_ref not in episodes_in_progress

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -522,8 +522,8 @@ def _read_all_archived_statuses(output_dir: Path, traj_id: str) -> list[dict]:
 # experiment_status.json lifecycle — end-to-end
 # ---------------------------------------------------------------------------
 
-from cube_harness.analyze.xray_utils import _driver_alive, _promote_ghost_episodes  # noqa: E402
-from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus  # noqa: E402
+from cube_harness.analyze.xray_utils import GHOST_TIMEOUT, _promote_ghost_episodes  # noqa: E402
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus, is_driver_alive  # noqa: E402
 
 
 def _make_simple_exp(tmp_dir: Path, scenarios: dict[str, list[str]], name: str = "exp_status") -> Experiment:
@@ -557,7 +557,7 @@ def test_experiment_status_sequential_happy_path(tmp_dir: Path) -> None:
     assert es.ended_at is not None
     assert es.ended_at >= es.started_at
     # Driver is done — XRay must see it as not alive.
-    assert _driver_alive(es, tmp_dir) is False
+    assert is_driver_alive(es, tmp_dir, timeout_s=GHOST_TIMEOUT) is False
 
 
 def test_experiment_status_sequential_interrupted(tmp_dir: Path, monkeypatch) -> None:
@@ -580,7 +580,7 @@ def test_experiment_status_sequential_interrupted(tmp_dir: Path, monkeypatch) ->
     assert es is not None
     assert es.status == "INTERRUPTED"
     assert es.ended_at is not None
-    assert _driver_alive(es, tmp_dir) is False
+    assert is_driver_alive(es, tmp_dir, timeout_s=GHOST_TIMEOUT) is False
 
 
 @pytest.mark.slow
@@ -601,7 +601,7 @@ def test_experiment_status_ray_happy_path(tmp_dir: Path) -> None:
     assert es.started_at >= started_before
     assert es.ended_at is not None and es.ended_at >= es.started_at
     # Driver finished — not alive.
-    assert _driver_alive(es, tmp_dir) is False
+    assert is_driver_alive(es, tmp_dir, timeout_s=GHOST_TIMEOUT) is False
 
 
 def test_experiment_status_interrupted_promotes_queued(tmp_dir: Path, monkeypatch) -> None:

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -516,3 +516,136 @@ def _read_all_archived_statuses(output_dir: Path, traj_id: str) -> list[dict]:
             if status_path.exists():
                 archived.append(json.loads(status_path.read_text()))
     return archived
+
+
+# ---------------------------------------------------------------------------
+# experiment_status.json lifecycle — end-to-end
+# ---------------------------------------------------------------------------
+
+from cube_harness.analyze.xray_utils import _driver_alive, _promote_ghost_episodes  # noqa: E402
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus  # noqa: E402
+
+
+def _make_simple_exp(tmp_dir: Path, scenarios: dict[str, list[str]], name: str = "exp_status") -> Experiment:
+    """Build an Experiment with the debug benchmark for a given scenario dict."""
+    return Experiment(
+        name=name,
+        output_dir=tmp_dir,
+        agent_config=DebugAgentConfig(
+            counter_dir=str(tmp_dir / "_counters"),
+            scenarios=scenarios,
+            hang_seconds=0.0,
+        ),
+        benchmark_config=make_debug_benchmark(scenarios),
+        max_retries=0,
+    )
+
+
+def test_experiment_status_sequential_happy_path(tmp_dir: Path) -> None:
+    """After a successful sequential run, experiment_status.json is COMPLETED with correct counters."""
+    exp = _make_simple_exp(tmp_dir, {"task_a": ["succeed"], "task_b": ["succeed"]})
+
+    run_sequentially(exp)
+
+    es = ExperimentStatus.read(tmp_dir / EXPERIMENT_STATUS_FILENAME)
+    assert es is not None, "experiment_status.json should exist after run"
+    assert es.status == "COMPLETED"
+    assert es.mode == "sequential"
+    assert es.total_episodes == 2
+    assert es.completed == 2
+    assert es.failed == 0
+    assert es.ended_at is not None
+    assert es.ended_at >= es.started_at
+    # Driver is done — XRay must see it as not alive.
+    assert _driver_alive(es, tmp_dir) is False
+
+
+def test_experiment_status_sequential_interrupted(tmp_dir: Path, monkeypatch) -> None:
+    """A driver-level exception leaves experiment_status.json marked INTERRUPTED."""
+    exp = _make_simple_exp(tmp_dir, {"task_a": ["succeed"]})
+
+    # Inject a failure in the retry loop so the lifecycle context manager
+    # exits via exception, exercising the INTERRUPTED branch.
+    from cube_harness import exp_runner
+
+    def _boom(*_args, **_kwargs) -> None:
+        raise RuntimeError("simulated driver crash")
+
+    monkeypatch.setattr(exp_runner, "_run_sequentially_with_retries", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated driver crash"):
+        run_sequentially(exp)
+
+    es = ExperimentStatus.read(tmp_dir / EXPERIMENT_STATUS_FILENAME)
+    assert es is not None
+    assert es.status == "INTERRUPTED"
+    assert es.ended_at is not None
+    assert _driver_alive(es, tmp_dir) is False
+
+
+@pytest.mark.slow
+def test_experiment_status_ray_happy_path(tmp_dir: Path) -> None:
+    """Ray run heartbeats experiment_status.json, ends COMPLETED with counters set."""
+    exp = _make_simple_exp(tmp_dir, {"task_a": ["succeed"], "task_b": ["succeed"]})
+    started_before = time.time()
+
+    run_with_ray(exp, n_cpus=2, ray_poll_timeout=0.2, step_timeout_s=10.0, cancel_grace_s=0.5)
+
+    es = ExperimentStatus.read(tmp_dir / EXPERIMENT_STATUS_FILENAME)
+    assert es is not None
+    assert es.status == "COMPLETED"
+    assert es.mode == "ray"
+    assert es.total_episodes == 2
+    assert es.completed == 2
+    assert es.failed == 0
+    assert es.started_at >= started_before
+    assert es.ended_at is not None and es.ended_at >= es.started_at
+    # Driver finished — not alive.
+    assert _driver_alive(es, tmp_dir) is False
+
+
+def test_experiment_status_interrupted_promotes_queued(tmp_dir: Path, monkeypatch) -> None:
+    """When the driver dies mid-run, leftover QUEUED episodes are swept to STALE by XRay.
+
+    This is the contract XRay relies on: a missing terminal status (or an
+    INTERRUPTED one) plus a stale heartbeat is the signal to clean up orphans.
+    """
+    from cube_harness import exp_runner
+
+    # Set up an experiment whose pre-claim runs but never reaches episode.run().
+    exp = _make_simple_exp(tmp_dir, {"task_a": ["succeed"]})
+
+    # Allow pre-claim to write QUEUED, then crash before any episode runs.
+    real_impl = exp_runner._run_sequentially_impl
+
+    def _crash_after_preclaim(exp_arg, **kw):
+        # Borrow the pre-claim path: get_episodes_to_run + _pre_claim + then bail.
+        storage = FileStorage(exp_arg.output_dir)
+        with exp_arg.benchmark_config.make(exp_arg.infra) as benchmark:
+            episodes = exp_arg.get_episodes_to_run(benchmark, step_timeout_s=10.0, cancel_grace_s=0.5)
+            for ep in episodes:
+                exp_runner._pre_claim(storage, ep)
+        raise RuntimeError("crash after pre-claim")
+
+    monkeypatch.setattr(exp_runner, "_run_sequentially_impl", _crash_after_preclaim)
+
+    with pytest.raises(RuntimeError):
+        run_sequentially(exp)
+
+    # Reset patch so we can use the runner internals freely.
+    monkeypatch.setattr(exp_runner, "_run_sequentially_impl", real_impl)
+
+    # The episode is QUEUED on disk, experiment is INTERRUPTED.
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    assert len(statuses) == 1
+    traj_id, ep_status = next(iter(statuses.items()))
+    assert ep_status.status == "QUEUED"
+
+    es = ExperimentStatus.read(tmp_dir / EXPERIMENT_STATUS_FILENAME)
+    assert es is not None and es.status == "INTERRUPTED"
+
+    # XRay refresh should now promote the orphan QUEUED → STALE.
+    _promote_ghost_episodes(tmp_dir)
+    promoted = storage.list_episode_statuses()[traj_id]
+    assert promoted.status == "STALE"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -549,6 +549,57 @@ class TestFileStorageOverwrite:
         with pytest.raises(FileExistsError):
             storage2.save_trajectory(traj)
 
+    def test_archive_preserves_episode_config_for_retry(
+        self, tmp_dir, mock_agent_config, mock_cube_task_config
+    ) -> None:
+        """Archiving an episode dir must leave episode_config.json behind so the
+        retry pipeline (list_episode_configs / _episode_config_dirs) still finds
+        the task. The config is written once at experiment prep and is not
+        re-saved on retry.
+        """
+        from cube_harness.episode import EpisodeConfig
+
+        storage = FileStorage(tmp_dir)
+        episode_config = EpisodeConfig(
+            id=0,
+            agent_config=mock_agent_config,
+            task_config=mock_cube_task_config,
+            exp_name="test_exp",
+            output_dir=tmp_dir,
+            max_steps=100,
+        )
+        storage.save_episode_config(episode_config)
+        traj_id = f"{mock_cube_task_config.task_id}_ep0"
+        traj = Trajectory(id=traj_id, metadata={"task_id": mock_cube_task_config.task_id, "agent_name": "A"})
+        storage.save_trajectory(traj)
+
+        ep_dir = storage._episode_dir(traj_id)
+        storage._archive_episode(ep_dir)
+
+        episodes_dir = Path(tmp_dir) / "episodes"
+        archived = [d for d in episodes_dir.iterdir() if ".archived_" in d.name]
+        assert len(archived) == 1
+        assert (archived[0] / "episode_config.json").exists()
+        assert ep_dir.exists()
+        assert (ep_dir / "episode_config.json").exists()
+        assert ep_dir in list(storage._episode_config_dirs())
+
+    def test_archive_no_config_leaves_no_dir(self, tmp_dir) -> None:
+        """If the episode dir has no episode_config.json (e.g. legacy run), archive
+        should still rename the dir without creating an empty replacement.
+        """
+        storage = FileStorage(tmp_dir)
+        traj = Trajectory(id="task_1_ep0", metadata={"task_id": "task_1", "agent_name": "A"})
+        storage.save_trajectory(traj)
+
+        ep_dir = storage._episode_dir("task_1_ep0")
+        storage._archive_episode(ep_dir)
+
+        assert not ep_dir.exists()
+        episodes_dir = Path(tmp_dir) / "episodes"
+        archived = [d for d in episodes_dir.iterdir() if ".archived_" in d.name]
+        assert len(archived) == 1
+
 
 class TestLoadTrajectoryMetadata:
     def test_load_metadata_returns_trajectory_with_no_steps(self, tmp_dir: Path) -> None:

--- a/tests/test_xray_promote_ghost.py
+++ b/tests/test_xray_promote_ghost.py
@@ -1,8 +1,9 @@
 """Unit tests for _promote_ghost_episodes (xray_utils).
 
-Covers the fix in PR #372: QUEUED episodes must never be promoted to STALE
-by the viewer's refresh path — only sweep_stale_statuses() (runner-owned)
-may touch them.
+Covers:
+- PR #372: QUEUED episodes must not be promoted without a dead-driver signal.
+- PR #365: QUEUED promoted when driver is confirmed dead via experiment_status.json;
+           RUNNING promoted immediately in sequential mode when driver is dead.
 """
 
 from __future__ import annotations
@@ -14,64 +15,166 @@ import pytest
 
 from cube_harness.analyze.xray_utils import _promote_ghost_episodes
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 
 
-def _write_status(ep_dir: Path, status: str, age_seconds: float) -> None:
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_ep_status(ep_dir: Path, status: str, age_seconds: float) -> None:
     ep_dir.mkdir(parents=True, exist_ok=True)
+    now = time.time()
     s = EpisodeStatus(
         status=status,
         task_id="test-task",
         episode_id=0,
-        started_at=time.time() - age_seconds,
-        last_heartbeat_at=time.time() - age_seconds,
+        started_at=now - age_seconds,
+        last_heartbeat_at=now - age_seconds,
     )
     s.write(ep_dir / STATUS_FILENAME)
 
 
-def test_queued_episode_never_promoted(tmp_path: Path) -> None:
-    """QUEUED episodes are not touched regardless of age."""
+def _write_exp_status(exp_dir: Path, status: str, mode: str, hb_age_seconds: float = 0) -> None:
+    now = time.time()
+    es = ExperimentStatus(
+        status=status,
+        mode=mode,
+        pid=12345,
+        host="test-host",
+        started_at=now - hb_age_seconds - 1,
+        last_heartbeat_at=now - hb_age_seconds,
+        total_episodes=1,
+    )
+    es.write(exp_dir / EXPERIMENT_STATUS_FILENAME)
+
+
+# ---------------------------------------------------------------------------
+# QUEUED promotion
+# ---------------------------------------------------------------------------
+
+
+def test_queued_not_promoted_without_experiment_status(tmp_path: Path) -> None:
+    """No experiment_status.json → driver assumed alive → QUEUED never promoted.
+
+    Backward-compat: old experiments without a status file must not have their
+    QUEUED episodes swept to STALE by the viewer.
+    """
     ep = tmp_path / "episodes" / "ep_000"
-    _write_status(ep, "QUEUED", age_seconds=99_999)
+    _write_ep_status(ep, "QUEUED", age_seconds=99_999)
 
     _promote_ghost_episodes(tmp_path)
 
-    after = EpisodeStatus.read(ep / STATUS_FILENAME)
-    assert after is not None
-    assert after.status == "QUEUED"
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "QUEUED"
+
+
+@pytest.mark.parametrize("mode", ["ray", "sequential"])
+def test_queued_promoted_when_driver_dead(tmp_path: Path, mode: str) -> None:
+    """QUEUED → STALE when experiment_status.json reports a dead driver."""
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_ep_status(ep, "QUEUED", age_seconds=99_999)
+    _write_exp_status(tmp_path, status="INTERRUPTED", mode=mode)
+
+    _promote_ghost_episodes(tmp_path)
+
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "STALE"
+
+
+def test_queued_not_promoted_when_driver_alive(tmp_path: Path) -> None:
+    """QUEUED preserved when the driver heartbeat is fresh."""
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_ep_status(ep, "QUEUED", age_seconds=99_999)
+    _write_exp_status(tmp_path, status="RUNNING", mode="ray", hb_age_seconds=10)
+
+    _promote_ghost_episodes(tmp_path)
+
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "QUEUED"
+
+
+# ---------------------------------------------------------------------------
+# RUNNING promotion — ray mode
+# ---------------------------------------------------------------------------
 
 
 def test_old_running_episode_promoted_to_stale(tmp_path: Path) -> None:
     """RUNNING episode whose heartbeat is beyond GHOST_TIMEOUT becomes STALE."""
     ep = tmp_path / "episodes" / "ep_001"
-    _write_status(ep, "RUNNING", age_seconds=99_999)
+    _write_ep_status(ep, "RUNNING", age_seconds=99_999)
 
     _promote_ghost_episodes(tmp_path)
 
-    after = EpisodeStatus.read(ep / STATUS_FILENAME)
-    assert after is not None
-    assert after.status == "STALE"
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "STALE"
 
 
 def test_fresh_running_episode_not_promoted(tmp_path: Path) -> None:
     """RUNNING episode with a recent heartbeat is left alone."""
     ep = tmp_path / "episodes" / "ep_002"
-    _write_status(ep, "RUNNING", age_seconds=30)
+    _write_ep_status(ep, "RUNNING", age_seconds=30)
 
     _promote_ghost_episodes(tmp_path)
 
-    after = EpisodeStatus.read(ep / STATUS_FILENAME)
-    assert after is not None
-    assert after.status == "RUNNING"
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "RUNNING"
+
+
+def test_running_ray_dead_driver_still_waits_ghost_timeout(tmp_path: Path) -> None:
+    """Ray workers run independently of the driver.
+
+    A dead driver must NOT immediately promote a fresh RUNNING episode — the
+    worker may still be alive and will write its own terminal status.
+    """
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_ep_status(ep, "RUNNING", age_seconds=30)
+    _write_exp_status(tmp_path, status="INTERRUPTED", mode="ray")
+
+    _promote_ghost_episodes(tmp_path)
+
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "RUNNING"
+
+
+# ---------------------------------------------------------------------------
+# RUNNING promotion — sequential mode (driver == worker)
+# ---------------------------------------------------------------------------
+
+
+def test_running_sequential_promoted_immediately_when_driver_dead(tmp_path: Path) -> None:
+    """In sequential mode the driver IS the worker.
+
+    A dead driver means the episode process also died, so we promote RUNNING →
+    STALE immediately without waiting for GHOST_TIMEOUT.
+    """
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_ep_status(ep, "RUNNING", age_seconds=30)  # fresh heartbeat
+    _write_exp_status(tmp_path, status="INTERRUPTED", mode="sequential")
+
+    _promote_ghost_episodes(tmp_path)
+
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "STALE"
+
+
+def test_running_sequential_not_promoted_when_driver_alive(tmp_path: Path) -> None:
+    """Sequential RUNNING with a live driver and fresh heartbeat is left alone."""
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_ep_status(ep, "RUNNING", age_seconds=30)
+    _write_exp_status(tmp_path, status="RUNNING", mode="sequential", hb_age_seconds=10)
+
+    _promote_ghost_episodes(tmp_path)
+
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == "RUNNING"
+
+
+# ---------------------------------------------------------------------------
+# Terminal episodes — never re-promoted
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("terminal_status", ["COMPLETED", "FAILED", "CANCELLED", "STALE"])
 def test_terminal_episodes_not_touched(tmp_path: Path, terminal_status: str) -> None:
-    """Already-terminal episodes are never re-promoted."""
+    """Already-terminal episodes are never re-promoted, even with a dead driver."""
     ep = tmp_path / "episodes" / "ep_003"
-    _write_status(ep, terminal_status, age_seconds=99_999)
+    _write_ep_status(ep, terminal_status, age_seconds=99_999)
+    _write_exp_status(tmp_path, status="INTERRUPTED", mode="ray")
 
     _promote_ghost_episodes(tmp_path)
 
-    after = EpisodeStatus.read(ep / STATUS_FILENAME)
-    assert after is not None
-    assert after.status == terminal_status
+    assert EpisodeStatus.read(ep / STATUS_FILENAME).status == terminal_status

--- a/tests/test_xray_promote_ghost.py
+++ b/tests/test_xray_promote_ghost.py
@@ -17,7 +17,6 @@ from cube_harness.analyze.xray_utils import _promote_ghost_episodes
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
 from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_xray_promote_ghost.py
+++ b/tests/test_xray_promote_ghost.py
@@ -1,0 +1,77 @@
+"""Unit tests for _promote_ghost_episodes (xray_utils).
+
+Covers the fix in PR #372: QUEUED episodes must never be promoted to STALE
+by the viewer's refresh path — only sweep_stale_statuses() (runner-owned)
+may touch them.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from cube_harness.analyze.xray_utils import _promote_ghost_episodes
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+
+
+def _write_status(ep_dir: Path, status: str, age_seconds: float) -> None:
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    s = EpisodeStatus(
+        status=status,
+        task_id="test-task",
+        episode_id=0,
+        started_at=time.time() - age_seconds,
+        last_heartbeat_at=time.time() - age_seconds,
+    )
+    s.write(ep_dir / STATUS_FILENAME)
+
+
+def test_queued_episode_never_promoted(tmp_path: Path) -> None:
+    """QUEUED episodes are not touched regardless of age."""
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_status(ep, "QUEUED", age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "QUEUED"
+
+
+def test_old_running_episode_promoted_to_stale(tmp_path: Path) -> None:
+    """RUNNING episode whose heartbeat is beyond GHOST_TIMEOUT becomes STALE."""
+    ep = tmp_path / "episodes" / "ep_001"
+    _write_status(ep, "RUNNING", age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "STALE"
+
+
+def test_fresh_running_episode_not_promoted(tmp_path: Path) -> None:
+    """RUNNING episode with a recent heartbeat is left alone."""
+    ep = tmp_path / "episodes" / "ep_002"
+    _write_status(ep, "RUNNING", age_seconds=30)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "RUNNING"
+
+
+@pytest.mark.parametrize("terminal_status", ["COMPLETED", "FAILED", "CANCELLED", "STALE"])
+def test_terminal_episodes_not_touched(tmp_path: Path, terminal_status: str) -> None:
+    """Already-terminal episodes are never re-promoted."""
+    ep = tmp_path / "episodes" / "ep_003"
+    _write_status(ep, terminal_status, age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == terminal_status


### PR DESCRIPTION
## Summary

Comprehensive robustness pass on the harness retry / queue / status machinery, surfaced by overnight SWE-bench Verified and TerminalBench runs. Each fix below was independently rediscovered across feature branches; this PR consolidates them onto `main` so other threads can drop their local copies.

## Changes

### 1. `_archive_episode` was destroying the planning record

`Experiment.prepare_episodes` writes `episode_config.json` exactly once and the retry pipeline relies on it to discover retriable work. The old `_archive_episode` renamed the whole directory, hiding the config inside `.archived_<ts>/` so subsequent retries silently dropped the task.

**Fix:** read `episode_config.json` before rename and rewrite into the fresh `ep_dir`. Trajectory data, status, logs all stay archived; only the planning record is preserved.

### 2. XRay viewer was killing in-flight tasks; `ray.get` could hang forever

- `_promote_ghost_episodes` was promoting `QUEUED` episodes to STALE on every UI refresh. In a 89-task TerminalBench batch (`--n-parallel 10`) the last tasks legitimately sit QUEUED for hours — opening the viewer mid-run silently killed 3 unstarted tasks.
- `ray.get(task_ref)` had no timeout, so a worker hanging during teardown froze the entire `_poll_ray` loop.

**Fix:** XRay only promotes `RUNNING` episodes (later refined — see #4); `ray.get` now takes `timeout=step_timeout_s + cancel_grace_s`.

### 3. Phase-aware setup timeout + kill-and-retry RUNNING sweep (#332)

Setup hangs (container boot, env reset) had to wait the full `step_timeout_s` (30 min default) before being killed. And a re-launched run could not sweep RUNNING episodes whose heartbeat predated the new process start, even though those workers were provably dead.

**Fix:**
- New `setup_timeout_s` (default `4 × step_timeout_s = 7200s`; container scheduling can queue) applied when `current_step == 0` in `_kill_stale_workers`. Setup hangs detected on their own budget without shortening agent-step budget.
- `sweep_stale_statuses` accepts `process_start_s` and force-sweeps RUNNING episodes whose heartbeat predates it — fixes the kill-and-retry race where a freshly killed worker has a recent heartbeat.
- Episode heartbeat writes are now fail-open (don't abort the run on transient I/O errors).

### 4. Experiment-level heartbeat + XRay dead-driver detection

`experiment_status.json` (new file at `output_dir/` root) is written by the runner driver, not by Ray workers. XRay reads it to decide whether the driver is alive, and only then sweeps orphan QUEUED → STALE.

- `run_with_ray`: heartbeats every 30 s from `_poll_ray`.
- `run_sequentially`: heartbeats before each `episode.run()` call (driver is the worker, so heartbeat may lag by one episode wall-clock).
- `_driver_alive` is mode-aware: ray trusts the experiment heartbeat; sequential falls back to per-episode heartbeats to avoid false positives during long episodes.
- `_promote_ghost_episodes` now also promotes QUEUED → STALE when the driver is confirmed dead, and **immediately** promotes RUNNING → STALE in sequential mode (driver == worker; process death kills both).
- Old experiments without `experiment_status.json` keep their prior behaviour (QUEUED preserved).

### 5. Centralised the RUNNING → STALE predicate

`should_sweep_running_to_stale` in `episode_status.py` is now the single source of truth for *is this RUNNING worker dead?* — used by both `sweep_stale_statuses` (runner-side) and `_promote_ghost_episodes` (viewer-side). Removes the silent duplication that would have rotted.

### 6. Cleanup pass on the new experiment-status code

- New `_experiment_lifecycle()` context manager wraps init + COMPLETED/INTERRUPTED terminal write. Shed ~25 lines of duplicated lifecycle code from each runner.
- New `ExperimentStatus.heartbeat()` method collapses the *set fields, try-write, swallow* pattern into one call at every heartbeat site.
- Added a final-counter flush at the end of `_poll_ray` and the sequential loop — without it, the last batch of completions (or any work shorter than `_EXP_HEARTBEAT_INTERVAL_S`) was lost from the on-disk record.

## Test plan

- [x] **Unit tests** — 13 cases in `tests/test_xray_promote_ghost.py` covering QUEUED-promotion gated by driver liveness (both modes), sequential fast-sweep on driver death, ray waiting for `GHOST_TIMEOUT` even when driver is dead, terminal episodes never re-promoted, backward compat for old experiments without `experiment_status.json`.
- [x] **Integration tests** — 4 new cases in `tests/test_retry_integration.py`:
  - `test_experiment_status_sequential_happy_path` — COMPLETED + correct counters
  - `test_experiment_status_sequential_interrupted` — INTERRUPTED on driver crash
  - `test_experiment_status_ray_happy_path` — Ray heartbeat lifecycle (slow, real Ray cluster)
  - `test_experiment_status_interrupted_promotes_queued` — full handoff: runner crashes mid-run → XRay's `_promote_ghost_episodes` sweeps orphan QUEUED → STALE.
- [x] Full local suite: 627 passing (pandas-dependent xray UI tests excluded as on main).
- [x] `make lint-check` clean.
- [x] Slow Ray integration tests pass locally (~45 s).

## Notes

- The original two-fix scope grew to a six-fix scope after Alex's review pass — the bugs were tightly entangled (config preservation, XRay sweeps, heartbeats, dead-driver detection all touch the same control plane). Reviewer mental model is the same: trust this PR is the canonical retry/queue cleanup.
- `ContainerBackend` shows up as a CI ruff failure on a file we don't touch (`cubes/swebench-verified-cube/src/swebench_verified_cube/task.py`). Minimal `# noqa: F401` patch included to unblock CI; full removal of `container_backend` across all cubes is tracked as a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)