### PR TITLE
llm: replace completion_with_retries with tenacity 120s-ceiling backoff

### DIFF
--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -3,11 +3,20 @@
 import pprint
 from datetime import datetime
 from functools import partial
-from typing import Callable, List, Literal
+from typing import Any, Callable, List, Literal
 from uuid import uuid4
 
+import litellm
+import tenacity
 from cube.core import TypedBaseModel
-from litellm import Message, completion_with_retries
+from litellm import Message
+from litellm.exceptions import (
+    APIConnectionError,
+    InternalServerError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+)
 from litellm.utils import token_counter
 from pydantic import Field
 
@@ -80,8 +89,6 @@ class LLM:
             "model": self.config.model_name,
             "temperature": self.config.temperature,
             "max_completion_tokens": self.config.max_completion_tokens,
-            "num_retries": self.config.num_retries,
-            "retry_strategy": self.config.retry_strategy,
             "tool_choice": self.config.tool_choice,
             "parallel_tool_calls": self.config.parallel_tool_calls,
             "tools": prompt.tools,
@@ -90,9 +97,31 @@ class LLM:
         }
         if self.config.reasoning_effort is not None:
             kwargs["reasoning_effort"] = self.config.reasoning_effort
-        response = completion_with_retries(**kwargs)
+        response = self._completion_with_retry(**kwargs)
         usage = self._extract_usage(response)
         return LLMResponse(message=response.choices[0].message, usage=usage)
+
+    def _completion_with_retry(self, **kwargs: Any) -> Any:
+        """Call litellm.completion with exponential backoff on transient errors.
+
+        litellm's completion_with_retries caps its backoff at 10 s, which is too
+        short for Anthropic overloaded_error responses under heavy load. We own the
+        retry loop here to get a proper 120 s ceiling.
+        """
+        _RETRIABLE = (
+            InternalServerError,
+            ServiceUnavailableError,
+            RateLimitError,
+            Timeout,
+            APIConnectionError,
+        )
+        retryer = tenacity.Retrying(
+            wait=tenacity.wait_exponential(multiplier=2, max=120),
+            stop=tenacity.stop_after_attempt(self.config.num_retries),
+            retry=tenacity.retry_if_exception_type(_RETRIABLE),
+            reraise=True,
+        )
+        return retryer(litellm.completion, **kwargs)
 
     def _extract_usage(self, response) -> Usage:
         """Extract usage info from LiteLLM response."""

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+import tenacity
 from litellm import Message
 from litellm.types.utils import ChatCompletionMessageToolCall, Function
 
@@ -110,7 +112,7 @@ class TestLLM:
         llm = LLM(config=sample_llm_config)
         assert llm.config == sample_llm_config
 
-    @patch("cube_harness.llm.completion_with_retries")
+    @patch("cube_harness.llm.litellm.completion")
     def test_llm_call(self, mock_completion, sample_llm_config, sample_prompt):
         """Test LLM call with mocked completion."""
         mock_message = Message(role="assistant", content="Hello! How can I help?")
@@ -129,7 +131,7 @@ class TestLLM:
         assert result.message.content == "Hello! How can I help?"
         assert result.usage.prompt_tokens == 0  # No usage info provided
 
-    @patch("cube_harness.llm.completion_with_retries")
+    @patch("cube_harness.llm.litellm.completion")
     def test_llm_call_with_tools(self, mock_completion, sample_llm_config) -> None:
         """Test LLM call with tools."""
         tool_call = ChatCompletionMessageToolCall(
@@ -190,3 +192,63 @@ class TestLLMCall:
         assert "id" in data
         assert "timestamp" in data
         assert data["llm_config"]["model_name"] == "gpt-5-nano"
+
+
+class TestRetryBackoff:
+    """Tests for LLM._completion_with_retry tenacity-based retry."""
+
+    def _make_ok_response(self) -> MagicMock:
+        return MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="ok"))],
+            usage=None,
+        )
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_succeeds_on_first_attempt(self, mock_completion: MagicMock) -> None:
+        """No retry needed when the first call succeeds."""
+        mock_completion.return_value = self._make_ok_response()
+        llm = LLM(config=LLMConfig(model_name="gpt-5-nano", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        llm(prompt)
+        assert mock_completion.call_count == 1
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_retries_on_transient_error_then_succeeds(self, mock_completion: MagicMock) -> None:
+        """Retries when first call raises a retriable error, then succeeds."""
+        from litellm.exceptions import InternalServerError
+
+        mock_completion.side_effect = [
+            InternalServerError("overloaded", llm_provider="anthropic", model="claude"),
+            self._make_ok_response(),
+        ]
+        llm = LLM(config=LLMConfig(model_name="gpt-5-nano", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with patch("tenacity.wait_exponential", return_value=tenacity.wait_none()):
+            result = llm(prompt)
+        assert mock_completion.call_count == 2
+        assert result.message.content == "ok"
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_does_not_retry_permanent_errors(self, mock_completion: MagicMock) -> None:
+        """Non-retriable errors (e.g. NotFoundError) are raised immediately without retry."""
+        from litellm.exceptions import NotFoundError
+
+        mock_completion.side_effect = NotFoundError("model not found", llm_provider="openai", model="bad-model")
+        llm = LLM(config=LLMConfig(model_name="bad-model", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with pytest.raises(NotFoundError):
+            llm(prompt)
+        assert mock_completion.call_count == 1
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_reraises_after_exhausting_retries(self, mock_completion: MagicMock) -> None:
+        """After num_retries attempts all failing, the exception is re-raised."""
+        from litellm.exceptions import RateLimitError
+
+        mock_completion.side_effect = RateLimitError("rate limited", llm_provider="openai", model="gpt-5-nano")
+        llm = LLM(config=LLMConfig(model_name="gpt-5-nano", num_retries=2))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with patch("tenacity.wait_exponential", return_value=tenacity.wait_none()):
+            with pytest.raises(RateLimitError):
+                llm(prompt)
+        assert mock_completion.call_count == 2

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -252,3 +252,103 @@ class TestRetryBackoff:
             with pytest.raises(RateLimitError):
                 llm(prompt)
         assert mock_completion.call_count == 2
+
+
+class TestRetryIntegration:
+    """Integration tests for LLM retry — tenacity loop runs for real, only the
+    underlying litellm.completion call is stubbed.  We patch time.sleep to keep
+    tests fast without bypassing tenacity's own retry/stop/wait machinery."""
+
+    def _ok_response(self) -> MagicMock:
+        return MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="ok"))],
+            usage=None,
+        )
+
+    @patch("time.sleep")
+    @patch("cube_harness.llm.litellm.completion")
+    def test_full_retry_loop_attempt_count(self, mock_completion: MagicMock, mock_sleep: MagicMock) -> None:
+        """Tenacity calls litellm exactly num_retries times when every attempt fails."""
+        from litellm.exceptions import ServiceUnavailableError
+
+        mock_completion.side_effect = ServiceUnavailableError("unavailable", llm_provider="anthropic", model="claude")
+        llm = LLM(config=LLMConfig(model_name="claude-sonnet", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with pytest.raises(ServiceUnavailableError):
+            llm(prompt)
+        assert mock_completion.call_count == 3
+        # tenacity slept between attempts (num_retries-1 sleeps for num_retries attempts)
+        assert mock_sleep.call_count == 2
+
+    @patch("time.sleep")
+    @patch("cube_harness.llm.litellm.completion")
+    def test_sleep_duration_is_exponential(self, mock_completion: MagicMock, mock_sleep: MagicMock) -> None:
+        """Sleep durations grow exponentially (multiplier=2): ~2s, ~4s."""
+        from litellm.exceptions import InternalServerError
+
+        mock_completion.side_effect = [
+            InternalServerError("err", llm_provider="anthropic", model="claude"),
+            InternalServerError("err", llm_provider="anthropic", model="claude"),
+            self._ok_response(),
+        ]
+        llm = LLM(config=LLMConfig(model_name="claude-sonnet", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        llm(prompt)
+        assert mock_completion.call_count == 3
+        assert mock_sleep.call_count == 2
+        first_sleep, second_sleep = (c.args[0] for c in mock_sleep.call_args_list)
+        # multiplier=2: wait = 2 * 2^(attempt-1), capped at 120
+        assert 1.9 <= first_sleep <= 2.1, f"expected ~2s, got {first_sleep}"
+        assert 3.9 <= second_sleep <= 4.1, f"expected ~4s, got {second_sleep}"
+
+    @patch("time.sleep")
+    @patch("cube_harness.llm.litellm.completion")
+    def test_num_retries_zero_makes_single_attempt(self, mock_completion: MagicMock, mock_sleep: MagicMock) -> None:
+        """num_retries=0 makes exactly one attempt with no sleep — never zero attempts."""
+        from litellm.exceptions import RateLimitError
+
+        mock_completion.side_effect = RateLimitError("limited", llm_provider="openai", model="gpt")
+        llm = LLM(config=LLMConfig(model_name="gpt-5-nano", num_retries=0))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with pytest.raises(RateLimitError):
+            llm(prompt)
+        # Exactly 1 attempt — tenacity's minimum even with stop_after_attempt(0)
+        assert mock_completion.call_count == 1
+        assert mock_sleep.call_count == 0
+
+    @patch("time.sleep")
+    @patch("cube_harness.llm.litellm.completion")
+    def test_permanent_error_no_sleep(self, mock_completion: MagicMock, mock_sleep: MagicMock) -> None:
+        """A non-retriable error raises immediately — tenacity never sleeps."""
+        from litellm.exceptions import NotFoundError
+
+        mock_completion.side_effect = NotFoundError("model not found", llm_provider="openai", model="bad")
+        llm = LLM(config=LLMConfig(model_name="bad", num_retries=5))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        with pytest.raises(NotFoundError):
+            llm(prompt)
+        assert mock_completion.call_count == 1
+        assert mock_sleep.call_count == 0
+
+    @patch("time.sleep")
+    @patch("cube_harness.llm.litellm.completion")
+    def test_success_after_retries_returns_correct_response(
+        self, mock_completion: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """The response from the successful attempt is returned, not a retry artefact."""
+        from litellm.exceptions import Timeout
+
+        success = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="final answer"))],
+            usage=None,
+        )
+        mock_completion.side_effect = [
+            Timeout("timeout", llm_provider="openai", model="gpt"),
+            Timeout("timeout", llm_provider="openai", model="gpt"),
+            success,
+        ]
+        llm = LLM(config=LLMConfig(model_name="gpt-5-nano", num_retries=3))
+        prompt = Prompt(messages=[{"role": "user", "content": "hi"}], tools=[])
+        result = llm(prompt)
+        assert result.message.content == "final answer"
+        assert mock_completion.call_count == 3


### PR DESCRIPTION
## Bug

`litellm.completion_with_retries` hardcodes its exponential backoff to `wait_exponential(multiplier=1, max=10)` — a 10 s ceiling that's not configurable. Under heavy load (Anthropic `overloaded_error`, provider rate limits), a single failed request kills an entire multi-step episode with no chance of recovery, because all retries are exhausted in ~50 s while the provider window is often minutes long.

A 150-step episode that hit one transient 502 at step 73 would raise immediately and record `FAILED`, wasting all prior work.

## Fix

Own the retry loop with `tenacity.Retrying` directly — essentially the same 5 lines litellm wraps internally, but with the three parameters that matter actually exposed:

- `wait_exponential(multiplier=2, max=120)` — sleeps grow 2s → 4s → 8s → 16s → 32s → 64s → 120s (cap), outlasting typical overload windows.
- `retry_if_exception_type(...)` — only retriable errors are caught: `InternalServerError`, `ServiceUnavailableError`, `RateLimitError`, `Timeout`, `APIConnectionError`. Permanent errors (`NotFoundError`, `AuthenticationError`, etc.) surface immediately instead of wasting `num_retries` attempts.
- `reraise=True` — callers see the actual exception, not tenacity's `RetryError` wrapper.

`tenacity` was already a direct dependency, so no new packages.

## Verification

**Unit tests** (`TestRetryBackoff`, patch `tenacity.wait_exponential`):
- succeeds on first attempt → 1 call
- retries transient error then succeeds → 2 calls
- permanent error not retried → 1 call, raises immediately
- exhausted retries re-raises → `num_retries` calls then raises

**Integration tests** (`TestRetryIntegration`, real tenacity loop, only `time.sleep` patched):
- attempt count matches `num_retries`
- sleep durations are exponential (~2s, ~4s with `multiplier=2`)
- `num_retries=0` → 1 attempt (tenacity minimum)
- permanent error → 0 sleeps, 1 attempt
- successful retry returns the final response, not an artefact

## Follow-up

`LLMConfig.retry_strategy` is now dead config (was only consumed by `completion_with_retries`). Will be removed in a separate cleanup.