### PR TITLE
feat(llm): promote reasoning/thinking to a first-class LLM concern

### DIFF
--- a/openspec/changes/reasoning-first-class/deltas.md
+++ b/openspec/changes/reasoning-first-class/deltas.md
@@ -21,10 +21,11 @@ class Usage(TypedBaseModel):
 ```
 
 `LLM._extract_usage` MUST populate `reasoning_tokens` from
-`response.usage.completion_tokens_details.reasoning_tokens` when present
-(OpenAI o-series, gpt-5 family, and any provider LiteLLM normalizes to that
-shape). Anthropic does not surface reasoning tokens separately — they are folded
-into `completion_tokens`; `reasoning_tokens` stays 0 on Anthropic responses.
+`response.usage.completion_tokens_details.reasoning_tokens` when present.
+LiteLLM normalizes both OpenAI (native field on `completion_tokens_details`) and
+Anthropic (computed from `thinking_blocks`) into the same path, so the
+extraction is provider-agnostic. The reported value is **already counted
+inside `completion_tokens`** — telemetry only, not budget.
 
 ---
 
@@ -116,9 +117,13 @@ is replaced with:
 > `response.message.thinking_blocks` / `reasoning_content` for round-trip and
 > offline analysis.
 >
-> **Anthropic + thinking constraint.** Anthropic forbids `temperature != 1.0`
-> when extended thinking is active. `LLMConfig` validates this at construction
-> time.
+> **Anthropic + thinking constraints.** Three API-level restrictions apply when
+> `reasoning_effort` is set on an Anthropic model:
+> 1. `temperature` must be `1.0` (validated at config construction).
+> 2. `tool_choice` cannot be `"required"` (Anthropic 400s with "Thinking may
+>    not be enabled when tool_choice forces tool use"). Use `"auto"`.
+> 3. `max_completion_tokens` must exceed the thinking `budget_tokens` LiteLLM
+>    derives from `reasoning_effort` (≈1024 for "low"); set ≥2048 in practice.
 >
 > **Tool-use loops with Anthropic thinking.** Each assistant turn's
 > `thinking_blocks` (including `signature`) MUST be echoed back in subsequent

--- a/openspec/changes/reasoning-first-class/deltas.md
+++ b/openspec/changes/reasoning-first-class/deltas.md
@@ -1,0 +1,134 @@
+# Deltas: Reasoning First-Class
+
+Applies to: `openspec/specs/llm/spec.md`
+
+---
+
+## MODIFIED — `Usage`
+
+A new `reasoning_tokens` field is added. Default 0 so existing serialized records
+deserialize unchanged.
+
+```python
+class Usage(TypedBaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    cache_creation_tokens: int = 0
+    reasoning_tokens: int = 0     # NEW — provider-reported reasoning/thinking tokens
+    cost: float = 0.0
+```
+
+`LLM._extract_usage` MUST populate `reasoning_tokens` from
+`response.usage.completion_tokens_details.reasoning_tokens` when present
+(OpenAI o-series, gpt-5 family, and any provider LiteLLM normalizes to that
+shape). Anthropic does not surface reasoning tokens separately — they are folded
+into `completion_tokens`; `reasoning_tokens` stays 0 on Anthropic responses.
+
+---
+
+## ADDED — `get_reasoning(msg: Message) -> str`
+
+Module-level helper in `cube_harness.llm`. Provider-agnostic extractor:
+
+1. `msg.reasoning_content` if non-empty (OpenAI / streaming).
+2. Concatenation of `msg.thinking_blocks[*].thinking` if present (Anthropic
+   extended thinking).
+3. Empty string.
+
+The function operates on any `litellm.Message`, including those reconstructed
+from persisted `LLMCall.output` records — making it the canonical reasoning
+extractor for both live runs and offline trajectory analysis.
+
+---
+
+## ADDED — `LLMResponse.reasoning_text`
+
+A computed property on `LLMResponse`:
+
+```python
+class LLMResponse(TypedBaseModel):
+    message: Message
+    usage: Usage
+
+    @property
+    def reasoning_text(self) -> str:
+        return get_reasoning(self.message)
+```
+
+Agents SHOULD use `response.reasoning_text` to populate `AgentOutput.thoughts`.
+
+---
+
+## MODIFIED — `LLMConfig`
+
+Adds a Pydantic `model_validator` that fails at construction time when
+`reasoning_effort` is set on an Anthropic model with `temperature != 1.0`.
+
+```python
+@model_validator(mode="after")
+def _check_anthropic_thinking_temperature(self) -> "LLMConfig":
+    if (
+        self.reasoning_effort is not None
+        and _is_anthropic_model(self.model_name)
+        and self.temperature != 1.0
+    ):
+        raise ValueError(...)
+    return self
+```
+
+Anthropic extended thinking forbids `temperature != 1.0`; previously this
+surfaced as a 400 mid-run. The validator surfaces it at config time.
+
+---
+
+## MODIFIED — `Prompt` invariants
+
+A new invariant is added (currently true by virtue of
+`Message.model_dump(exclude_none=True)`, but unprotected):
+
+> **Round-trip invariant.** `Prompt._coerce_messages` MUST preserve provider
+> reasoning fields on assistant messages so the messages can be re-sent to the
+> provider in subsequent calls. Specifically: `thinking_blocks` (including each
+> block's `signature`), `reasoning_content`, and `tool_calls` survive coercion
+> from `litellm.Message` to dict.
+
+A unit test in `tests/test_llm.py` MUST exercise this invariant.
+
+---
+
+## MODIFIED — Gotchas
+
+The existing gotcha:
+
+> Anthropic extended thinking: set `reasoning_effort`. The reasoning output lands in
+> `message.reasoning_content` / `message.thinking_blocks` — log them via
+> `AgentOutput.thoughts` so the XRay viewer can display them.
+
+is replaced with:
+
+> **Reasoning extraction.** Set `reasoning_effort` to activate native reasoning
+> on supported models (OpenAI o-series and gpt-5, Anthropic Claude 3.7+/4.x,
+> Gemini 2.5, Grok 3/4, DeepSeek R1/R2, Qwen3-thinking, Magistral). Use
+> `response.reasoning_text` to obtain the thinking string for
+> `AgentOutput.thoughts`. The structured form is preserved on
+> `response.message.thinking_blocks` / `reasoning_content` for round-trip and
+> offline analysis.
+>
+> **Anthropic + thinking constraint.** Anthropic forbids `temperature != 1.0`
+> when extended thinking is active. `LLMConfig` validates this at construction
+> time.
+>
+> **Tool-use loops with Anthropic thinking.** Each assistant turn's
+> `thinking_blocks` (including `signature`) MUST be echoed back in subsequent
+> calls. `Prompt._coerce_messages` preserves them automatically via
+> `Message.model_dump(exclude_none=True)`. Do not strip these fields.
+
+---
+
+## MODIFIED — Public API surface in spec.md
+
+The `Usage` and `LLMResponse` sections of the spec are updated to reflect the
+new field and property. The "Public API" section gains an entry for
+`get_reasoning`.

--- a/openspec/changes/reasoning-first-class/proposal.md
+++ b/openspec/changes/reasoning-first-class/proposal.md
@@ -81,13 +81,11 @@ class Usage(TypedBaseModel):
     cost: float = 0.0
 ```
 
-Extracted in `_extract_usage` from:
-
-- **OpenAI**: `usage.completion_tokens_details.reasoning_tokens`.
-- **Anthropic**: not surfaced separately by the API — reasoning is folded into
-  `completion_tokens`. Leave at 0; document the gap.
-- **Other providers**: best-effort via the same `completion_tokens_details` path
-  (LiteLLM normalizes most reasoning models to this shape).
+Extracted in `_extract_usage` from
+`usage.completion_tokens_details.reasoning_tokens`. LiteLLM normalizes both
+OpenAI (native field) and Anthropic (computed from `thinking_blocks`) into this
+path, so the extraction is provider-agnostic. The value is **already part of
+`completion_tokens`** — telemetry only, not budgeting.
 
 Default of 0 means existing trajectory JSONs without the field deserialize cleanly.
 

--- a/openspec/changes/reasoning-first-class/proposal.md
+++ b/openspec/changes/reasoning-first-class/proposal.md
@@ -1,0 +1,226 @@
+# RFC: Reasoning / Extended Thinking as a First-Class LLM Concern
+
+**Status:** DRAFT
+**Author:** Alexandre Lacoste
+**Date:** 2026-05-13
+
+---
+
+## Problem
+
+Modern reasoning models (OpenAI o-series and gpt-5 family, Anthropic Claude 3.7+/4.x,
+Gemini 2.5, Grok 3/4, DeepSeek R1/R2, Qwen3-thinking, Magistral) emit a structured
+*thinking* artifact alongside their final response — `thinking_blocks` (Anthropic),
+`reasoning_content` (OpenAI), or equivalent. LiteLLM normalizes these onto the
+`Message` object that flows through `cube_harness.llm`.
+
+cube-harness treats this artifact ad-hoc:
+
+1. **Per-agent extraction.** Only Genny2 knows how to pull the reasoning text out
+   of a response (private `_get_reasoning`, called from three sites). `react.py`,
+   `genny.py`, and any future agent have to reinvent the same provider-fanout
+   logic to populate `AgentOutput.thoughts`.
+
+2. **No usage accounting.** Reasoning tokens are billable but invisible. OpenAI
+   exposes them as `completion_tokens_details.reasoning_tokens`; we drop the field
+   in `_extract_usage`. Cost dashboards therefore can't separate "tokens spent
+   thinking" from "tokens spent answering."
+
+3. **No round-trip verification.** Anthropic extended thinking requires that
+   `thinking_blocks` (with `signature`) be echoed back in subsequent assistant
+   turns when tool use is in the loop. The current `Prompt._coerce_messages` does
+   preserve them (verified empirically: `Message.model_dump(exclude_none=True)`
+   keeps the field), but there is no test locking this in. A future refactor
+   could silently break tool-use loops on Claude with thinking enabled.
+
+4. **No validator for Anthropic's `temperature=1` constraint.** Setting
+   `reasoning_effort` on a Claude model with `temperature != 1` produces a 400
+   from the provider. Today this fails at run time; it should fail at config
+   time.
+
+---
+
+## Scope
+
+A small refactor of `cube_harness.llm` that promotes reasoning to a first-class
+LLM concern, so every agent gets it uniformly:
+
+- `Usage.reasoning_tokens` — extracted automatically per call.
+- `LLMResponse.reasoning_text` — provider-agnostic accessor for the thinking text.
+- Module-level `get_reasoning(msg) -> str` helper for offline analysis
+  (`LLMCall.output`, persisted trajectories).
+- `LLMConfig` validator: Anthropic + `reasoning_effort` requires `temperature == 1`.
+- Regression test for the `Prompt` round-trip: `thinking_blocks` + `signature`
+  survive coercion and are accepted back by LiteLLM.
+
+Genny2 stops being the special case: its private `_get_reasoning` is removed
+and all three call sites are replaced with calls to the shared helper.
+
+**Out of scope:**
+
+- New configuration knobs for explicit thinking budget control
+  (`reasoning_effort` is sufficient; LiteLLM does the budget mapping).
+- Changes to `AgentOutput.thoughts` (stays `str | None` for trajectory back-compat).
+- Special XRay rendering of structured thinking blocks (flat text suffices).
+- Changes to cube-standard.
+
+---
+
+## Design
+
+### Layer 1 — `Usage` (new field)
+
+```python
+class Usage(TypedBaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    cache_creation_tokens: int = 0
+    reasoning_tokens: int = 0   # NEW
+    cost: float = 0.0
+```
+
+Extracted in `_extract_usage` from:
+
+- **OpenAI**: `usage.completion_tokens_details.reasoning_tokens`.
+- **Anthropic**: not surfaced separately by the API — reasoning is folded into
+  `completion_tokens`. Leave at 0; document the gap.
+- **Other providers**: best-effort via the same `completion_tokens_details` path
+  (LiteLLM normalizes most reasoning models to this shape).
+
+Default of 0 means existing trajectory JSONs without the field deserialize cleanly.
+
+### Layer 2 — `LLMResponse.reasoning_text` + `get_reasoning(msg)`
+
+Promote Genny2's private `_get_reasoning` to `cube_harness.llm`:
+
+```python
+def get_reasoning(msg: "Message") -> str:
+    """Provider-agnostic reasoning text extractor.
+
+    Checks reasoning_content (OpenAI / Anthropic streaming),
+    then thinking_blocks (Anthropic extended thinking),
+    then falls back to plain content.
+    """
+    if rc := getattr(msg, "reasoning_content", None):
+        return rc
+    blocks = getattr(msg, "thinking_blocks", None) or []
+    text = " ".join(b.get("thinking", "") for b in blocks if isinstance(b, dict))
+    if text:
+        return text
+    return msg.content or ""
+
+
+class LLMResponse(TypedBaseModel):
+    message: Message
+    usage: Usage
+
+    @property
+    def reasoning_text(self) -> str:
+        return get_reasoning(self.message)
+```
+
+Call-site impact in Genny2: three sites previously calling private
+`_get_reasoning(...)` now call `get_reasoning(...)` from `cube_harness.llm`. Any
+future agent gets thinking with the same one-liner.
+
+### Layer 3 — `LLMConfig` validator
+
+```python
+@model_validator(mode="after")
+def _check_anthropic_thinking_temperature(self) -> "LLMConfig":
+    if (
+        self.reasoning_effort is not None
+        and _is_anthropic_model(self.model_name)
+        and self.temperature != 1.0
+    ):
+        raise ValueError(
+            f"Anthropic extended thinking requires temperature=1.0, "
+            f"got temperature={self.temperature}. "
+            f"Either set temperature=1.0 or remove reasoning_effort."
+        )
+    return self
+```
+
+Fail at config construction, not at API call time.
+
+### Layer 4 — Round-trip regression test
+
+```python
+def test_thinking_blocks_survive_prompt_coercion() -> None:
+    msg = Message(
+        role="assistant",
+        content="here is my answer",
+        thinking_blocks=[
+            {"type": "thinking", "thinking": "let me think...", "signature": "sig_abc123"}
+        ],
+        reasoning_content="let me think...",
+    )
+    prompt = Prompt(messages=[msg], tools=[])
+    coerced = prompt.messages[0]
+
+    assert coerced["thinking_blocks"][0]["signature"] == "sig_abc123"
+    assert coerced["thinking_blocks"][0]["thinking"] == "let me think..."
+    assert coerced["reasoning_content"] == "let me think..."
+```
+
+No live API call. Locks in the current empirical behavior as a contract.
+
+### Layer 5 — Optional: OTel span attribute
+
+LiteLLM's OTel callback emits `gen_ai.usage.*` attributes automatically. If
+`reasoning_tokens` is exposed in `Usage`, we should additionally emit
+`gen_ai.usage.reasoning_tokens` on the LLM client span — matching the GenAI
+semantic convention. This is a one-line addition in whichever code path
+populates the harness-side LLM span (or a config tweak on the LiteLLM OTel
+callback if it does not emit it by default).
+
+Verification deferred to implementation: if LiteLLM already emits this
+attribute, no harness change is needed.
+
+---
+
+## Migration
+
+Call sites to update:
+
+- `genny2.py`: replace three `_get_reasoning(...)` calls with `get_reasoning(...)`
+  imported from `cube_harness.llm`; delete the private helper.
+
+No serialization break: `Usage.reasoning_tokens` defaults to 0 for old records.
+No API break: `LLMResponse.reasoning_text` is additive; existing
+`response.message.thinking_blocks` access still works.
+
+---
+
+## Alternatives considered
+
+**Add a `thinking_budget_tokens` knob to `LLMConfig`.** Rejected for V1:
+`reasoning_effort` (low/medium/high) is the unified abstraction LiteLLM provides,
+and over-parameterization here would push provider-specific concerns into the
+config. Easy to add later if a need emerges.
+
+**Make `AgentOutput.thoughts` a structured type (list of thinking blocks).**
+Rejected: changes the trajectory storage format and breaks XRay rendering for
+zero capability gain. The structured form is already preserved inside
+`LLMCall.output`; tooling that wants it can read it from there.
+
+**Auto-override temperature instead of validating.** Rejected: silent overrides
+of user-supplied config violate the constitution's explicitness pillar. Better
+to fail loudly with a clear message.
+
+**Move the helper to cube-standard.** Rejected: reasoning is an LLM-layer
+artifact, not a Task/Tool/Benchmark contract. cube-standard has no opinion on
+how agents introspect LLM responses.
+
+---
+
+## Open questions
+
+1. Does LiteLLM already emit `gen_ai.usage.reasoning_tokens` on its OTel client
+   spans? If yes, harness change is zero for Layer 5. If no, where is the cleanest
+   place to add it.
+2. `Usage.reasoning_tokens` is for telemetry only — for OpenAI o-series the
+   reasoning tokens are already counted inside `completion_tokens`, so adding
+   them to a budget tally would double-count. Documented in spec gotchas.

--- a/openspec/specs/llm/spec.md
+++ b/openspec/specs/llm/spec.md
@@ -51,14 +51,30 @@ class LLMResponse(TypedBaseModel):
     message: Message          # litellm.Message
     usage: Usage
 
+    @property
+    def reasoning_text(self) -> str   # provider-agnostic; empty when no reasoning
+
 class Usage(TypedBaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
     cached_tokens: int = 0
     cache_creation_tokens: int = 0    # Anthropic prompt caching
+    reasoning_tokens: int = 0          # OpenAI o-series / gpt-5 (Anthropic: folded into completion_tokens, stays 0)
     cost: float = 0.0                  # USD from LiteLLM pricing
 ```
+
+### `get_reasoning(msg: Message) -> str`
+
+Module-level helper. Provider-agnostic reasoning extractor:
+
+1. `msg.reasoning_content` if non-empty (OpenAI / streaming).
+2. Concatenation of `msg.thinking_blocks[*].thinking` (Anthropic extended thinking).
+3. Fallback to `msg.content`, else empty string.
+
+Works on any `litellm.Message`, including those reconstructed from persisted
+`LLMCall.output` records — so it's the canonical reasoning extractor for both
+live runs (`LLMResponse.reasoning_text`) and offline trajectory analysis.
 
 ### `LLM`
 ```python
@@ -92,6 +108,16 @@ steps in traces and training data.
 4. Module-level `litellm.callbacks` is intentionally NOT set. OTel callbacks are
    attached only after a proper `TracerProvider` is configured (see metrics spec) —
    otherwise litellm's default console exporter floods stdout.
+5. **Reasoning round-trip.** `Prompt._coerce_messages` MUST preserve provider
+   reasoning fields on assistant messages so they can be re-sent in subsequent
+   calls. Specifically: `thinking_blocks` (including each block's `signature`),
+   `reasoning_content`, and `tool_calls` survive coercion from `litellm.Message`
+   to dict. Anthropic extended thinking with tool use requires the prior turn's
+   `thinking_blocks` to be echoed back; stripping them breaks the tool-use loop.
+6. **Anthropic thinking + temperature.** `LLMConfig` rejects construction when
+   `reasoning_effort` is set on an Anthropic model with `temperature != 1.0`.
+   Anthropic forbids non-unit temperature under extended thinking; the validator
+   surfaces this at config time rather than at API time.
 
 ## Caching (Anthropic)
 
@@ -136,7 +162,21 @@ Anthropic response so trace consumers can see cache-hit rates per step.
 - `Prompt.messages` accepts both dicts and `litellm.Message` objects; the
   `field_validator` coerces Messages to dicts at construction so the stored type
   is always `list[dict]`. Downstream readers don't need to handle the union.
-- Anthropic extended thinking: set `reasoning_effort`. The reasoning output lands in
-  `message.reasoning_content` / `message.thinking_blocks` — log them via
-  `AgentOutput.thoughts` so the XRay viewer can display them.
+- **Reasoning extraction.** Set `reasoning_effort` to activate native reasoning on
+  supported models (OpenAI o-series / gpt-5; Anthropic Claude 3.7+/4.x; Gemini 2.5;
+  Grok 3/4; DeepSeek R1/R2; Qwen3-thinking; Magistral). Use
+  `response.reasoning_text` (or `get_reasoning(msg)` for offline analysis) to obtain
+  the thinking string for `AgentOutput.thoughts`. The structured form is preserved
+  on `response.message.thinking_blocks` / `reasoning_content` for round-trip.
+- **Anthropic thinking constraint.** Anthropic forbids `temperature != 1.0` when
+  extended thinking is active. `LLMConfig` validates this at construction time.
+- **Tool-use loops with Anthropic thinking.** Each assistant turn's
+  `thinking_blocks` (including `signature`) MUST be echoed back in subsequent
+  calls. `Prompt._coerce_messages` preserves them automatically via
+  `Message.model_dump(exclude_none=True)`. Do not strip these fields.
+- **`reasoning_tokens` accounting.** OpenAI o-series / gpt-5 surface
+  `completion_tokens_details.reasoning_tokens` separately, but those tokens are
+  already counted inside `completion_tokens` — do not add them to a budget tally,
+  or you will double-count. The field exists for telemetry, not for budgeting.
+  Anthropic reports nothing here; reasoning is folded into `completion_tokens`.
 - Cost is USD from LiteLLM's built-in pricing — may lag behind provider price changes.

--- a/openspec/specs/llm/spec.md
+++ b/openspec/specs/llm/spec.md
@@ -60,7 +60,7 @@ class Usage(TypedBaseModel):
     total_tokens: int = 0
     cached_tokens: int = 0
     cache_creation_tokens: int = 0    # Anthropic prompt caching
-    reasoning_tokens: int = 0          # OpenAI o-series / gpt-5 (Anthropic: folded into completion_tokens, stays 0)
+    reasoning_tokens: int = 0          # LiteLLM-normalized across providers; subset of completion_tokens
     cost: float = 0.0                  # USD from LiteLLM pricing
 ```
 
@@ -168,15 +168,30 @@ Anthropic response so trace consumers can see cache-hit rates per step.
   `response.reasoning_text` (or `get_reasoning(msg)` for offline analysis) to obtain
   the thinking string for `AgentOutput.thoughts`. The structured form is preserved
   on `response.message.thinking_blocks` / `reasoning_content` for round-trip.
-- **Anthropic thinking constraint.** Anthropic forbids `temperature != 1.0` when
-  extended thinking is active. `LLMConfig` validates this at construction time.
+- **OpenAI hides the reasoning text.** OpenAI o-series and gpt-5 (including
+  Azure-OpenAI deployments) return `reasoning_tokens > 0` to confirm the model
+  thought, but **do not return the thinking text** — `reasoning_content` and
+  `thinking_blocks` are empty even with `reasoning_effort` set. This is an
+  OpenAI design choice. Consequence: `AgentOutput.thoughts` will be `None` on
+  OpenAI episodes even when the model reasoned. The agent still benefits from
+  the reasoning; only the human-readable trace is unavailable.
+- **Anthropic thinking constraints.** Two API-level restrictions surface when
+  `reasoning_effort` is set on an Anthropic model:
+  1. `temperature` must be `1.0`. `LLMConfig` validates this at construction time.
+  2. `tool_choice` must NOT be `"required"`. Anthropic returns 400 with
+     "Thinking may not be enabled when tool_choice forces tool use." Stay on
+     `"auto"` (the default) and shape the prompt to elicit the tool call.
+  3. `max_completion_tokens` must exceed the thinking `budget_tokens` LiteLLM
+     maps `reasoning_effort` onto (≈1024 for "low", more for higher). Set
+     `max_completion_tokens` to at least 2048 when reasoning is active.
 - **Tool-use loops with Anthropic thinking.** Each assistant turn's
   `thinking_blocks` (including `signature`) MUST be echoed back in subsequent
   calls. `Prompt._coerce_messages` preserves them automatically via
   `Message.model_dump(exclude_none=True)`. Do not strip these fields.
-- **`reasoning_tokens` accounting.** OpenAI o-series / gpt-5 surface
-  `completion_tokens_details.reasoning_tokens` separately, but those tokens are
-  already counted inside `completion_tokens` — do not add them to a budget tally,
-  or you will double-count. The field exists for telemetry, not for budgeting.
-  Anthropic reports nothing here; reasoning is folded into `completion_tokens`.
+- **`reasoning_tokens` accounting.** LiteLLM normalizes `reasoning_tokens` for
+  both OpenAI (native `completion_tokens_details.reasoning_tokens`) and
+  Anthropic (computed from `thinking_blocks`) into the same `Usage` field.
+  These tokens are **already counted inside `completion_tokens`** — do not add
+  them to a budget tally, or you will double-count. The field exists for
+  telemetry only.
 - Cost is USD from LiteLLM's built-in pricing — may lag behind provider price changes.

--- a/scripts/smoke/reasoning.py
+++ b/scripts/smoke/reasoning.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Smoke test: reasoning/thinking + caching + tool-use round-trip against real APIs.
+
+Verifies, on cheap reasoning-capable models, that the harness's reasoning support
+behaves end-to-end against live providers:
+
+  1. LLMConfig validator rejects Anthropic + reasoning_effort + temperature != 1
+     at config time (no API call).
+  2. Without reasoning_effort: response.reasoning_text is empty, reasoning_tokens=0.
+  3. With reasoning_effort: thinking activates. Anthropic exposes the text on
+     thinking_blocks; OpenAI / Azure-OpenAI only report reasoning_tokens (text
+     stays server-side, by design).
+  4. Usage accounting: reasoning_tokens > 0 and bounded by completion_tokens
+     (no double-count).
+  5. Anthropic prompt caching: a repeated call sharing the long system prefix
+     reports cache_read_tokens.
+  6. Tool-use round-trip: an assistant turn's thinking_blocks (with signature)
+     are preserved through Prompt._coerce_messages and accepted back by the API
+     on the follow-up call.
+
+Auto-skips providers whose API keys are not set. Costs ~$0.05-$0.10 per provider.
+
+Final line follows the cube-harness smoke contract:
+    SMOKE OK: reasoning      (exit 0 — every configured provider passed)
+    SMOKE FAIL: reasoning    (exit 1 — at least one check failed)
+    SMOKE SKIP: reasoning    (exit 2 — no provider available to test)
+
+Usage:
+    uv run scripts/smoke/reasoning.py                              # anthropic + openai
+    uv run scripts/smoke/reasoning.py --anthropic-model claude-haiku-4-5
+    uv run scripts/smoke/reasoning.py --azure-model azure/gpt-5-mini-deployment
+    uv run scripts/smoke/reasoning.py --skip-anthropic
+"""
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Annotated
+
+import typer
+
+from cube_harness.llm import LLMConfig, Prompt
+
+# Filler system prompt — must exceed Anthropic's per-model cache minimum
+# (1024 tokens for Sonnet/Opus, 2048 for Haiku). Sized at ~2500 tokens to give
+# margin across the matrix. Content is intentionally bland so it does not bias
+# the reasoning trigger downstream.
+LONG_SYSTEM_PROMPT = """\
+You are a careful and precise assistant designed to support software engineering
+and analytical tasks. You favor correctness over speed, and clarity over brevity.
+You verify assumptions before acting on them, and you state explicitly when you
+are uncertain about a fact, a value, or an outcome. When a question admits more
+than one reasonable interpretation, you call this out before proceeding rather
+than silently picking one.
+
+Your output style guidelines:
+- Plain prose, no unnecessary emphasis, no decorative headings unless asked.
+- Identifiers, file paths, and command snippets are formatted as code.
+- Numbers are written digit-first; units are SI-canonical where one exists.
+- When summarizing a longer body of evidence, you separate observations from
+  inferences and label each. Observations cite the source; inferences cite the
+  observations they depend on.
+
+Your reasoning process, when a task warrants it:
+1. Restate the goal in your own words to confirm understanding. Skip when the
+   goal is unambiguous and a one-sentence task.
+2. Inventory what you know, what you assume, and what you would need to check.
+   Treat the inventory as falsifiable: each item could be wrong, and you note
+   how you would discover that.
+3. Enumerate candidate approaches when more than one is plausible. State the
+   trade-off for each in one line.
+4. Pick an approach and proceed, with an explicit fallback plan if the chosen
+   approach hits an obstacle.
+5. Verify the result against the original goal before declaring completion.
+
+You take care to avoid common reasoning failures:
+- Anchoring on the first plausible explanation without considering alternatives.
+- Treating a partial pattern match as confirmation of a full match.
+- Confusing correlation with causation when summarizing observed data.
+- Conflating necessary with sufficient conditions in proofs and analyses.
+- Over-generalizing from a single example, especially when the example is
+  chosen for ease of explanation rather than representativeness.
+- Trusting your own prior outputs without re-checking them against the source
+  when the chain of reasoning grows long.
+
+On disagreement: if the user or another agent challenges a claim you made, you
+re-examine the claim from first principles rather than defending it from
+authority. If you find your claim was wrong, you state so directly, identify
+which step in your reasoning failed, and update the conclusion. If you find
+your claim was right, you explain the disagreement source and offer the
+evidence that resolves it.
+
+On uncertainty: you distinguish between aleatoric uncertainty (the outcome is
+inherently random) and epistemic uncertainty (you lack relevant information).
+You give numeric ranges or confidence levels where the question demands them.
+You do not invent numbers to satisfy a request for a confidence level.
+
+On code: you treat code as a precise medium. You read more than you write. You
+explain the intent of a change separately from the mechanism. You consider how
+a change ages — whether it will hold up under requirements you can foresee, and
+whether it leaves enough hooks to adapt to ones you cannot. You prefer
+deletions when feasible, refactors when they reduce surface area, and additions
+only when they earn their keep against the rest of the codebase.
+
+On testing: you treat tests as documentation of behavior, not as decoration.
+You prefer tests that fail loudly when the behavior they pin down changes. You
+distinguish between tests that exercise a contract and tests that exercise an
+implementation; you write more of the former and fewer of the latter. You
+recognize that a test passing is not the same as the behavior being correct;
+it is the same as the behavior not having drifted from the snapshot the test
+encodes.
+
+On collaboration: you respect the conventions of the codebase you are working
+in. You match the existing style, idioms, and abstractions unless you have a
+specific and stated reason to depart from them. You ask before introducing a
+new dependency, a new abstraction layer, or a new pattern that has no precedent
+elsewhere in the project.
+
+These guidelines apply uniformly across tasks. You do not have to recite them;
+you simply follow them. When a specific task contradicts a guideline, you
+follow the task and note the contradiction.
+
+On debugging: you treat a failing observation as a constraint, not a nuisance.
+The failure mode tells you which assumption was wrong; the fix that addresses
+the wrong assumption is the right fix, and the fix that just makes the
+observation go away is the wrong fix even when it works. You name the
+hypothesis you are testing before you run each test, so you can tell whether
+the result confirms or refutes it. You distinguish between intermittent and
+deterministic failures and choose your reproduction strategy accordingly.
+
+On data: you treat data with the same skepticism you treat code. A surprising
+number is more likely a bug in the pipeline than a discovery. You sanity-check
+totals, distributions, and outliers before drawing conclusions. You note when a
+metric is a proxy for the underlying quantity you actually care about, and you
+state the limits of the proxy explicitly. You prefer reporting raw counts
+alongside ratios because ratios alone can hide both the numerator and the
+denominator.
+
+On versions and dependencies: you treat the exact version of an external
+component as load-bearing. Behavior differences between minor versions are
+common; behavior differences between major versions are routine. You pin
+versions in tests that depend on specific behavior, and you note when a fix
+is contingent on a particular version of a library or service.
+
+On safety: you do not take destructive actions (deleting files, dropping
+tables, force-pushing, terminating processes) without explicit confirmation
+from the user when those actions are reversible only with effort, and never
+without explanation when those actions are irreversible. You prefer additive
+changes over replacements, and reversible changes over irreversible ones,
+when both are viable.
+
+On documentation: you write documentation that ages with the system it
+describes. You prefer reference documentation that points at canonical
+sources to documentation that copies them. You write commit messages and PR
+descriptions that explain why a change was made, not just what was changed —
+the diff already shows what. You include enough context that a reviewer
+six months later can understand the trade-off without reading the original
+conversation.
+
+On scope: you respect the boundary of the task you were given. You do not
+enlarge a refactor into a redesign without checking. You do not enlarge a bug
+fix into a feature without checking. You note adjacent issues that you noticed
+while doing the requested work, and surface them as follow-ups rather than
+silently including them.
+
+On naming: you treat names as the primary documentation of a function, a
+variable, or a module. A good name describes the role the thing plays in the
+program, not the mechanism by which it plays it. When a name is hard to
+choose, the underlying abstraction is usually wrong; that is a signal to step
+back and rethink, not to push through and pick the least-bad option. When you
+rename a thing, you update every reference at once rather than introducing a
+temporary period in which both names exist.
+
+On comments: you write comments only when the code cannot speak for itself.
+Comments that restate what the code does are noise; comments that explain why
+a choice was made, why an alternative was rejected, or why a constraint exists
+are signal. You delete comments that have rotted past their referent. You do
+not leave commented-out code in the tree; if a path is worth keeping, you put
+it behind a flag, and if it is not worth keeping, you delete it.
+
+On performance: you measure before optimizing. You profile, you do not guess.
+You consider the cost of the optimization (additional complexity, harder to
+read, harder to change) against the benefit (latency, throughput, cost). You
+prefer algorithmic improvements over micro-optimizations because they age
+better. You leave a comment when an optimization has counter-intuitive
+behavior — for instance, when the obvious-looking version is actually slower
+because of a hidden constraint.
+
+On error handling: you distinguish between expected errors (a network call
+fails, a file is missing, a parse rejects input) and unexpected errors (a
+data structure is in a state your code did not anticipate). The first kind
+becomes part of the contract; the second kind becomes a bug. You do not catch
+exceptions to silence them; you catch exceptions to translate them into a
+shape that the caller can act on. You let exceptions propagate when the
+caller is genuinely better positioned to handle them.
+
+On asynchrony: you treat concurrency as a source of subtle bugs and adopt it
+deliberately, not by default. You name the boundaries — what may block, what
+must run sequentially, where state is shared — explicitly. You prefer message
+passing over shared mutable state when the language affords it. You document
+the threading or async model at the top of any module that mixes sync and
+async paths.
+
+On configuration: you keep configuration small and explicit. You prefer code
+that names its inputs in the function signature to code that pulls them from
+a global config object. When a config value is genuinely global (e.g. a
+database URL, an API key), you load it once at startup and pass it down. You
+do not let configuration grow into a parallel program: if a config switch
+changes meaningful behavior, that behavior belongs in code that you can read
+and test.
+
+On feedback: when reviewing someone else's work, you separate observations
+from prescriptions. An observation describes what you saw; a prescription
+recommends what to do about it. You give the reader the chance to disagree
+with the prescription without disagreeing with the observation. You frame
+suggestions as suggestions, blocking issues as blocking, and personal taste
+as personal taste — and you label each clearly so the reader can route their
+energy.
+
+On disagreement after consensus: when you have followed a prior decision for
+a while and accumulated evidence that the decision was wrong, you surface the
+evidence rather than quietly working around it. You phrase the update as a
+proposed revision, not a complaint, and you offer the smallest viable change
+that would resolve the underlying issue. You accept that revisiting a settled
+decision has a cost, and you justify the cost with the evidence rather than
+with the discomfort of working around the original.
+"""
+
+# Reasoning trigger: small enough to be cheap, hard enough to force the model
+# to think rather than pattern-match the answer.
+REASONING_QUESTION = (
+    "What is the third largest prime number less than 100? "
+    "Show your work briefly, then state the final answer on the last line."
+)
+
+NOTE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "note",
+        "description": "Record a short note for later reference.",
+        "parameters": {
+            "type": "object",
+            "properties": {"text": {"type": "string", "description": "The note content."}},
+            "required": ["text"],
+        },
+    },
+}
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    details: str
+
+
+@dataclass
+class Provider:
+    name: str
+    model: str
+    # True when the provider returns the thinking *text* (not just the count).
+    # Anthropic exposes thinking_blocks; OpenAI / Azure-OpenAI keep reasoning
+    # server-side and only report reasoning_tokens — reasoning_text will be ""
+    # there, by design, even with reasoning_effort active.
+    exposes_reasoning_text: bool
+    # True when prompt caching is worth testing on this provider through the
+    # current LLMConfig (only Anthropic today via set_cache_control="auto").
+    supports_cache_test: bool
+
+
+# ---------------------------------------------------------------------------
+# Checks — return CheckResult instead of raising so partial runs surface fully.
+# ---------------------------------------------------------------------------
+
+
+def check_validator() -> CheckResult:
+    """LLMConfig rejects Anthropic + reasoning_effort + temperature != 1 at config time."""
+    try:
+        LLMConfig(model_name="claude-haiku-4-5", temperature=0.5, reasoning_effort="low")
+    except ValueError as e:
+        if "temperature=1.0" in str(e):
+            return CheckResult("LLMConfig validator", True, "raised expected ValueError at construction")
+        return CheckResult("LLMConfig validator", False, f"raised but wrong message: {e}")
+    return CheckResult("LLMConfig validator", False, "validator did not raise on Anthropic+thinking+temp=0.5")
+
+
+def check_no_reasoning(provider: Provider) -> CheckResult:
+    """Baseline: without reasoning_effort, reasoning_text is empty and reasoning_tokens=0."""
+    cfg = LLMConfig(model_name=provider.model, temperature=1.0, max_completion_tokens=200)
+    llm = cfg.make()
+    prompt = Prompt(
+        messages=[{"role": "user", "content": "Say the word 'hello' and nothing else."}],
+        tools=[],
+    )
+    resp = llm(prompt)
+    if resp.reasoning_text:
+        return CheckResult("baseline (no reasoning)", False, f"unexpected reasoning_text: {resp.reasoning_text[:80]!r}")
+    if resp.usage.reasoning_tokens != 0:
+        return CheckResult(
+            "baseline (no reasoning)", False, f"unexpected reasoning_tokens={resp.usage.reasoning_tokens}"
+        )
+    return CheckResult(
+        "baseline (no reasoning)",
+        True,
+        f"reasoning_text empty, reasoning_tokens=0, content={resp.message.content[:30]!r}",
+    )
+
+
+def check_reasoning_activates(provider: Provider, captured: dict) -> CheckResult:
+    """With reasoning_effort, the model actually reasons.
+
+    The activation signal is provider-dependent:
+      - Anthropic exposes the thinking text on thinking_blocks → reasoning_text
+        is non-empty.
+      - OpenAI / Azure-OpenAI keep reasoning server-side; only reasoning_tokens
+        is reported. reasoning_text stays empty by design.
+
+    Both reveal "the model thought" — just through different signals. The
+    response is captured for the next checks so we pay for one call, not two.
+    """
+    cfg = LLMConfig(
+        model_name=provider.model,
+        temperature=1.0,
+        # Anthropic requires max_tokens > thinking.budget_tokens; LiteLLM maps
+        # reasoning_effort="low" to budget_tokens=1024, so allow generous headroom.
+        max_completion_tokens=2048,
+        reasoning_effort="low",
+    )
+    llm = cfg.make()
+    prompt = Prompt(messages=[{"role": "user", "content": REASONING_QUESTION}], tools=[])
+    resp = llm(prompt)
+    captured["with_reasoning_resp"] = resp
+    text = resp.reasoning_text
+    rt = resp.usage.reasoning_tokens
+    if provider.exposes_reasoning_text:
+        if not text:
+            return CheckResult(
+                "thinking activates",
+                False,
+                f"expected non-empty reasoning_text (Anthropic exposes thinking_blocks), got empty (rt={rt})",
+            )
+        return CheckResult(
+            "thinking activates",
+            True,
+            f"reasoning_text len={len(text)} chars; head={text[:80]!r}",
+        )
+    # OpenAI / Azure: text hidden server-side; only the count is reported.
+    if rt <= 0:
+        return CheckResult(
+            "thinking activates",
+            False,
+            f"reasoning_tokens={rt} (provider keeps text hidden; the count is the only activation signal)",
+        )
+    return CheckResult(
+        "thinking activates",
+        True,
+        f"reasoning_tokens={rt} (text hidden by provider design; count confirms activation)",
+    )
+
+
+def check_reasoning_tokens(provider: Provider, captured: dict) -> CheckResult:
+    """reasoning_tokens > 0 when reasoning is active — same expectation for all providers.
+
+    LiteLLM normalizes both OpenAI (native completion_tokens_details.reasoning_tokens)
+    and Anthropic (computed from thinking_blocks) into the same field. The count
+    is included within completion_tokens; the separate field is for telemetry.
+    """
+    resp = captured.get("with_reasoning_resp")
+    if resp is None:
+        return CheckResult("reasoning token accounting", False, "prior check did not capture a response")
+    rt = resp.usage.reasoning_tokens
+    ct = resp.usage.completion_tokens
+    if rt <= 0:
+        return CheckResult(
+            "reasoning token accounting",
+            False,
+            f"expected reasoning_tokens>0 when reasoning is on, got {rt} (completion={ct})",
+        )
+    if rt > ct:
+        return CheckResult(
+            "reasoning token accounting",
+            False,
+            f"reasoning_tokens={rt} > completion_tokens={ct} — double-count risk; should be subset",
+        )
+    return CheckResult(
+        "reasoning token accounting",
+        True,
+        f"reasoning_tokens={rt} within completion_tokens={ct} (no double-count)",
+    )
+
+
+def check_cache_works(provider: Provider) -> CheckResult:
+    """Anthropic: a repeated call sharing the long system prefix reports cache_read tokens.
+
+    set_cache_control="auto" places the breakpoint at message index 1, so the
+    cached prefix covers [system, user]. Both calls must therefore send the
+    same [system, user] pair — only differing turns appended later would still
+    hit the cache. We send the SAME pair twice, varying nothing.
+    """
+    cfg = LLMConfig(
+        model_name=provider.model,
+        temperature=1.0,
+        max_completion_tokens=80,
+        set_cache_control="auto",
+    )
+    llm = cfg.make()
+    messages = [
+        {"role": "system", "content": LONG_SYSTEM_PROMPT},
+        {"role": "user", "content": "Reply with the single letter 'A'."},
+    ]
+    resp1 = llm(Prompt(messages=messages, tools=[]))
+    resp2 = llm(Prompt(messages=messages, tools=[]))
+    created = resp1.usage.cache_creation_tokens
+    read = resp2.usage.cached_tokens
+    if read > 0:
+        return CheckResult(
+            "prompt caching (Anthropic)",
+            True,
+            f"call1 cache_creation={created}, call2 cache_read={read}",
+        )
+    return CheckResult(
+        "prompt caching (Anthropic)",
+        False,
+        f"call1 cache_creation={created}, call2 cache_read={read} (expected >0)",
+    )
+
+
+def check_tool_use_roundtrip(provider: Provider) -> CheckResult:
+    """Tool-use loop with thinking: prior assistant turn's thinking_blocks round-trip.
+
+    The integration form of TestPromptThinkingRoundTrip — call 1 emits thinking +
+    a tool_call, call 2 echoes the assistant message back (with thinking_blocks)
+    plus a tool result; if the signature is dropped or mangled, Anthropic returns
+    a 400 here.
+    """
+    # Note: Anthropic rejects tool_choice="required" alongside reasoning_effort
+    # ("Thinking may not be enabled when tool_choice forces tool use"), so we
+    # stay on "auto" and shape the prompt to make the tool call obvious.
+    cfg1 = LLMConfig(
+        model_name=provider.model,
+        temperature=1.0,
+        # Headroom for reasoning_effort="low" (budget_tokens=1024 on Anthropic).
+        max_completion_tokens=2048,
+        reasoning_effort="low",
+        tool_choice="auto",
+    )
+    llm1 = cfg1.make()
+    user_msg = (
+        "Use the `note` tool to record your final answer to this question, "
+        f"then stop. Do not answer in plain text — only call the tool. "
+        f"Question: {REASONING_QUESTION}"
+    )
+    resp1 = llm1(Prompt(messages=[{"role": "user", "content": user_msg}], tools=[NOTE_TOOL]))
+    if not resp1.message.tool_calls:
+        return CheckResult("tool-use round-trip", False, "no tool_call in call 1")
+    tc = resp1.message.tool_calls[0]
+    # Build follow-up: pass resp1.message (a litellm.Message) into Prompt; the
+    # validator coerces it to a dict via model_dump(exclude_none=True), which
+    # is the same path the harness uses in real episodes.
+    prompt2 = Prompt(
+        messages=[
+            {"role": "user", "content": user_msg},
+            resp1.message,
+            {"role": "tool", "tool_call_id": tc.id, "content": "noted"},
+            {"role": "user", "content": "In one short sentence, confirm what you noted."},
+        ],
+        tools=[NOTE_TOOL],
+    )
+    cfg2 = LLMConfig(
+        model_name=provider.model,
+        temperature=1.0,
+        # Same headroom as call 1 — call 2 also has reasoning_effort enabled.
+        max_completion_tokens=2048,
+        reasoning_effort="low",
+        tool_choice="auto",
+    )
+    llm2 = cfg2.make()
+    try:
+        llm2(prompt2)
+    except Exception as e:
+        return CheckResult(
+            "tool-use round-trip",
+            False,
+            f"call 2 raised {type(e).__name__}: {str(e)[:160]}",
+        )
+    asst_dict = prompt2.messages[1]
+    if not isinstance(asst_dict, dict):
+        return CheckResult("tool-use round-trip", False, "assistant message not coerced to dict")
+    if provider.name == "anthropic":
+        blocks = asst_dict.get("thinking_blocks") or []
+        if not blocks:
+            return CheckResult(
+                "tool-use round-trip",
+                False,
+                "assistant turn lost thinking_blocks after Prompt coercion (Anthropic would 400 here)",
+            )
+        sig = blocks[0].get("signature")
+        if not sig:
+            return CheckResult(
+                "tool-use round-trip",
+                False,
+                "thinking_block present but signature missing — would break tool-use loop",
+            )
+        return CheckResult(
+            "tool-use round-trip",
+            True,
+            f"thinking_blocks preserved with signature ({sig[:18]}…), call 2 accepted",
+        )
+    # OpenAI / Azure: no per-turn signature to track; success is the round-trip not raising.
+    return CheckResult(
+        "tool-use round-trip",
+        True,
+        "call 2 accepted (OpenAI does not require thinking_blocks echoed back)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProviderResults:
+    provider: Provider
+    results: list[CheckResult] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+
+def _pass_fail(passed: bool) -> str:
+    return (
+        typer.style("PASS", fg=typer.colors.GREEN, bold=True)
+        if passed
+        else typer.style("FAIL", fg=typer.colors.RED, bold=True)
+    )
+
+
+def _emit(check: CheckResult) -> None:
+    typer.echo(f"  {check.name:<38} {_pass_fail(check.passed)}  {check.details}")
+
+
+def run_provider(provider: Provider) -> ProviderResults:
+    out = ProviderResults(provider=provider)
+    typer.echo(f"\n[{provider.name} / {provider.model}]")
+    t0 = time.monotonic()
+    captured: dict = {}
+    for check in (
+        check_no_reasoning(provider),
+        check_reasoning_activates(provider, captured),
+        check_reasoning_tokens(provider, captured),
+        *([check_cache_works(provider)] if provider.supports_cache_test else []),
+        check_tool_use_roundtrip(provider),
+    ):
+        _emit(check)
+        out.results.append(check)
+    out.elapsed_s = time.monotonic() - t0
+    typer.echo(f"  ({out.elapsed_s:.1f}s)")
+    return out
+
+
+def main(
+    anthropic_model: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Anthropic model. Default is Sonnet 4.5: it has a 1024-token cache minimum so "
+                "the cache check fits the smoke-test fixture. Haiku 4.5 also works for thinking "
+                "and round-trip checks but has a higher cache-minimum that the fixture does not "
+                "exceed, so the cache check will fail on it."
+            )
+        ),
+    ] = "claude-sonnet-4-5",
+    openai_model: Annotated[str, typer.Option(help="OpenAI model to test (direct, via OPENAI_API_KEY)")] = "gpt-5-mini",
+    azure_model: Annotated[
+        str | None,
+        typer.Option(help="Azure-OpenAI deployment (e.g. azure/<deployment-name>) to test. Skipped if not set."),
+    ] = None,
+    skip_anthropic: Annotated[bool, typer.Option(help="Skip the Anthropic provider")] = False,
+    skip_openai: Annotated[bool, typer.Option(help="Skip the direct-OpenAI provider")] = False,
+) -> None:
+    """Run the reasoning + caching + round-trip smoke tests against real APIs.
+
+    Skips providers whose API keys are not set. Costs roughly $0.02-$0.05 per
+    provider. Intended to be invoked by a human (or Claude Code on request),
+    not by CI.
+    """
+    typer.echo(typer.style("=== Smoke test: reasoning + caching + tool-use round-trip ===", bold=True))
+
+    all_results: list[CheckResult] = []
+
+    # No-API gate
+    v = check_validator()
+    typer.echo("\n[validator (no API)]")
+    _emit(v)
+    all_results.append(v)
+
+    # Provider matrix
+    providers: list[Provider] = []
+    if not skip_anthropic and os.environ.get("ANTHROPIC_API_KEY"):
+        providers.append(
+            Provider(
+                name="anthropic",
+                model=anthropic_model,
+                exposes_reasoning_text=True,
+                supports_cache_test=True,
+            )
+        )
+    elif not skip_anthropic:
+        typer.echo(typer.style("\n[anthropic] SKIPPED — ANTHROPIC_API_KEY not set", fg=typer.colors.YELLOW))
+
+    if not skip_openai and os.environ.get("OPENAI_API_KEY"):
+        providers.append(
+            Provider(
+                name="openai",
+                model=openai_model,
+                exposes_reasoning_text=False,
+                supports_cache_test=False,
+            )
+        )
+    elif not skip_openai:
+        typer.echo(typer.style("\n[openai] SKIPPED — OPENAI_API_KEY not set", fg=typer.colors.YELLOW))
+
+    if azure_model:
+        if os.environ.get("AZURE_API_KEY") or os.environ.get("AZURE_OPENAI_API_KEY"):
+            providers.append(
+                Provider(
+                    name="azure",
+                    model=azure_model,
+                    exposes_reasoning_text=False,
+                    supports_cache_test=False,
+                )
+            )
+        else:
+            typer.echo(
+                typer.style(
+                    f"\n[azure / {azure_model}] SKIPPED — AZURE_API_KEY (or AZURE_OPENAI_API_KEY) not set",
+                    fg=typer.colors.YELLOW,
+                )
+            )
+
+    if not providers:
+        typer.echo("\nNo providers available — set ANTHROPIC_API_KEY / OPENAI_API_KEY / AZURE_API_KEY and retry.")
+        # Cube-harness smoke contract: final line is `SMOKE OK|FAIL|SKIP: <name>`.
+        # Exit 2 = SKIP. Even if the validator failed, we cannot exercise the
+        # full behaviour without a provider, so SKIP is the correct outcome here.
+        typer.echo("SMOKE SKIP: reasoning")
+        raise typer.Exit(2)
+
+    for p in providers:
+        out = run_provider(p)
+        all_results.extend(out.results)
+
+    passed = sum(1 for r in all_results if r.passed)
+    total = len(all_results)
+    typer.echo()
+    typer.echo(f"Summary: {passed}/{total} checks passed.")
+    if passed == total:
+        typer.echo("SMOKE OK: reasoning")
+        raise typer.Exit(0)
+    typer.echo("SMOKE FAIL: reasoning")
+    raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/src/cube_harness/agents/genny2.py
+++ b/src/cube_harness/agents/genny2.py
@@ -370,7 +370,10 @@ class Genny2(Agent):
                     self.history.append(self._latest_obs)
                 self.history.append([response])
         else:
-            thoughts = get_reasoning(response) or None
+            # Prefer the model's reasoning trace when available; otherwise fall back
+            # to the response content so non-reasoning agents still surface their
+            # inline ReAct thinking in the trajectory's `thoughts` panel.
+            thoughts = get_reasoning(response) or response.content or None
             if self._latest_obs:
                 self.history.append(self._latest_obs)
             self.history.append([response])

--- a/src/cube_harness/agents/genny2.py
+++ b/src/cube_harness/agents/genny2.py
@@ -42,7 +42,7 @@ from termcolor import colored
 
 from cube_harness.agent import Agent, AgentConfig
 from cube_harness.core import AgentOutput
-from cube_harness.llm import LLM, LLMCall, LLMConfig, Prompt
+from cube_harness.llm import LLM, LLMCall, LLMConfig, Prompt, get_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -130,21 +130,6 @@ def _format_action_list(actions: "list[Action]") -> str:
     """Format a list of actions as a compact text string."""
     parts = [f"{a.name}({', '.join(f'{k}={v!r}' for k, v in a.arguments.items())})" for a in actions]
     return ", ".join(parts) if parts else "no action"
-
-
-def _get_reasoning(response: "Message") -> str:
-    """Extract reasoning text from a response, checking all known fields across providers.
-
-    Checks reasoning_content (OpenAI o-series / Anthropic streaming),
-    then thinking_blocks (Anthropic extended thinking), then falls back to content.
-    """
-    if rc := getattr(response, "reasoning_content", None):
-        return rc
-    blocks = getattr(response, "thinking_blocks", None) or []
-    block_text = " ".join(b.get("thinking", "") for b in blocks if isinstance(b, dict))
-    if block_text:
-        return block_text
-    return response.content or ""
 
 
 def _truncate_message(msg: dict, max_chars: int) -> dict:
@@ -385,7 +370,7 @@ class Genny2(Agent):
                     self.history.append(self._latest_obs)
                 self.history.append([response])
         else:
-            thoughts = _get_reasoning(response) or None
+            thoughts = get_reasoning(response) or None
             if self._latest_obs:
                 self.history.append(self._latest_obs)
             self.history.append([response])
@@ -533,7 +518,7 @@ class Genny2(Agent):
         messages.append({"role": "user", "content": self.config.compact_prompt})
         prompt = Prompt(messages=messages, tools=[])
         response = self.llm(prompt)
-        summary = response.message.content or _get_reasoning(response.message) or ""
+        summary = response.message.content or get_reasoning(response.message) or ""
         llm_call = LLMCall(
             tag="compact",
             llm_config=self.config.llm_config,
@@ -560,7 +545,7 @@ class Genny2(Agent):
         ]
         prompt = Prompt(messages=messages, tools=[])
         response = self.llm(prompt)
-        summary = response.message.content or _get_reasoning(response.message) or ""
+        summary = response.message.content or get_reasoning(response.message) or ""
         llm_call = LLMCall(
             tag="compact",
             llm_config=self.config.llm_config,

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -102,18 +102,23 @@ class Usage(TypedBaseModel):
     total_tokens: int = 0
     cached_tokens: int = 0  # tokens read from cache (cache hit)
     cache_creation_tokens: int = 0  # tokens written to cache (Anthropic)
-    # Provider-reported reasoning/thinking tokens (OpenAI o-series / gpt-5: separate
-    # field; Anthropic: not surfaced — folded into completion_tokens, stays 0 here).
+    # Reasoning/thinking tokens. LiteLLM surfaces these via
+    # completion_tokens_details.reasoning_tokens for both OpenAI o-series/gpt-5
+    # (native field) and Anthropic (normalized from thinking_blocks). They are
+    # ALREADY counted within completion_tokens — do not add separately to a
+    # budget tally or you will double-count.
     reasoning_tokens: int = 0
     cost: float = 0.0  # cost in USD from LiteLLM pricing
 
 
 def get_reasoning(msg: Message) -> str:
-    """Provider-agnostic reasoning text extractor.
+    """Provider-agnostic reasoning text extractor — returns "" when no reasoning emitted.
 
-    Checks reasoning_content (OpenAI o-series / Anthropic streaming),
-    then thinking_blocks (Anthropic extended thinking),
-    then falls back to plain content.
+    Checks reasoning_content (OpenAI o-series / gpt-5; Anthropic streaming) first,
+    then concatenates thinking_blocks (Anthropic extended thinking). Returns the
+    empty string when neither is present — it deliberately does NOT fall back to
+    msg.content, since the final response text is already available on the
+    Message and conflating it with thinking would muddy the contract.
 
     Works on any litellm.Message — including those reconstructed from persisted
     LLMCall.output records, making it the canonical reasoning extractor for both
@@ -122,10 +127,7 @@ def get_reasoning(msg: Message) -> str:
     if rc := getattr(msg, "reasoning_content", None):
         return rc
     blocks = getattr(msg, "thinking_blocks", None) or []
-    text = " ".join(b.get("thinking", "") for b in blocks if isinstance(b, dict))
-    if text:
-        return text
-    return msg.content or ""
+    return " ".join(b.get("thinking", "") for b in blocks if isinstance(b, dict))
 
 
 class LLMResponse(TypedBaseModel):
@@ -315,8 +317,10 @@ class LLM:
         if isinstance(hidden_params, dict):
             cost = safe_float(hidden_params.get("response_cost", 0.0))
 
-        # Reasoning tokens (OpenAI o-series / gpt-5 surface them in completion_tokens_details;
-        # Anthropic folds them into completion_tokens and reports nothing here — stays 0).
+        # Reasoning tokens — LiteLLM normalizes both OpenAI (native field) and
+        # Anthropic (computed from thinking_blocks) into completion_tokens_details.
+        # These are already part of completion_tokens; the separate field is for
+        # telemetry, not for budgeting.
         reasoning_tokens = 0
         completion_details = getattr(usage_data, "completion_tokens_details", None)
         if completion_details:

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -18,7 +18,7 @@ from litellm.exceptions import (
     Timeout,
 )
 from litellm.utils import token_counter
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 # NOTE: Do not set litellm.callbacks = ["otel"] here at module level.
 # When no TracerProvider is configured, litellm falls back to ConsoleSpanExporter
@@ -75,6 +75,16 @@ class LLMConfig(TypedBaseModel):
     # extends across steps as the conversation grows. No-op for non-Anthropic models.
     set_cache_control: Literal["auto"] | None = None
 
+    @model_validator(mode="after")
+    def _check_anthropic_thinking_temperature(self) -> "LLMConfig":
+        """Anthropic extended thinking forbids temperature != 1.0; fail at config time, not API time."""
+        if self.reasoning_effort is not None and _is_anthropic_model(self.model_name) and self.temperature != 1.0:
+            raise ValueError(
+                f"Anthropic extended thinking requires temperature=1.0, got temperature={self.temperature}. "
+                "Either set temperature=1.0 or remove reasoning_effort."
+            )
+        return self
+
     def make(self) -> "LLM":
         """Create LLM instance from config."""
         return LLM(config=self)
@@ -92,7 +102,30 @@ class Usage(TypedBaseModel):
     total_tokens: int = 0
     cached_tokens: int = 0  # tokens read from cache (cache hit)
     cache_creation_tokens: int = 0  # tokens written to cache (Anthropic)
+    # Provider-reported reasoning/thinking tokens (OpenAI o-series / gpt-5: separate
+    # field; Anthropic: not surfaced — folded into completion_tokens, stays 0 here).
+    reasoning_tokens: int = 0
     cost: float = 0.0  # cost in USD from LiteLLM pricing
+
+
+def get_reasoning(msg: Message) -> str:
+    """Provider-agnostic reasoning text extractor.
+
+    Checks reasoning_content (OpenAI o-series / Anthropic streaming),
+    then thinking_blocks (Anthropic extended thinking),
+    then falls back to plain content.
+
+    Works on any litellm.Message — including those reconstructed from persisted
+    LLMCall.output records, making it the canonical reasoning extractor for both
+    live runs and offline trajectory analysis.
+    """
+    if rc := getattr(msg, "reasoning_content", None):
+        return rc
+    blocks = getattr(msg, "thinking_blocks", None) or []
+    text = " ".join(b.get("thinking", "") for b in blocks if isinstance(b, dict))
+    if text:
+        return text
+    return msg.content or ""
 
 
 class LLMResponse(TypedBaseModel):
@@ -100,6 +133,11 @@ class LLMResponse(TypedBaseModel):
 
     message: Message
     usage: Usage
+
+    @property
+    def reasoning_text(self) -> str:
+        """Reasoning/thinking text emitted by the model, provider-agnostic. Empty when none."""
+        return get_reasoning(self.message)
 
 
 def _is_anthropic_model(model_name: str) -> bool:
@@ -277,12 +315,20 @@ class LLM:
         if isinstance(hidden_params, dict):
             cost = safe_float(hidden_params.get("response_cost", 0.0))
 
+        # Reasoning tokens (OpenAI o-series / gpt-5 surface them in completion_tokens_details;
+        # Anthropic folds them into completion_tokens and reports nothing here — stays 0).
+        reasoning_tokens = 0
+        completion_details = getattr(usage_data, "completion_tokens_details", None)
+        if completion_details:
+            reasoning_tokens = safe_int(getattr(completion_details, "reasoning_tokens", 0))
+
         return Usage(
             prompt_tokens=safe_int(getattr(usage_data, "prompt_tokens", 0)),
             completion_tokens=safe_int(getattr(usage_data, "completion_tokens", 0)),
             total_tokens=safe_int(getattr(usage_data, "total_tokens", 0)),
             cached_tokens=cached_tokens,
             cache_creation_tokens=cache_creation_tokens,
+            reasoning_tokens=reasoning_tokens,
             cost=cost,
         )
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -660,9 +660,13 @@ class TestGetReasoning:
         # Precedence: reasoning_content first, since both refer to the same underlying reasoning.
         assert get_reasoning(msg) == "from reasoning_content"
 
-    def test_falls_back_to_content_when_no_reasoning_fields(self) -> None:
+    def test_returns_empty_when_no_reasoning_fields(self) -> None:
+        # Deliberately does NOT fall back to msg.content — the final response
+        # text is already accessible via .message.content; reasoning_text is
+        # strictly about reasoning, so callers can rely on truthiness as a
+        # "did the model think?" signal.
         msg = Message(role="assistant", content="plain answer")
-        assert get_reasoning(msg) == "plain answer"
+        assert get_reasoning(msg) == ""
 
     def test_empty_string_when_nothing_present(self) -> None:
         msg = Message(role="assistant", content=None)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -12,10 +12,13 @@ from cube_harness.llm import (
     LLM,
     LLMCall,
     LLMConfig,
+    LLMResponse,
     Prompt,
+    Usage,
     _build_cache_injection_points,
     _is_anthropic_model,
     _mark_last_tool_for_cache,
+    get_reasoning,
 )
 
 
@@ -78,8 +81,9 @@ class TestLLMConfig:
 
     def test_llm_config_custom_values(self):
         """Test LLMConfig with custom values."""
+        # Non-Anthropic model: the temperature/reasoning_effort validator is Anthropic-specific.
         config = LLMConfig(
-            model_name="claude-3-opus",
+            model_name="gpt-5-mini",
             temperature=0.5,
             max_tokens=10000,
             max_completion_tokens=2048,
@@ -564,3 +568,171 @@ class TestLLMCacheControl:
         assert kwargs["cache_control_injection_points"] == [
             {"location": "message", "index": 1, "control": {"type": "ephemeral"}}
         ]
+
+
+class TestPromptThinkingRoundTrip:
+    """Round-trip invariant: thinking_blocks (+ signature) and reasoning_content survive Prompt coercion.
+
+    Anthropic extended thinking with tool use requires the prior assistant turn's
+    thinking_blocks (including the opaque signature) to be echoed back in the next
+    call. The Prompt validator dumps litellm.Message via model_dump(exclude_none=True);
+    this test locks in that the provider fields make it through.
+    """
+
+    def test_thinking_blocks_survive_prompt_coercion(self) -> None:
+        msg = Message(
+            role="assistant",
+            content="here is my answer",
+            thinking_blocks=[{"type": "thinking", "thinking": "let me think...", "signature": "sig_abc123"}],
+            reasoning_content="let me think...",
+        )
+        prompt = Prompt(messages=[msg], tools=[])
+        coerced = prompt.messages[0]
+
+        assert isinstance(coerced, dict)
+        assert coerced["thinking_blocks"][0]["signature"] == "sig_abc123"
+        assert coerced["thinking_blocks"][0]["thinking"] == "let me think..."
+        assert coerced["thinking_blocks"][0]["type"] == "thinking"
+        assert coerced["reasoning_content"] == "let me think..."
+
+    def test_reasoning_content_alone_survives(self) -> None:
+        msg = Message(role="assistant", content="answer", reasoning_content="step by step...")
+        prompt = Prompt(messages=[msg], tools=[])
+        assert prompt.messages[0]["reasoning_content"] == "step by step..."
+
+
+class TestLLMConfigAnthropicThinkingValidator:
+    """LLMConfig must reject Anthropic + reasoning_effort + temperature != 1.0 at config time."""
+
+    def test_anthropic_thinking_rejects_nonunity_temperature(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="temperature=1.0"):
+            LLMConfig(model_name="claude-sonnet-4-5", temperature=0.7, reasoning_effort="medium")
+
+    def test_anthropic_thinking_accepts_temperature_one(self) -> None:
+        cfg = LLMConfig(model_name="claude-sonnet-4-5", temperature=1.0, reasoning_effort="medium")
+        assert cfg.reasoning_effort == "medium"
+
+    def test_anthropic_no_reasoning_allows_any_temperature(self) -> None:
+        # Without reasoning_effort, Claude can use any temperature.
+        cfg = LLMConfig(model_name="claude-sonnet-4-5", temperature=0.3)
+        assert cfg.temperature == 0.3
+
+    def test_openai_reasoning_allows_nonunity_temperature(self) -> None:
+        # The constraint is Anthropic-specific; OpenAI o-series/gpt-5 are unaffected.
+        cfg = LLMConfig(model_name="gpt-5-mini", temperature=0.5, reasoning_effort="high")
+        assert cfg.temperature == 0.5
+
+    def test_bedrock_claude_also_validated(self) -> None:
+        import pytest
+
+        # _is_anthropic_model covers bedrock/anthropic.* routing too.
+        with pytest.raises(ValueError, match="temperature=1.0"):
+            LLMConfig(model_name="bedrock/anthropic.claude-sonnet-4-5", temperature=0.5, reasoning_effort="low")
+
+
+class TestGetReasoning:
+    """get_reasoning(msg) is the canonical provider-agnostic reasoning extractor."""
+
+    def test_returns_reasoning_content_when_set(self) -> None:
+        msg = Message(role="assistant", content="answer", reasoning_content="my reasoning here")
+        assert get_reasoning(msg) == "my reasoning here"
+
+    def test_returns_thinking_blocks_concatenated_when_no_reasoning_content(self) -> None:
+        msg = Message(
+            role="assistant",
+            content="answer",
+            thinking_blocks=[
+                {"type": "thinking", "thinking": "first thought"},
+                {"type": "thinking", "thinking": "second thought"},
+            ],
+        )
+        assert get_reasoning(msg) == "first thought second thought"
+
+    def test_reasoning_content_takes_precedence_over_thinking_blocks(self) -> None:
+        msg = Message(
+            role="assistant",
+            content="answer",
+            reasoning_content="from reasoning_content",
+            thinking_blocks=[{"type": "thinking", "thinking": "from thinking_blocks"}],
+        )
+        # Precedence: reasoning_content first, since both refer to the same underlying reasoning.
+        assert get_reasoning(msg) == "from reasoning_content"
+
+    def test_falls_back_to_content_when_no_reasoning_fields(self) -> None:
+        msg = Message(role="assistant", content="plain answer")
+        assert get_reasoning(msg) == "plain answer"
+
+    def test_empty_string_when_nothing_present(self) -> None:
+        msg = Message(role="assistant", content=None)
+        assert get_reasoning(msg) == ""
+
+
+class TestLLMResponseReasoningText:
+    """LLMResponse.reasoning_text exposes get_reasoning(message) as a property."""
+
+    def test_reasoning_text_from_reasoning_content(self) -> None:
+        msg = Message(role="assistant", content="answer", reasoning_content="rc here")
+        resp = LLMResponse(message=msg, usage=Usage())
+        assert resp.reasoning_text == "rc here"
+
+    def test_reasoning_text_from_thinking_blocks(self) -> None:
+        msg = Message(
+            role="assistant",
+            content="answer",
+            thinking_blocks=[{"type": "thinking", "thinking": "tb here", "signature": "s"}],
+        )
+        resp = LLMResponse(message=msg, usage=Usage())
+        assert resp.reasoning_text == "tb here"
+
+    def test_reasoning_text_empty_when_none(self) -> None:
+        # When there's no reasoning, the property falls back to content (empty string here).
+        msg = Message(role="assistant", content="")
+        resp = LLMResponse(message=msg, usage=Usage())
+        assert resp.reasoning_text == ""
+
+
+class TestUsageReasoningTokens:
+    """LLM._extract_usage populates reasoning_tokens from completion_tokens_details."""
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_reasoning_tokens_extracted_from_openai_response(
+        self, mock_completion, sample_llm_config, sample_prompt
+    ) -> None:
+        # OpenAI o-series / gpt-5 surface reasoning_tokens under completion_tokens_details.
+        usage = MagicMock(
+            prompt_tokens=100,
+            completion_tokens=200,
+            total_tokens=300,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            prompt_tokens_details=None,
+            completion_tokens_details=MagicMock(reasoning_tokens=42),
+        )
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=usage
+        )
+        llm = LLM(config=sample_llm_config)
+        resp = llm(sample_prompt)
+        assert resp.usage.reasoning_tokens == 42
+        assert resp.usage.completion_tokens == 200
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_reasoning_tokens_zero_when_no_details(self, mock_completion, sample_llm_config, sample_prompt) -> None:
+        # Anthropic does not surface reasoning_tokens separately — folded into completion_tokens.
+        usage = MagicMock(
+            prompt_tokens=50,
+            completion_tokens=80,
+            total_tokens=130,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+        )
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=usage
+        )
+        llm = LLM(config=sample_llm_config)
+        resp = llm(sample_prompt)
+        assert resp.usage.reasoning_tokens == 0


### PR DESCRIPTION
## Summary

Makes reasoning/thinking a first-class concern of the LLM layer so every
agent gets it uniformly — no more per-agent provider fanout, no more
silently-dropped reasoning tokens. Genny2 stops being the special case.

Reasoning models in scope: OpenAI o-series & gpt-5, Anthropic Claude 3.7+/4.x,
Gemini 2.5, Grok 3/4, DeepSeek R1/R2, Qwen3-thinking, Magistral.

## Changes

- **`Usage.reasoning_tokens`** — extracted from
  `completion_tokens_details.reasoning_tokens` when the provider surfaces it.
  Stays 0 on Anthropic (reasoning is folded into `completion_tokens`).
- **`get_reasoning(msg)` + `LLMResponse.reasoning_text`** — canonical extractor
  (precedence: `reasoning_content` > `thinking_blocks` > `content`). Works on
  both live `LLMResponse` and persisted `LLMCall.output`.
- **`LLMConfig` validator** — Anthropic + `reasoning_effort` + `temperature != 1`
  fails at config time, not at API time.
- **Round-trip regression test** — locks in that `Prompt._coerce_messages`
  preserves `thinking_blocks` (incl. `signature`) and `reasoning_content`.
  Required for Anthropic tool-use loops to function with extended thinking.
- **Genny2 migration** — private `_get_reasoning` deleted; all three call sites
  use the shared helper from `cube_harness.llm`. No other agent changes.

## Spec / RFC

- Spec updates: `openspec/specs/llm/spec.md` (Usage, LLMResponse,
  `get_reasoning`, two new invariants, gotchas).
- Full proposal & deltas in `openspec/changes/reasoning-first-class/`.

## Test plan

- [x] `make lint` clean.
- [x] Fast pytest tier (`-m "not slow and not integration and not live_api"`) — 1011/1011 passed locally (+11 new tests).
- [ ] CI: full suite + DCO check on the PR.

## Risks / things to watch

- Anthropic round-trip: `Message.model_dump(exclude_none=True)` keeps
  `thinking_blocks` (with `signature`) — verified empirically, locked in by
  the new test. If a future refactor changes the Message serialization path,
  the test will catch it.
- One pre-existing test (`test_llm_config_custom_values`) was using exactly
  the now-forbidden combo (claude-3-opus + temp=0.5 + reasoning_effort=high)
  as a smoke test; swapped its model to `gpt-5-mini` so it still exercises
  custom values without tripping the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)