### PR TITLE
fix(runner): stop XRay from killing QUEUED tasks; add ray.get timeout

### DIFF
--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -444,10 +444,17 @@ _XRAY_CACHE_FILENAME = ".xray_summary.json"
 
 
 def _promote_ghost_episodes(exp_dir: Path) -> None:
-    """Write STALE into status.json for RUNNING/QUEUED episodes whose heartbeat is dead.
+    """Write STALE into status.json for RUNNING episodes whose heartbeat has gone silent.
 
     Fixes experiments where the runner crashed without marking episodes terminal.
     This lets the cache machinery treat the experiment as finished so it can be frozen.
+
+    Only RUNNING episodes are promoted — QUEUED episodes are legitimately waiting for
+    a Ray worker slot and must not be touched here.  In a large batch (e.g. 89 tasks,
+    --n-parallel 10) the last tasks can sit QUEUED for many hours; promoting them from
+    the viewer would silently kill tasks that the runner is about to dispatch.
+    QUEUED orphan cleanup is handled exclusively by sweep_stale_statuses() in
+    experiment.py, which runs either at resume-time or on runner shutdown.
     """
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
@@ -457,7 +464,7 @@ def _promote_ghost_episodes(exp_dir: Path) -> None:
         if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
             continue
         status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
-        if status is None or status.status not in ("RUNNING", "QUEUED"):
+        if status is None or status.status != "RUNNING":
             continue
         hb = status.last_heartbeat_at or status.started_at
         if now - hb > GHOST_TIMEOUT:

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -280,7 +280,7 @@ def _poll_ray(
         for task_ref in done:
             traj_id = ref_to_traj_id[task_ref]
             try:
-                traj: Trajectory = ray.get(task_ref)
+                traj: Trajectory = ray.get(task_ref, timeout=step_timeout_s + cancel_grace_s)
                 logger.info(
                     "Completed trajectory %s with %d steps (%d agent steps, %d environment steps)",
                     traj_id,

--- a/tests/test_xray_promote_ghost.py
+++ b/tests/test_xray_promote_ghost.py
@@ -1,0 +1,77 @@
+"""Unit tests for _promote_ghost_episodes (xray_utils).
+
+Covers the fix in PR #372: QUEUED episodes must never be promoted to STALE
+by the viewer's refresh path — only sweep_stale_statuses() (runner-owned)
+may touch them.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from cube_harness.analyze.xray_utils import _promote_ghost_episodes
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+
+
+def _write_status(ep_dir: Path, status: str, age_seconds: float) -> None:
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    s = EpisodeStatus(
+        status=status,
+        task_id="test-task",
+        episode_id=0,
+        started_at=time.time() - age_seconds,
+        last_heartbeat_at=time.time() - age_seconds,
+    )
+    s.write(ep_dir / STATUS_FILENAME)
+
+
+def test_queued_episode_never_promoted(tmp_path: Path) -> None:
+    """QUEUED episodes are not touched regardless of age."""
+    ep = tmp_path / "episodes" / "ep_000"
+    _write_status(ep, "QUEUED", age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "QUEUED"
+
+
+def test_old_running_episode_promoted_to_stale(tmp_path: Path) -> None:
+    """RUNNING episode whose heartbeat is beyond GHOST_TIMEOUT becomes STALE."""
+    ep = tmp_path / "episodes" / "ep_001"
+    _write_status(ep, "RUNNING", age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "STALE"
+
+
+def test_fresh_running_episode_not_promoted(tmp_path: Path) -> None:
+    """RUNNING episode with a recent heartbeat is left alone."""
+    ep = tmp_path / "episodes" / "ep_002"
+    _write_status(ep, "RUNNING", age_seconds=30)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == "RUNNING"
+
+
+@pytest.mark.parametrize("terminal_status", ["COMPLETED", "FAILED", "CANCELLED", "STALE"])
+def test_terminal_episodes_not_touched(tmp_path: Path, terminal_status: str) -> None:
+    """Already-terminal episodes are never re-promoted."""
+    ep = tmp_path / "episodes" / "ep_003"
+    _write_status(ep, terminal_status, age_seconds=99_999)
+
+    _promote_ghost_episodes(tmp_path)
+
+    after = EpisodeStatus.read(ep / STATUS_FILENAME)
+    assert after is not None
+    assert after.status == terminal_status


### PR DESCRIPTION
## Summary

Two bugs caught during overnight 89-task TerminalBench runs:

1. **XRay silently killed QUEUED tasks** — `_promote_ghost_episodes()` (called on every XRay UI refresh) was promoting QUEUED episodes to STALE using a 1-hour orphan threshold. In a large batch (89 tasks, `--n-parallel 10`) the last tasks legitimately sit QUEUED for many hours before a worker slot opens. Opening the viewer mid-run silently killed 3 unstarted tasks in a gpt-5.4 run. Fix: only promote RUNNING episodes from the viewer. QUEUED orphan cleanup belongs exclusively to `sweep_stale_statuses()` in `experiment.py`, which runs at resume-time or runner shutdown.

2. **`ray.get()` had no timeout** — if a worker hangs during teardown (e.g. `eai job kill` blocks), the entire `_poll_ray` loop freezes and `_kill_stale_workers` never runs again. Fix: pass `timeout=step_timeout_s + cancel_grace_s` to `ray.get()`, matching the same budget already used for worker kill decisions.

## Test plan

- [ ] `make lint` clean
- [ ] Run XRay viewer on a live experiment with QUEUED episodes — confirm none are promoted to STALE
- [ ] Verify `_poll_ray` recovers after a hung worker (via `ray.get` timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)