### PR TITLE
swebench-verified: fix _normalize_django_directive double-append

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -241,6 +241,11 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata]):
         m = re.match(r"^(\w+)\s+\(([^)]+)\)$", directive.strip())
         if m:
             method, class_path = m.group(1), m.group(2)
+            # Some SWE-bench entries already include the method name as the last
+            # segment of class_path (e.g. "test_foo (module.Class.test_foo)").
+            # Avoid duplicating it into "module.Class.test_foo.test_foo".
+            if class_path.endswith(f".{method}"):
+                return class_path
             return f"{class_path}.{method}"
         return directive  # already in the right format or unrecognised — pass through
 

--- a/cubes/swebench-verified-cube/tests/test_django_normalize.py
+++ b/cubes/swebench-verified-cube/tests/test_django_normalize.py
@@ -1,0 +1,53 @@
+"""Unit tests for SWEBenchVerifiedTask._normalize_django_directive.
+
+The function converts SWE-bench's unittest verbose format
+("test_method (module.ClassName)") to Django runtests.py format
+("module.ClassName.test_method").
+
+The bug fixed here: when class_path already ends with ".method_name"
+(i.e. the entry was stored as "test_foo (module.Class.test_foo)"),
+the old code produced "module.Class.test_foo.test_foo" — a double-appended
+method name that Django rejects, causing reward=0 for otherwise-correct patches.
+"""
+
+from __future__ import annotations
+
+
+from swebench_verified_cube.task import SWEBenchVerifiedTask
+
+_normalize = SWEBenchVerifiedTask._normalize_django_directive
+
+
+class TestNormalizeDjangoDirective:
+    def test_standard_format(self) -> None:
+        """Normal case: method_name (module.ClassName) → module.ClassName.method_name."""
+        assert _normalize("test_foo (myapp.tests.MyTest)") == "myapp.tests.MyTest.test_foo"
+
+    def test_already_normalized(self) -> None:
+        """If class_path already ends with the method name, don't duplicate it."""
+        assert _normalize("test_foo (myapp.tests.MyTest.test_foo)") == "myapp.tests.MyTest.test_foo"
+
+    def test_already_normalized_nested(self) -> None:
+        """Deeper nesting: method appears both in path and as final segment."""
+        assert _normalize("test_bar (a.b.c.MyClass.test_bar)") == "a.b.c.MyClass.test_bar"
+
+    def test_different_suffix_not_stripped(self) -> None:
+        """class_path ends with a different method — should still append."""
+        assert _normalize("test_foo (myapp.tests.MyTest.test_bar)") == "myapp.tests.MyTest.test_bar.test_foo"
+
+    def test_passthrough_when_no_parens(self) -> None:
+        """Dotted path with no parens is passed through unchanged."""
+        assert _normalize("myapp.tests.MyTest.test_foo") == "myapp.tests.MyTest.test_foo"
+
+    def test_passthrough_unrecognized(self) -> None:
+        """Unrecognized format is passed through unchanged."""
+        weird = "some weird string"
+        assert _normalize(weird) == weird
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        """Leading/trailing whitespace in directive is stripped before matching."""
+        assert _normalize("  test_foo (myapp.tests.MyTest)  ") == "myapp.tests.MyTest.test_foo"
+
+    def test_single_class_no_module(self) -> None:
+        """Simple class with no module prefix."""
+        assert _normalize("test_foo (MyTest)") == "MyTest.test_foo"


### PR DESCRIPTION
## Bug

`_normalize_django_directive` could produce a double-appended method name for entries where the method is already embedded in class_path.

**Bug:** When a SWE-bench entry stores a directive as `test_foo (module.Class.test_foo)` — where the method name is already the last segment of class_path — the old code produced `module.Class.test_foo.test_foo`. Django's `runtests.py` rejects that path, returning a non-zero exit code even when the agent's patch was correct.

**Symptoms:** Judge analysis flagged ~5 episodes as `eval_brittle` with `primary_blame=eval_brittle` and `intervention=eval_fix`. All were Django repo tasks where the agent's patch was mechanically correct (gold-patch baseline reproduced the issue). The verifier returned reward=0 due to the double-appended test path.

**Fix:** Guard: if `class_path.endswith(f".{method}")`, return `class_path` directly without appending again.

**Verification:** 8 unit tests in `tests/test_django_normalize.py` cover the standard case, the already-normalized case, nested paths, and pass-through for unrecognized formats. Not independently verified via a controlled re-run of the flagged episodes; fix is by logic inspection.

> **Note:** This fix also exists on `feat/llm-cache-control` (PR #353) which touched `task.py`. This PR targets `main` directly; if #353 lands first, this can be closed (no conflict — different lines) or cherry-picked onto #353's base.