### PR TITLE
openspec: auto-cube RFC

### DIFF
--- a/openspec/changes/auto-cube/deltas.md
+++ b/openspec/changes/auto-cube/deltas.md
@@ -2,21 +2,21 @@
 
 Applies to: `openspec/specs/analyze/spec.md` (primary), `openspec/specs/storage/spec.md` (minor).
 
-The seam PR (forward-compat to PR #366) already landed `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories` parameter as no-op extensions. These deltas widen those types into a first-class surface and add the coding-agent driver Protocol, audit pass, and cross-experiment artifacts.
+The seam PR (forward-compat to PR #366) already landed `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories` parameter as no-op extensions. These deltas widen those types into a first-class surface and add the coding-agent driver Protocol, audit pass, benchmark-context sub-agent, and cross-experiment runners.
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/driver.py`
 
-`AgentDriver` Protocol with `run(...)` and `continue_session(...)` async methods returning a `DriverResult` (output text, token counts, cost, duration, observed tool actions, optional LiteLLM proxy URL, optional session id).
+`AgentDriver` Protocol with async `run(...)` and `continue_session(...)` methods returning a `DriverResult` (output text, token counts, cost, duration, observed tool actions, optional LiteLLM proxy URL, optional session id).
 
-Two concrete drivers: `ClaudeCodeSDKDriver` (`max_parallelism=8`, wraps `claude-agent-sdk`) and `TerminalClaudeDriver` (`max_parallelism=2`, wraps `claude -p` via subprocess; reports `cost_usd=0`). Codex driver is a signposted follow-up.
+Two concrete drivers: `ClaudeCodeSDKDriver` (`max_parallelism=8`, wraps `claude-agent-sdk`) and `TerminalClaudeDriver` (`max_parallelism=2`, wraps `claude -p` via subprocess; reports `cost_usd=0`). Codex driver is a follow-up.
 
-Both drivers honour `LITELLM_PROXY_URL` / `LITELLM_PROXY_AUTH_TOKEN` by exporting `ANTHROPIC_BASE_URL` to the underlying SDK/CLI. When unset, they use the SDK/CLI default. The URL (no credentials) is recorded on `DriverResult` and propagates into `judge_metadata.json`.
+Both honour `LITELLM_PROXY_URL` / `LITELLM_PROXY_AUTH_TOKEN` by exporting `ANTHROPIC_BASE_URL` to the underlying SDK/CLI. The URL (no credentials) is recorded on `DriverResult`.
 
 ### Invariants
 
-- `AgentDriver.run` is `async`. `continue_session` raises `NotImplementedError` when unsupported; callers fall back to a fresh `run` with prior context serialised into the prompt.
+- `run` is `async`. `continue_session` raises `NotImplementedError` when unsupported; callers fall back to a fresh `run` with prior context serialised into the prompt.
 - `max_parallelism` is advisory — `judge_experiment` clamps and logs.
 - `DriverResult.cost_usd == 0.0` is a sentinel for "driver does not meter."
 
@@ -24,33 +24,79 @@ Both drivers honour `LITELLM_PROXY_URL` / `LITELLM_PROXY_AUTH_TOKEN` by exportin
 
 ## ADDED — `cube_harness/analyze/judge/use_cases/`
 
-Each subdirectory is a self-contained use case: `recipe.py` (exports `RECIPE: JudgeRecipe`), `SKILL.md` (meta-agent skill), `prompts/`, optional `scripts/`. `__init__.py` walks subdirectories on import and assembles `RECIPE_CATALOG: dict[str, JudgeRecipe]`.
+Each subdirectory is a self-contained use case: `recipe.py` (exports `RECIPE: JudgeRecipe`, with prompts and `OutputModel` declared inline), `SKILL.md` (meta-agent skill), optional `scripts/`. `__init__.py` walks subdirectories on import and assembles `RECIPE_CATALOG: dict[str, JudgeRecipe]`.
 
-Initial directories: `general_blame`, `profiling`, `agent_scaffolding`. Adding a use case is a single PR that drops a new directory; no central registration touched.
+Initial directories: `general_blame`, `profiling`, `agent_scaffolding`. Adding a use case is a single PR.
 
-A small script (`scripts/sync_judge_skills.py`) symlinks each `SKILL.md` into `.claude/skills/judge-<name>` so the meta-agent reads a single source of truth.
+A small script (`scripts/sync_judge_skills.py`) symlinks each `SKILL.md` into `.claude/skills/judge-<name>`.
 
 ### Invariants
 
 - Recipe `name` equals directory name.
-- Importing a use-case module performs no network or filesystem I/O beyond Pydantic field validation.
-- Recipes serialise to JSON without custom serialisers (no driver/selector fields).
+- Importing a use-case module performs no I/O beyond Pydantic field validation.
+- Each `OutputModel` extends a shared `BaseJudgeOutput` carrying the cross-recipe core fields (`primary_blame`, `outcome`, `primary_blame_confidence`).
+
+---
+
+## ADDED — `cube_harness/analyze/judge/recipe.py` widening
+
+`JudgeRecipe` (seam PR landed `name`, `system_prompt`, `model`, `allowed_tools`) gains:
+
+- `user_prompt_template: str`
+- `output_model: type[TypedBaseModel]` — per-recipe output schema (extends `BaseJudgeOutput`)
+- `audit: bool = False`
+- `permission_mode: Literal["bypassPermissions", "ask"]`
+
+`allowed_tools` tightens from `list[str] | None` to `tuple[str, ...]`.
+
+**No `driver` or `selector` field.** Both are call-time arguments. **No `post_judge_survey` field** — survey is folded into the audit pass.
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/audit.py`
 
-Flag-gated audit pass. `run_audit_pass(...)` calls `driver.continue_session` with an audit prompt; falls back to `driver.run` when continuation is unsupported. Writes `audit.json` next to `judge_output.json` with fields covering `verdict` (`sound`/`questionable`/`wrong`), `reasoning_quality`, `missed_evidence`, and any `alternative_blames`.
+Single unified self-evaluation pass (replaces both the previous `self_judge` recipe and the separate `post_judge_survey`).
 
-Schema versioned via a `schema_version: int` field on `AuditOutput`, mirroring the existing `JUDGE_SCHEMA_VERSION` convention.
+`AuditOutput`:
+- `schema_version: int = 1`
+- `recipe: str`, `driver: str`
+- `verdict: Literal["sound", "questionable", "wrong"]`
+- `reasoning_quality: int` (0-5)
+- `ease_of_analysis: int` (0-5)
+- `context_quality: int` (0-5)
+- `tooling_gaps: list[str]`
+- `missed_evidence: list[str]`
+- `alternative_blames: list[BlameAlternative]`
+- `notes: str | None`
+
+`run_audit_pass(...)` calls `driver.continue_session` with the audit prompt; falls back to `driver.run` when continuation is unsupported. Writes `audit.json` next to `judge_output.json`.
+
+The previous separate `post_judge_survey.json` file is **removed from scope** — its fields move into `audit.json`.
+
+---
+
+## ADDED — `cube_harness/analyze/judge/benchmark_context_agent.py`
+
+Sub-agent that auto-generates `<experiment_dir>/judge_context.md` when missing.
+
+- Default model: `"claude-opus-4-7"`.
+- Runs through the same `AgentDriver` interface as the judge itself.
+- System prompt instructs the agent to walk `experiment_config.json`, identify the cube package, agent package, and `cube_harness` source dir, and emit a `\`\`\`paths` fenced block matching the format `validate_context_file` already parses.
+- Called automatically from `_judge_episode_impl` when `find_default_context_file(experiment_dir)` raises.
+- Surfaced via `ch-judge init-context <experiment_dir>` for explicit/ad-hoc use.
+
+### Invariants
+
+- The sub-agent's output is parsed by the existing `_PATHS_FENCE_RE` regex; no new marker format introduced.
+- Every path in the emitted block is verified to exist locally before the judge proceeds; missing paths raise `FileNotFoundError`.
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/selection.py` (Selector extensions)
 
-`Selector` Protocol with `select(*, main_episode, experiment_dir, all_refs) -> list[Path]`. Three built-in selectors: `SameTaskDifferentAgent`, `SameAgentPreviousIteration`, `TopKBySimilarityStub`.
+`Selector` Protocol with `select(*, main_episode, experiment_dir, all_refs) -> list[Path]`. Three built-in selectors: `SameTaskDifferentAgent`, `SameAgentPreviousIteration`, `TopKBySimilarityStub` (real similarity scorer is a follow-up).
 
-Selectors are call-time arguments to `judge_episode` / `judge_experiment`, not recipe fields. Existing `EpisodeRef` / `discover_episodes` / `select_episodes` helpers are unchanged.
+Selectors are call-time arguments. Existing `EpisodeRef` / `discover_episodes` / `select_episodes` helpers are unchanged.
 
 ### Invariants
 
@@ -61,48 +107,58 @@ Selectors are call-time arguments to `judge_episode` / `judge_experiment`, not r
 
 ## ADDED — `cube_harness/analyze/cross_experiment/`
 
-Two schema-only files in this PR (runners ship as follow-ups):
+**Runners ship in this PR**, not just schemas (per design feedback).
 
-- `joint_csv.py` — `JOINT_REPORT_FILENAME = "joint_judge_report.csv"`, fixed column list including `driver`, `recipe`, and `litellm_proxy_url`. `write_joint_csv(...)` declared with `NotImplementedError`.
-- `cross_judge_agreement.py` — `AGREEMENT_REPORT_FILENAME = "cross_judge_agreement.csv"`, fixed column list keyed by `(trajectory_id, recipe)` with a `seeds` column. **Single recipe, varying seeds only** — cross-recipe comparison is out of scope for this artifact. `write_cross_judge_agreement(...)` declared with `NotImplementedError`.
+### `joint_csv.py`
+
+`write_joint_csv(sweep_dir: Path, *, experiment_dirs: Sequence[Path] | None = None) -> Path`
+
+Walks experiment directories, reads each `experiment_judge_report.csv` plus `cross_judge_agreement.csv` if present, writes one row per `(experiment, episode)` to `<sweep_dir>/joint_judge_report.csv`. Atomic write.
+
+`JOINT_REPORT_COLUMNS` includes per-experiment columns plus `experiment_id`, `family_id`, `agent_dotted`, `benchmark_dotted`, `driver`, `recipe`, `litellm_proxy_url`, and joined cross-judge columns.
+
+### `cross_judge_agreement.py`
+
+Implementation invoked by `judge_experiment(..., n_seeds=N)`. Re-runs the judge N times per selected episode with the **same recipe** at varying seeds, then writes `cross_judge_agreement.csv` keyed by `(trajectory_id, recipe)` with columns `seeds`, `primary_blame_modal`, `primary_blame_agreement`, `outcome_modal`, `outcome_agreement`, `confidence_mean`.
 
 ### Invariants
 
 - Joint CSV: one row per `(experiment_id, trajectory_id)`; atomic write.
 - Agreement CSV: one row per `(trajectory_id, recipe)` with `n_judgments >= 2`; agreements in `[0, 1]`.
+- Cross-judge runs **same recipe, different seeds** — cross-recipe comparison is out of scope for this artifact.
 
 ---
 
-## MODIFIED — `cube_harness/analyze/judge/recipe.py`
+## ADDED — `experiment_judge_report.json`
 
-`JudgeRecipe` gains `user_prompt_template: str`, `audit: bool = False`, `post_judge_survey: bool = True`, `permission_mode: Literal["bypassPermissions", "ask"]`. `allowed_tools` tightens from `list[str] | None` to `tuple[str, ...]`.
-
-**Does NOT gain `driver` or `selector` fields** — both are call-time arguments. No `DRIVER_REGISTRY`.
-
-`DEFAULT_RECIPE` is re-exported from `use_cases/general_blame/recipe.py`.
+Aggregate report alongside the existing `experiment_judge_report.csv` (PR #366). Same per-episode rows but preserves the per-recipe `OutputModel` shape (the CSV flattens to the base schema). Written by the same code path that writes the CSV.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/core.py`
 
-`judge_episode` and `judge_experiment` gain `recipe`, `driver`, `selector`, `audit` keyword arguments; lose `model` (now part of the recipe). `n_parallel` is clamped to `driver.max_parallelism` with a log line.
+`judge_episode` and `judge_experiment` gain `recipe`, `driver`, `selector`, `audit`, `n_seeds` keyword arguments; lose `model` (now part of recipe). `n_parallel` clamps to `driver.max_parallelism` with a log line.
 
 `_judge_episode_impl`:
-- Calls `find_default_context_file(experiment_dir)` and `validate_context_file(...)`. **Raises** `FileNotFoundError` if the context file is missing or any path doesn't resolve. No fallback to `collect_source_paths`.
+- Calls `find_default_context_file(experiment_dir)`. If missing, invokes `benchmark_context_agent.generate(experiment_dir, driver=...)` to create it. Then calls `validate_context_file(...)`. Raises if any path doesn't resolve.
 - Calls `selector.select(...)` when a selector is provided.
 - Calls `driver.run(...)` instead of `_run_claude_code(...)`.
-- Runs the survey pass when `recipe.post_judge_survey` is True; writes `post_judge_survey.json`.
-- Runs the audit pass when `audit or recipe.audit`; writes `audit.json`.
+- When `audit or recipe.audit`, calls `audit.run_audit_pass(...)` and writes `audit.json`. **No separate survey pass.**
+- Parses output against `recipe.output_model`, not a hardcoded `JudgeOutput`.
 
-Aggregate cost in `experiment_judge_summary.json` excludes survey and audit costs by default; additive `total_survey_cost_usd` and `total_audit_cost_usd` fields are appended.
+`judge_experiment` runs the cross-judge loop when `n_seeds > 1` and writes `cross_judge_agreement.csv`. Always writes both `experiment_judge_report.csv` and `experiment_judge_report.json`.
+
+Aggregate cost in `experiment_judge_summary.json` excludes audit cost by default; an additive `total_audit_cost_usd` field is appended.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/context.py`
 
-`find_default_context_file(experiment_dir: Path) -> Path` returns `experiment_dir / "judge_context.md"` and raises if absent.
+`find_default_context_file(experiment_dir: Path) -> Path` returns `experiment_dir / "judge_context.md"` and raises if absent. Used by `_judge_episode_impl` to decide whether to invoke the benchmark-context sub-agent.
 
-`collect_source_paths` continues to exist as the implementation of the new `ch-judge init-context` subcommand. It is **no longer called by the judge's runtime path**.
+`collect_source_paths` is **removed**. Its behaviour is superseded by the benchmark-context sub-agent for the auto-generation path and is no longer called at judge time.
+
+`validate_context_file` (already seamed) is now the only context resolver in the judge's hot path. No signature change.
 
 ---
 
@@ -114,24 +170,28 @@ Aggregate cost in `experiment_judge_summary.json` excludes survey and audit cost
 
 ## MODIFIED — `cube_harness/analyze/judge/cli.py`
 
-New flags: `--recipe NAME`, `--driver {claude-code-sdk,claude-terminal}`, `--audit`, `--no-survey`. The `--model` flag is removed; a backwards-compatibility shim accepts it with a deprecation warning.
+New flags: `--recipe NAME`, `--driver {claude-code-sdk,claude-terminal}`, `--audit`, `--n-seeds N`. The `--model` flag is removed; backwards-compatibility shim accepts it with a deprecation warning.
 
-New subcommand: `ch-judge init-context <experiment_dir>` walks `experiment_config.json` and writes a starter `judge_context.md` (paths fence only).
+`--no-survey` is **not added** — survey is folded into the audit pass; toggle via `--audit` instead.
+
+New subcommand: `ch-judge init-context <experiment_dir>` invokes the benchmark-context sub-agent explicitly (same code path as the auto-generation hook).
 
 ---
 
 ## MODIFIED — `openspec/specs/analyze/spec.md`
 
-Adds a "Judge subsystem" section documenting: the use-case directory layout, `JudgeRecipe` (with driver/selector as call-time arguments), the `AgentDriver` Protocol and its two concrete drivers, LiteLLM proxy routing, the required-context-file contract, the post-judge survey, the audit pass, the CLI surface, and the cross-experiment artifact schemas.
+Adds a "Judge subsystem" section documenting: the use-case directory layout (`recipe.py` + `SKILL.md` + optional `scripts/`), `JudgeRecipe` (with per-recipe `OutputModel`, no driver/selector fields), the `AgentDriver` Protocol and its two concrete drivers, LiteLLM proxy routing, the benchmark-context sub-agent, the merged audit pass, the cross-judge runner, the joint-CSV runner, and the CLI surface. Also notes that batch results are written in both CSV and JSON.
 
 ---
 
 ## MODIFIED — `openspec/specs/storage/spec.md`
 
-One additive sentence under the experiment-root artifacts table covering `joint_judge_report.csv`, `cross_judge_agreement.csv`, and the per-episode `audit.json` when audit is enabled. No change to `EpisodeRecord`.
+One additive sentence under the experiment-root artifacts table covering `experiment_judge_report.json`, `cross_judge_agreement.csv`, the per-episode `audit.json` when audit is enabled, and the sweep-level `joint_judge_report.csv`. No change to `EpisodeRecord`.
 
 ---
 
 ## NOT CHANGED
 
-`JudgeOutput`, `JudgeMetadata`, `EpisodeRecord`, `Storage` Protocol, `Episode`, `Experiment`, `exp_runner`, `Trajectory`, `LLM`, `meta_agent/recipes/`, `.claude/commands/meta-agent.md`, cube-standard.
+`JudgeMetadata`, `EpisodeRecord`, `Storage` Protocol, `Episode`, `Experiment`, `exp_runner`, `Trajectory`, `LLM`, `meta_agent/recipes/`, `.claude/commands/meta-agent.md`, cube-standard.
+
+`JudgeOutput` is renamed to `BaseJudgeOutput` and becomes the parent class of each recipe's `OutputModel`. The `general_blame` recipe's `OutputModel` is identical to today's `JudgeOutput` (preserving on-disk compatibility for the default path).

--- a/openspec/changes/auto-cube/deltas.md
+++ b/openspec/changes/auto-cube/deltas.md
@@ -1,0 +1,393 @@
+# Deltas: Auto-CUBE
+
+Applies to: `openspec/specs/analyze/spec.md` (primary), `openspec/specs/storage/spec.md` (minor), `openspec/specs/experiment/spec.md` (minor, joint-CSV pointer).
+
+The seam PR (forward-compat to PR #366) already landed `JudgeRecipe`,
+`PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories`
+parameter as no-op extensions. These deltas widen those types into a
+first-class surface and add the coding-agent driver Protocol, selector
+Protocol, audit pass, cross-experiment artifacts, and the use-case
+directory layout.
+
+Revision 2 (2026-05-13) reflects design-review feedback:
+- Driver moves from recipe field to call-time argument.
+- Context file becomes required (no `collect_source_paths` fallback).
+- `self_judge` recipe replaced with a flag-gated audit pass.
+- Initial use-case catalog is three (not six).
+- LiteLLM proxy integration documented per PS-002.
+- Recipe directory layout becomes one-dir-per-use-case under `use_cases/`.
+
+---
+
+## ADDED — `cube_harness/analyze/judge/driver.py`
+
+### Public types
+
+- `TraceMode` — `Literal["actions", "full", "off"]` (moved from `sdk.py`; the
+  literal is re-exported from `sdk.py` for backwards compatibility).
+- `ToolAction` — `TypedBaseModel(tool: str, input_summary: str, raw_input: dict[str, Any] | None)`.
+  Replaces today's untyped `dict[str, Any]` entries in the `actions` list returned by
+  `_run_claude_code`. Pydantic serialisation maps cleanly into `judge_trace.json`.
+- `DriverResult` — `TypedBaseModel(output_text, prompt_tokens, completion_tokens, cost_usd, duration_s, actions: list[ToolAction], litellm_proxy_url: str | None = None, session_id: str | None = None)`.
+  The driver-shaped result; consumed by `_judge_episode_impl` to build `JudgeMetadata` and `judge_trace.json`.
+  `litellm_proxy_url` is set when `LITELLM_PROXY_URL` was honoured. `session_id` is set when the driver supports `continue_session` (used by the audit pass).
+- `AgentDriver` — `Protocol` with attributes `name: str`, `max_parallelism: int`, and methods:
+  - `async def run(*, system_prompt, user_prompt, cwd, additional_dirs, model, allowed_tools, verbose=False, trace_mode="actions") -> DriverResult`.
+  - `async def continue_session(*, follow_up_prompt, verbose=False, trace_mode="actions") -> DriverResult`. Drivers without continuation raise `NotImplementedError`; the audit pass falls back to a fresh `run` with the prior judgment serialised into the prompt.
+- `ClaudeCodeSDKDriver` — concrete `AgentDriver` wrapping `claude-agent-sdk`.
+  `name = "claude-code-sdk"`, `max_parallelism = 8`. Refactor of today's `_run_claude_code` into the Protocol shape; bit-identical observable behaviour when called from `_judge_episode_impl` for the `general_blame` recipe.
+- `TerminalClaudeDriver` — concrete `AgentDriver` wrapping the `claude` CLI via `asyncio.subprocess`.
+  `name = "claude-terminal"`, `max_parallelism = 2`. `cost_usd` and token counts are reported as `0`. JSON extraction reuses `analyze.judge.sdk._extract_json_block`. `continue_session` uses `claude --continue` against the most recent session ID.
+
+### LiteLLM proxy routing (PS-002)
+
+Both concrete drivers honour `LITELLM_PROXY_URL` and `LITELLM_PROXY_AUTH_TOKEN` env vars:
+
+- When `LITELLM_PROXY_URL` is set, the driver exports `ANTHROPIC_BASE_URL=$LITELLM_PROXY_URL` and the matching auth header before invoking the SDK / CLI subprocess. The SDK / CLI then routes through the LiteLLM proxy, which itself routes to Anthropic / Bedrock / Vertex / Azure per the LiteLLM config.
+- When unset, the driver falls back to the SDK / CLI default (direct Anthropic). API-key-based developer flows are unchanged.
+- The driver records `litellm_proxy_url` (URL only, no credentials) on `DriverResult`. This propagates into `judge_metadata.json` and the joint CSV's `litellm_proxy_url` column.
+
+### Invariants
+
+- `AgentDriver.run` MUST be implemented as `async def`. Synchronous wrappers belong in callers.
+- `AgentDriver.continue_session` MUST raise `NotImplementedError` when not supported (rather than returning a stub result).
+- `max_parallelism` is advisory. `judge_experiment(n_parallel=...)` clamps against `driver.max_parallelism` and logs the clamp.
+- `DriverResult.actions` MUST be empty when `trace_mode == "off"`.
+- `DriverResult.cost_usd` of `0.0` is a documented sentinel for "driver does not report cost"; the joint CSV's `driver` column lets consumers scope summations to metered drivers.
+- Drivers MUST NOT log credentials when `LITELLM_PROXY_AUTH_TOKEN` is in the environment.
+
+---
+
+## ADDED — `cube_harness/analyze/judge/use_cases/`
+
+A package containing one subdirectory per judge use case. Each subdirectory contains the
+recipe, a `SKILL.md` for the meta-agent, prompt templates, and any supporting scripts.
+
+### Layout
+
+```
+use_cases/
+├── __init__.py           # exports RECIPE_CATALOG; walks subdirectories on import
+├── general_blame/
+│   ├── __init__.py
+│   ├── recipe.py         # exports RECIPE: JudgeRecipe
+│   ├── SKILL.md          # meta-agent skill description
+│   ├── prompts/
+│   │   ├── system.md
+│   │   ├── user.md
+│   │   └── audit.md      # shared by all use cases via symlink in V1
+│   └── scripts/          # optional helper scripts (empty here)
+├── profiling/
+│   ├── __init__.py
+│   ├── recipe.py
+│   ├── SKILL.md
+│   ├── prompts/
+│   │   ├── system.md
+│   │   └── user.md
+│   └── scripts/
+│       └── summarise_profile.py
+└── agent_scaffolding/
+    ├── __init__.py
+    ├── recipe.py
+    ├── SKILL.md
+    ├── prompts/
+    │   ├── system.md
+    │   └── user.md
+    └── scripts/
+```
+
+### Public types
+
+- `RECIPE_CATALOG: dict[str, JudgeRecipe]` — name → recipe. Imported and used by the CLI's `--recipe NAME` flag and by `judge_episode(..., recipe=...)`. Assembled by `__init__.py` walking subdirectories and importing each `recipe.py`'s `RECIPE` constant.
+
+### Public recipes (Pydantic instances)
+
+- `general_blame: JudgeRecipe` — current default. Identical observable behaviour to today.
+- `profiling: JudgeRecipe` — narrower taxonomy, profiling-focused user-prompt template, `BashOutput` added to `allowed_tools`. Activated by the meta-agent when an experiment is flagged `profiling=True`.
+- `agent_scaffolding: JudgeRecipe` — deeper agent-failure ontology. Output schema extends `JudgeOutput` with a sibling field `scaffold_diagnosis: ScaffoldDiagnosis | None` (default `None`; non-breaking for other recipes).
+
+`hint_harvest`, `auto_verified`, and any other use cases are deferred to follow-up PRs (one directory per PR).
+
+### `SKILL.md` registration
+
+A small script (`scripts/sync_judge_skills.py`, committed in this PR) creates symlinks at `.claude/skills/judge-<name> -> src/cube_harness/analyze/judge/use_cases/<name>/SKILL.md`. The meta-agent reads the symlinked files; the source of truth is the use-case directory.
+
+### Invariants
+
+- Every recipe in `RECIPE_CATALOG` has a unique `name` field equal to its directory name.
+- Each `use_cases/<name>/recipe.py` exports exactly one module-level `RECIPE: JudgeRecipe`.
+- Each `use_cases/<name>/SKILL.md` exists and is non-empty.
+- A recipe's `model` SHOULD be a string accepted by both `ClaudeCodeSDKDriver` and `TerminalClaudeDriver`.
+- Recipes are pure data: importing the use-case module MUST NOT trigger network or filesystem I/O beyond what Pydantic does to validate field defaults.
+
+---
+
+## ADDED — `cube_harness/analyze/judge/audit.py`
+
+The flag-gated audit pass.
+
+### Public types
+
+- `AuditOutput` — `TypedBaseModel(schema_version=1, recipe, driver, reasoning_quality: int [0..5], missed_evidence: list[str], alternative_blames: list[BlameAlternative], verdict: Literal["sound", "questionable", "wrong"], notes: str | None)`.
+- `BlameAlternative` — `TypedBaseModel(blame: str, rationale: str)`.
+- `AUDIT_FILENAME = "audit.json"`.
+
+### Public functions
+
+- `run_audit_pass(*, recipe: JudgeRecipe, driver: AgentDriver, judge_output: JudgeOutput, judge_trace_path: Path, survey_path: Path, audit_prompt: str) -> AuditOutput` — issues `driver.continue_session(follow_up_prompt=audit_prompt)` and parses the result. Falls back to `driver.run(...)` with the prior judgment serialised into the user prompt when `continue_session` raises `NotImplementedError`.
+
+### Invariants
+
+- `AuditOutput.schema_version` is fixed at `1` for this RFC; subsequent schema changes increment the integer in lockstep with `JUDGE_SCHEMA_VERSION` semantics.
+- `AuditOutput.alternative_blames` is empty when `verdict == "sound"`.
+- `audit.json` is written next to `judge_output.json` and only when the audit pass is enabled.
+
+---
+
+## ADDED — `cube_harness/analyze/judge/selection.py` (extensions)
+
+The existing module gains a `Selector` Protocol and three built-in selectors. Existing public functions (`discover_episodes`, `select_episodes`, `_load_episode_record`, `EpisodeRef`) are unchanged.
+
+### Public types
+
+- `Selector` — `Protocol` with `name: str`, `k: int`, and `def select(*, main_episode: EpisodeRef, experiment_dir: Path, all_refs: Sequence[EpisodeRef]) -> list[Path]`.
+- `SameTaskDifferentAgent` — `Selector` implementation; returns up to `k` episode paths from sibling experiments that share the main episode's `task_id` but differ on `agent_config._type`.
+- `SameAgentPreviousIteration` — `Selector` implementation; returns up to `k` predecessor episodes from the same `family_id`.
+- `TopKBySimilarityStub` — `Selector` implementation; returns `k` most-recent neighbours by directory mtime. Placeholder for a real scorer.
+
+### Invariants
+
+- `Selector.select` MUST NOT return paths that resolve to `main_episode.episode_dir`.
+- Returned paths MUST exist on disk (selectors filter their candidates accordingly).
+- The list length is bounded by `k`; selectors return fewer when fewer candidates qualify.
+
+---
+
+## ADDED — `cube_harness/analyze/cross_experiment/joint_csv.py`
+
+Schema-only in the first PR; the runner that walks a sweep directory and writes the file ships in a follow-up.
+
+### Public types
+
+- `JOINT_REPORT_FILENAME = "joint_judge_report.csv"`
+- `JOINT_REPORT_COLUMNS: tuple[str, ...]` — fixed column order, listed in the proposal. Includes `litellm_proxy_url` and `driver` columns alongside the per-experiment columns from PR #366.
+
+### Public functions
+
+- `write_joint_csv(sweep_dir: Path, *, experiment_dirs: Sequence[Path] | None = None) -> Path` — declared in this PR with a `raise NotImplementedError("ships in follow-up PR")` body so callers and tests can be wired up. The schema is normative.
+
+### Invariants
+
+- Exactly one row per `(experiment_id, trajectory_id)`.
+- All columns in `JOINT_REPORT_COLUMNS` are present even when empty (empty string for missing cross-judge columns).
+- The file is written atomically (write to `.tmp`, rename).
+
+---
+
+## ADDED — `cube_harness/analyze/cross_experiment/cross_judge_agreement.py`
+
+Schema-only in the first PR; the runner ships in a follow-up. **Single recipe, multiple seeds** (revision 2): agreement is per `(recipe, trajectory)` pair across seeds, not across recipes.
+
+### Public types
+
+- `AGREEMENT_REPORT_FILENAME = "cross_judge_agreement.csv"`
+- `AGREEMENT_COLUMNS: tuple[str, ...]` — fixed column order: `trajectory_id`, `recipe`, `n_judgments`, `seeds`, `primary_blame_modal`, `primary_blame_agreement`, `outcome_modal`, `outcome_agreement`, `confidence_mean`.
+
+### Public functions
+
+- `write_cross_judge_agreement(experiment_dir: Path, *, judgments: dict[tuple[str, str], list[tuple[JudgeOutput, JudgeMetadata]]]) -> Path` — declared with `NotImplementedError` body. The dict is keyed by `(trajectory_id, recipe_name)`; each value is the list of seed-varying judgments for that pair. Schema is normative.
+
+### Invariants
+
+- One row per `(trajectory_id, recipe)` pair with `n_judgments >= 2`. Single-judgment pairs do not appear.
+- `primary_blame_agreement` and `outcome_agreement` are in `[0.0, 1.0]`.
+- `seeds` column is semicolon-separated.
+- The runner only re-judges with the **same recipe** at different seeds; cross-recipe agreement is explicitly out of scope for this artifact.
+
+---
+
+## MODIFIED — `cube_harness/analyze/judge/recipe.py`
+
+The seam PR landed `JudgeRecipe(name, system_prompt, model, allowed_tools)`. Auto-CUBE widens the fields and tightens types.
+
+### Public types
+
+- `JudgeRecipe` gains fields:
+  - `user_prompt_template: str` — `.format()`-style template; the same kwargs that `analyze.judge.prompt.build_user_prompt` accepts.
+  - `audit: bool` — default `False`. Gates the audit pass (which can also be enabled at call time via `--audit`).
+  - `post_judge_survey: bool` — default `True`. When `False`, the second-pass survey is skipped and `post_judge_survey.json` is written with `recipe=<name>`, `schema_version=1`, all other fields `None`/empty.
+  - `permission_mode: Literal["bypassPermissions", "ask"]` — default `"bypassPermissions"`.
+  - `allowed_tools: tuple[str, ...]` — change from `list[str] | None` to `tuple[str, ...]`. Default `("Read", "Glob", "Grep", "Bash")`. The `None` shape from the seam PR is no longer valid (was a placeholder while the field was unplumbed); migration is mechanical because no production caller passes `None` today.
+
+### NOT added (revision 2)
+
+- **`driver` field is NOT added to `JudgeRecipe`.** Drivers are call-time arguments, not recipe fields. This kills the need for a `DRIVER_REGISTRY` (recipes never reference drivers, so JSON serialisation is straightforward Pydantic; no custom serialiser).
+- **`selector` field is NOT added to `JudgeRecipe`.** Selectors are call-time arguments, mirroring driver placement.
+
+### Invariants
+
+- `JudgeRecipe.allowed_tools` is non-empty.
+- `JudgeRecipe` serialises to JSON without custom serialisers.
+
+### Public constants
+
+- `DEFAULT_RECIPE` — unchanged identity (still the `general_blame` recipe), but now imported from `analyze/judge/use_cases/general_blame/recipe.py` rather than defined inline. `analyze/judge/recipe.py` re-exports it.
+
+---
+
+## MODIFIED — `cube_harness/analyze/judge/core.py`
+
+### `judge_episode` signature
+
+Adds `recipe: JudgeRecipe | None = None`, `driver: AgentDriver | None = None`, `selector: Selector | None = None`, `audit: bool = False`. When `recipe is None`, `DEFAULT_RECIPE` is used; when `driver is None`, `ClaudeCodeSDKDriver()` is constructed. `audit=True` enables the audit pass for this call (overrides `recipe.audit=False`).
+
+```python
+def judge_episode(
+    episode_dir: Path,
+    *,
+    experiment_dir: Path | None = None,
+    recipe: JudgeRecipe | None = None,
+    driver: AgentDriver | None = None,
+    selector: Selector | None = None,
+    audit: bool = False,
+    verbose: bool = False,
+    trace_mode: TraceMode = "actions",
+) -> tuple[JudgeOutput, JudgeMetadata]: ...
+```
+
+The `model: str = DEFAULT_MODEL` kwarg is **removed**: model is part of the recipe. A deprecation note in the function docstring tells callers to migrate to `recipe=`.
+
+The `context_file: Path | None = None` parameter from revision 1 is **removed**: the context file is no longer optional. Its location is derived from `experiment_dir` (or from the `episode_dir`'s parent when `experiment_dir` is `None`) by `find_default_context_file`. If the file is missing, `_judge_episode_impl` raises `FileNotFoundError`.
+
+### `judge_experiment` signature
+
+Adds `recipe: JudgeRecipe | None = None`, `driver: AgentDriver | None = None`, `selector: Selector | None = None`, `audit: bool = False`. Drops `model: str`.
+
+```python
+def judge_experiment(
+    experiment_dir: Path,
+    *,
+    recipe: JudgeRecipe | None = None,
+    driver: AgentDriver | None = None,
+    selector: Selector | None = None,
+    audit: bool = False,
+    ids: list[str] | None = None,
+    sample: float | None = None,
+    n: int | None = None,
+    failures_only: bool = False,
+    overwrite: bool = False,
+    seed: int | None = None,
+    verbose: bool = False,
+    n_parallel: int = 1,
+    trace_mode: TraceMode = "actions",
+) -> dict[str, tuple[JudgeOutput, JudgeMetadata]]: ...
+```
+
+`n_parallel` is silently clamped to `driver.max_parallelism` with a single info-level log line.
+
+### `_judge_episode_impl` (internal)
+
+- Accepts `recipe: JudgeRecipe`, `driver: AgentDriver`, `selector: Selector | None`, and `audit: bool`.
+- Calls `find_default_context_file(experiment_dir)` and then `validate_context_file(...)`. Raises `FileNotFoundError` if the file is missing or any referenced path does not resolve. **No fallback to `collect_source_paths`.**
+- Calls `selector.select(...)` when `selector is not None`, and passes the returned related-trajectory paths to the user-prompt template (the template's `{related_trajectories}` placeholder is added; `general_blame` ignores it).
+- Calls `driver.run(...)` instead of `_run_claude_code(...)` directly.
+- After parsing `JudgeOutput`, when `recipe.post_judge_survey` is `True`, runs a second `driver.run(...)` pass with the survey prompt, parses the result against `PostJudgeSurvey`, and writes `post_judge_survey.json` next to `judge_trace.json`.
+- When `audit or recipe.audit`, runs `audit.run_audit_pass(...)` and writes `audit.json` next to `judge_output.json`.
+
+### Invariants (unchanged from PR #366)
+
+- `_validate_invariants(judge_output)` runs unchanged.
+- `_persist_judgment` writes `judge_output` and `judge_metadata` into `episode_record.json` or a sidecar.
+- Aggregate cost in `experiment_judge_summary.json` excludes survey-pass and audit-pass cost by default; additive `total_survey_cost_usd` and `total_audit_cost_usd` fields are appended so consumers can opt in.
+
+---
+
+## MODIFIED — `cube_harness/analyze/judge/context.py`
+
+`validate_context_file` is already present (seam PR). Auto-CUBE promotes it from "available when called" to "called by default and required". Helper additions:
+
+- `find_default_context_file(experiment_dir: Path) -> Path` — returns `experiment_dir / "judge_context.md"`. Raises `FileNotFoundError` when the file is absent. Used by `_judge_episode_impl`.
+
+### REMOVED — `collect_source_paths` from the judge's hot path
+
+`collect_source_paths` continues to exist as the implementation of `ch-judge init-context` (it walks the venv to bootstrap a starter `judge_context.md`). It is **not** called by `_judge_episode_impl` any more. The judge's runtime path is exclusively through `validate_context_file`.
+
+### Invariants
+
+- `validate_context_file` raises `FileNotFoundError` on any missing referenced path. The judge MUST surface this — it is an outer-loop bug, not a judge-time fallback condition.
+- `find_default_context_file` is the only place the filename `judge_context.md` is hardcoded.
+
+---
+
+## MODIFIED — `cube_harness/analyze/judge/sdk.py`
+
+The free function `_run_claude_code` is **deleted** after its body is moved into `ClaudeCodeSDKDriver.run`. The module retains:
+
+- `_extract_json_block` (still imported by `core.py` and reused by the terminal driver).
+- `_summarise_tool_input` (used by both drivers to populate `ToolAction.input_summary`).
+- `TraceMode`, `JUDGE_ALLOWED_TOOLS` re-exported for backwards compatibility.
+
+### Invariants
+
+- `_extract_json_block`'s public behaviour is unchanged.
+- `_summarise_tool_input` is moved here from `sdk.py` (where it already lives) and made driver-agnostic.
+
+---
+
+## MODIFIED — `cube_harness/analyze/judge/cli.py`
+
+The CLI gains four flags and one subcommand. Existing flags (`--summary`, `--overwrite`, `--ids`, `--sample`, `--n`, `--failures-only`, `--seed`, `--verbose`, `--n-parallel`, `--trace-mode`) are unchanged.
+
+- `--recipe NAME` — name from `RECIPE_CATALOG`. Default `general_blame`.
+- `--driver {claude-code-sdk,claude-terminal}` — driver override. Default `claude-code-sdk`. Always applied uniformly across the invocation.
+- `--audit` — enable the audit pass for this invocation (overrides `recipe.audit`).
+- `--no-survey` — disable the post-judge survey pass for this invocation (override of `recipe.post_judge_survey`).
+
+The `--model` flag is **removed** (model is part of the recipe). A backwards-compatibility shim accepts `--model X` and resolves to a synthetic recipe `JudgeRecipe(name="cli-override", ...).model_copy(update={"model": X})` based on the selected recipe, with a deprecation warning to stderr.
+
+### NEW subcommand — `ch-judge init-context <experiment_dir>`
+
+Walks `experiment_config.json` exactly as `collect_source_paths` does and writes a starter `judge_context.md` containing the discovered `paths` fence (no prose). Exits 0 on success, non-zero if `experiment_config.json` is unreadable. Idempotent — re-running overwrites the file with a warning.
+
+The `--context-file` flag from revision 1 is **removed**: the context file location is fixed at `<experiment_dir>/judge_context.md`. Out-of-tree paths are not supported in V1.
+
+---
+
+## MODIFIED — `openspec/specs/analyze/spec.md`
+
+A new section "Judge subsystem" is added (companion to the trajectory-judge section that lands with PR #366). The section documents:
+
+- The use-case directory layout under `analyze/judge/use_cases/<name>/` and the `RECIPE_CATALOG` assembly.
+- `JudgeRecipe` as the unit of judge configuration; `driver` and `selector` are call-time arguments, not recipe fields.
+- The `AgentDriver` Protocol, the two concrete drivers, the `continue_session` audit seam, and the cost/parallelism trade-offs.
+- The LiteLLM proxy integration via `LITELLM_PROXY_URL` (PS-002).
+- The context-file contract: `judge_context.md` is **required**; `validate_context_file` is the contract enforcer; `ch-judge init-context` is the bootstrap subcommand.
+- The post-judge survey schema (with `schema_version`) and when it is populated.
+- The audit pass (flag-gated), `audit.json` schema, and the pointer to the follow-up batch-audit runner.
+- The CLI surface above.
+- The joint-CSV and cross-judge-agreement output filenames and column lists (schema-normative even when the runners ship in follow-ups).
+
+---
+
+## MODIFIED — `openspec/specs/storage/spec.md`
+
+One additive sentence under the experiment-root artifacts table:
+
+> When the outer-loop meta-agent dispatches a sweep, the sweep directory may contain `joint_judge_report.csv` (one row per `(experiment, episode)`) and `cross_judge_agreement.csv` (one row per multi-seed (recipe, trajectory) pair). Both are read-mostly; their schemas are fixed in the Auto-CUBE proposal. Per-episode artifacts may include `audit.json` next to `judge_output.json` when the audit pass was enabled.
+
+No change to `EpisodeRecord` (PR #366's `judge_output` / `judge_metadata` already cover the per-episode surface).
+
+---
+
+## NOT CHANGED
+
+- `JudgeOutput` schema — taxonomy, evidence, confidence fields, invariants. Recipes that need richer output add sibling fields (e.g. `agent_scaffolding` adds `scaffold_diagnosis`); the core schema is frozen.
+- `JudgeMetadata` schema — unchanged. The terminal driver reports `cost_usd=0.0` per the documented sentinel; no new fields beyond the additive `litellm_proxy_url` carried via `DriverResult`.
+- `EpisodeRecord.judge_output` / `EpisodeRecord.judge_metadata` — same fields, same write path. The seam PR's invariants hold.
+- `Storage` Protocol — Auto-CUBE writes sidecar files (`judge_context.md`, `post_judge_survey.json`, `judge_trace.json`, `audit.json`, `joint_judge_report.csv`, `cross_judge_agreement.csv`); none of them go through the Storage interface.
+- `Episode`, `Experiment`, `exp_runner` — the episode loop and experiment dispatch are untouched. Auto-CUBE is post-hoc only.
+- `Trajectory`, `TrajectoryStep`, `AgentOutput` — no structural changes.
+- `LLM` (`cube_harness.llm`) — the judge calls drivers, not the LLM wrapper. The constitution's LiteLLM requirement (PS-002) is satisfied via the LiteLLM-proxy env-var path that both drivers honour.
+- `meta_agent/recipes/` — experiment-level recipes stay in place. Only judge recipes are new.
+- `.claude/commands/meta-agent.md` — slash command stays. A follow-up RFC may codify its responsibilities into typed Python under `analyze/cross_experiment/meta_agent/`.
+- Any benchmark or agent contracts. Auto-CUBE does not touch cube-standard.

--- a/openspec/changes/auto-cube/deltas.md
+++ b/openspec/changes/auto-cube/deltas.md
@@ -1,393 +1,137 @@
 # Deltas: Auto-CUBE
 
-Applies to: `openspec/specs/analyze/spec.md` (primary), `openspec/specs/storage/spec.md` (minor), `openspec/specs/experiment/spec.md` (minor, joint-CSV pointer).
+Applies to: `openspec/specs/analyze/spec.md` (primary), `openspec/specs/storage/spec.md` (minor).
 
-The seam PR (forward-compat to PR #366) already landed `JudgeRecipe`,
-`PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories`
-parameter as no-op extensions. These deltas widen those types into a
-first-class surface and add the coding-agent driver Protocol, selector
-Protocol, audit pass, cross-experiment artifacts, and the use-case
-directory layout.
-
-Revision 2 (2026-05-13) reflects design-review feedback:
-- Driver moves from recipe field to call-time argument.
-- Context file becomes required (no `collect_source_paths` fallback).
-- `self_judge` recipe replaced with a flag-gated audit pass.
-- Initial use-case catalog is three (not six).
-- LiteLLM proxy integration documented per PS-002.
-- Recipe directory layout becomes one-dir-per-use-case under `use_cases/`.
+The seam PR (forward-compat to PR #366) already landed `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories` parameter as no-op extensions. These deltas widen those types into a first-class surface and add the coding-agent driver Protocol, audit pass, and cross-experiment artifacts.
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/driver.py`
 
-### Public types
+`AgentDriver` Protocol with `run(...)` and `continue_session(...)` async methods returning a `DriverResult` (output text, token counts, cost, duration, observed tool actions, optional LiteLLM proxy URL, optional session id).
 
-- `TraceMode` — `Literal["actions", "full", "off"]` (moved from `sdk.py`; the
-  literal is re-exported from `sdk.py` for backwards compatibility).
-- `ToolAction` — `TypedBaseModel(tool: str, input_summary: str, raw_input: dict[str, Any] | None)`.
-  Replaces today's untyped `dict[str, Any]` entries in the `actions` list returned by
-  `_run_claude_code`. Pydantic serialisation maps cleanly into `judge_trace.json`.
-- `DriverResult` — `TypedBaseModel(output_text, prompt_tokens, completion_tokens, cost_usd, duration_s, actions: list[ToolAction], litellm_proxy_url: str | None = None, session_id: str | None = None)`.
-  The driver-shaped result; consumed by `_judge_episode_impl` to build `JudgeMetadata` and `judge_trace.json`.
-  `litellm_proxy_url` is set when `LITELLM_PROXY_URL` was honoured. `session_id` is set when the driver supports `continue_session` (used by the audit pass).
-- `AgentDriver` — `Protocol` with attributes `name: str`, `max_parallelism: int`, and methods:
-  - `async def run(*, system_prompt, user_prompt, cwd, additional_dirs, model, allowed_tools, verbose=False, trace_mode="actions") -> DriverResult`.
-  - `async def continue_session(*, follow_up_prompt, verbose=False, trace_mode="actions") -> DriverResult`. Drivers without continuation raise `NotImplementedError`; the audit pass falls back to a fresh `run` with the prior judgment serialised into the prompt.
-- `ClaudeCodeSDKDriver` — concrete `AgentDriver` wrapping `claude-agent-sdk`.
-  `name = "claude-code-sdk"`, `max_parallelism = 8`. Refactor of today's `_run_claude_code` into the Protocol shape; bit-identical observable behaviour when called from `_judge_episode_impl` for the `general_blame` recipe.
-- `TerminalClaudeDriver` — concrete `AgentDriver` wrapping the `claude` CLI via `asyncio.subprocess`.
-  `name = "claude-terminal"`, `max_parallelism = 2`. `cost_usd` and token counts are reported as `0`. JSON extraction reuses `analyze.judge.sdk._extract_json_block`. `continue_session` uses `claude --continue` against the most recent session ID.
+Two concrete drivers: `ClaudeCodeSDKDriver` (`max_parallelism=8`, wraps `claude-agent-sdk`) and `TerminalClaudeDriver` (`max_parallelism=2`, wraps `claude -p` via subprocess; reports `cost_usd=0`). Codex driver is a signposted follow-up.
 
-### LiteLLM proxy routing (PS-002)
-
-Both concrete drivers honour `LITELLM_PROXY_URL` and `LITELLM_PROXY_AUTH_TOKEN` env vars:
-
-- When `LITELLM_PROXY_URL` is set, the driver exports `ANTHROPIC_BASE_URL=$LITELLM_PROXY_URL` and the matching auth header before invoking the SDK / CLI subprocess. The SDK / CLI then routes through the LiteLLM proxy, which itself routes to Anthropic / Bedrock / Vertex / Azure per the LiteLLM config.
-- When unset, the driver falls back to the SDK / CLI default (direct Anthropic). API-key-based developer flows are unchanged.
-- The driver records `litellm_proxy_url` (URL only, no credentials) on `DriverResult`. This propagates into `judge_metadata.json` and the joint CSV's `litellm_proxy_url` column.
+Both drivers honour `LITELLM_PROXY_URL` / `LITELLM_PROXY_AUTH_TOKEN` by exporting `ANTHROPIC_BASE_URL` to the underlying SDK/CLI. When unset, they use the SDK/CLI default. The URL (no credentials) is recorded on `DriverResult` and propagates into `judge_metadata.json`.
 
 ### Invariants
 
-- `AgentDriver.run` MUST be implemented as `async def`. Synchronous wrappers belong in callers.
-- `AgentDriver.continue_session` MUST raise `NotImplementedError` when not supported (rather than returning a stub result).
-- `max_parallelism` is advisory. `judge_experiment(n_parallel=...)` clamps against `driver.max_parallelism` and logs the clamp.
-- `DriverResult.actions` MUST be empty when `trace_mode == "off"`.
-- `DriverResult.cost_usd` of `0.0` is a documented sentinel for "driver does not report cost"; the joint CSV's `driver` column lets consumers scope summations to metered drivers.
-- Drivers MUST NOT log credentials when `LITELLM_PROXY_AUTH_TOKEN` is in the environment.
+- `AgentDriver.run` is `async`. `continue_session` raises `NotImplementedError` when unsupported; callers fall back to a fresh `run` with prior context serialised into the prompt.
+- `max_parallelism` is advisory — `judge_experiment` clamps and logs.
+- `DriverResult.cost_usd == 0.0` is a sentinel for "driver does not meter."
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/use_cases/`
 
-A package containing one subdirectory per judge use case. Each subdirectory contains the
-recipe, a `SKILL.md` for the meta-agent, prompt templates, and any supporting scripts.
+Each subdirectory is a self-contained use case: `recipe.py` (exports `RECIPE: JudgeRecipe`), `SKILL.md` (meta-agent skill), `prompts/`, optional `scripts/`. `__init__.py` walks subdirectories on import and assembles `RECIPE_CATALOG: dict[str, JudgeRecipe]`.
 
-### Layout
+Initial directories: `general_blame`, `profiling`, `agent_scaffolding`. Adding a use case is a single PR that drops a new directory; no central registration touched.
 
-```
-use_cases/
-├── __init__.py           # exports RECIPE_CATALOG; walks subdirectories on import
-├── general_blame/
-│   ├── __init__.py
-│   ├── recipe.py         # exports RECIPE: JudgeRecipe
-│   ├── SKILL.md          # meta-agent skill description
-│   ├── prompts/
-│   │   ├── system.md
-│   │   ├── user.md
-│   │   └── audit.md      # shared by all use cases via symlink in V1
-│   └── scripts/          # optional helper scripts (empty here)
-├── profiling/
-│   ├── __init__.py
-│   ├── recipe.py
-│   ├── SKILL.md
-│   ├── prompts/
-│   │   ├── system.md
-│   │   └── user.md
-│   └── scripts/
-│       └── summarise_profile.py
-└── agent_scaffolding/
-    ├── __init__.py
-    ├── recipe.py
-    ├── SKILL.md
-    ├── prompts/
-    │   ├── system.md
-    │   └── user.md
-    └── scripts/
-```
-
-### Public types
-
-- `RECIPE_CATALOG: dict[str, JudgeRecipe]` — name → recipe. Imported and used by the CLI's `--recipe NAME` flag and by `judge_episode(..., recipe=...)`. Assembled by `__init__.py` walking subdirectories and importing each `recipe.py`'s `RECIPE` constant.
-
-### Public recipes (Pydantic instances)
-
-- `general_blame: JudgeRecipe` — current default. Identical observable behaviour to today.
-- `profiling: JudgeRecipe` — narrower taxonomy, profiling-focused user-prompt template, `BashOutput` added to `allowed_tools`. Activated by the meta-agent when an experiment is flagged `profiling=True`.
-- `agent_scaffolding: JudgeRecipe` — deeper agent-failure ontology. Output schema extends `JudgeOutput` with a sibling field `scaffold_diagnosis: ScaffoldDiagnosis | None` (default `None`; non-breaking for other recipes).
-
-`hint_harvest`, `auto_verified`, and any other use cases are deferred to follow-up PRs (one directory per PR).
-
-### `SKILL.md` registration
-
-A small script (`scripts/sync_judge_skills.py`, committed in this PR) creates symlinks at `.claude/skills/judge-<name> -> src/cube_harness/analyze/judge/use_cases/<name>/SKILL.md`. The meta-agent reads the symlinked files; the source of truth is the use-case directory.
+A small script (`scripts/sync_judge_skills.py`) symlinks each `SKILL.md` into `.claude/skills/judge-<name>` so the meta-agent reads a single source of truth.
 
 ### Invariants
 
-- Every recipe in `RECIPE_CATALOG` has a unique `name` field equal to its directory name.
-- Each `use_cases/<name>/recipe.py` exports exactly one module-level `RECIPE: JudgeRecipe`.
-- Each `use_cases/<name>/SKILL.md` exists and is non-empty.
-- A recipe's `model` SHOULD be a string accepted by both `ClaudeCodeSDKDriver` and `TerminalClaudeDriver`.
-- Recipes are pure data: importing the use-case module MUST NOT trigger network or filesystem I/O beyond what Pydantic does to validate field defaults.
+- Recipe `name` equals directory name.
+- Importing a use-case module performs no network or filesystem I/O beyond Pydantic field validation.
+- Recipes serialise to JSON without custom serialisers (no driver/selector fields).
 
 ---
 
 ## ADDED — `cube_harness/analyze/judge/audit.py`
 
-The flag-gated audit pass.
+Flag-gated audit pass. `run_audit_pass(...)` calls `driver.continue_session` with an audit prompt; falls back to `driver.run` when continuation is unsupported. Writes `audit.json` next to `judge_output.json` with fields covering `verdict` (`sound`/`questionable`/`wrong`), `reasoning_quality`, `missed_evidence`, and any `alternative_blames`.
 
-### Public types
-
-- `AuditOutput` — `TypedBaseModel(schema_version=1, recipe, driver, reasoning_quality: int [0..5], missed_evidence: list[str], alternative_blames: list[BlameAlternative], verdict: Literal["sound", "questionable", "wrong"], notes: str | None)`.
-- `BlameAlternative` — `TypedBaseModel(blame: str, rationale: str)`.
-- `AUDIT_FILENAME = "audit.json"`.
-
-### Public functions
-
-- `run_audit_pass(*, recipe: JudgeRecipe, driver: AgentDriver, judge_output: JudgeOutput, judge_trace_path: Path, survey_path: Path, audit_prompt: str) -> AuditOutput` — issues `driver.continue_session(follow_up_prompt=audit_prompt)` and parses the result. Falls back to `driver.run(...)` with the prior judgment serialised into the user prompt when `continue_session` raises `NotImplementedError`.
-
-### Invariants
-
-- `AuditOutput.schema_version` is fixed at `1` for this RFC; subsequent schema changes increment the integer in lockstep with `JUDGE_SCHEMA_VERSION` semantics.
-- `AuditOutput.alternative_blames` is empty when `verdict == "sound"`.
-- `audit.json` is written next to `judge_output.json` and only when the audit pass is enabled.
+Schema versioned via a `schema_version: int` field on `AuditOutput`, mirroring the existing `JUDGE_SCHEMA_VERSION` convention.
 
 ---
 
-## ADDED — `cube_harness/analyze/judge/selection.py` (extensions)
+## ADDED — `cube_harness/analyze/judge/selection.py` (Selector extensions)
 
-The existing module gains a `Selector` Protocol and three built-in selectors. Existing public functions (`discover_episodes`, `select_episodes`, `_load_episode_record`, `EpisodeRef`) are unchanged.
+`Selector` Protocol with `select(*, main_episode, experiment_dir, all_refs) -> list[Path]`. Three built-in selectors: `SameTaskDifferentAgent`, `SameAgentPreviousIteration`, `TopKBySimilarityStub`.
 
-### Public types
-
-- `Selector` — `Protocol` with `name: str`, `k: int`, and `def select(*, main_episode: EpisodeRef, experiment_dir: Path, all_refs: Sequence[EpisodeRef]) -> list[Path]`.
-- `SameTaskDifferentAgent` — `Selector` implementation; returns up to `k` episode paths from sibling experiments that share the main episode's `task_id` but differ on `agent_config._type`.
-- `SameAgentPreviousIteration` — `Selector` implementation; returns up to `k` predecessor episodes from the same `family_id`.
-- `TopKBySimilarityStub` — `Selector` implementation; returns `k` most-recent neighbours by directory mtime. Placeholder for a real scorer.
+Selectors are call-time arguments to `judge_episode` / `judge_experiment`, not recipe fields. Existing `EpisodeRef` / `discover_episodes` / `select_episodes` helpers are unchanged.
 
 ### Invariants
 
-- `Selector.select` MUST NOT return paths that resolve to `main_episode.episode_dir`.
-- Returned paths MUST exist on disk (selectors filter their candidates accordingly).
-- The list length is bounded by `k`; selectors return fewer when fewer candidates qualify.
+- A selector never returns the main episode's own path.
+- Returned paths exist on disk; list length is bounded by `k`.
 
 ---
 
-## ADDED — `cube_harness/analyze/cross_experiment/joint_csv.py`
+## ADDED — `cube_harness/analyze/cross_experiment/`
 
-Schema-only in the first PR; the runner that walks a sweep directory and writes the file ships in a follow-up.
+Two schema-only files in this PR (runners ship as follow-ups):
 
-### Public types
-
-- `JOINT_REPORT_FILENAME = "joint_judge_report.csv"`
-- `JOINT_REPORT_COLUMNS: tuple[str, ...]` — fixed column order, listed in the proposal. Includes `litellm_proxy_url` and `driver` columns alongside the per-experiment columns from PR #366.
-
-### Public functions
-
-- `write_joint_csv(sweep_dir: Path, *, experiment_dirs: Sequence[Path] | None = None) -> Path` — declared in this PR with a `raise NotImplementedError("ships in follow-up PR")` body so callers and tests can be wired up. The schema is normative.
+- `joint_csv.py` — `JOINT_REPORT_FILENAME = "joint_judge_report.csv"`, fixed column list including `driver`, `recipe`, and `litellm_proxy_url`. `write_joint_csv(...)` declared with `NotImplementedError`.
+- `cross_judge_agreement.py` — `AGREEMENT_REPORT_FILENAME = "cross_judge_agreement.csv"`, fixed column list keyed by `(trajectory_id, recipe)` with a `seeds` column. **Single recipe, varying seeds only** — cross-recipe comparison is out of scope for this artifact. `write_cross_judge_agreement(...)` declared with `NotImplementedError`.
 
 ### Invariants
 
-- Exactly one row per `(experiment_id, trajectory_id)`.
-- All columns in `JOINT_REPORT_COLUMNS` are present even when empty (empty string for missing cross-judge columns).
-- The file is written atomically (write to `.tmp`, rename).
-
----
-
-## ADDED — `cube_harness/analyze/cross_experiment/cross_judge_agreement.py`
-
-Schema-only in the first PR; the runner ships in a follow-up. **Single recipe, multiple seeds** (revision 2): agreement is per `(recipe, trajectory)` pair across seeds, not across recipes.
-
-### Public types
-
-- `AGREEMENT_REPORT_FILENAME = "cross_judge_agreement.csv"`
-- `AGREEMENT_COLUMNS: tuple[str, ...]` — fixed column order: `trajectory_id`, `recipe`, `n_judgments`, `seeds`, `primary_blame_modal`, `primary_blame_agreement`, `outcome_modal`, `outcome_agreement`, `confidence_mean`.
-
-### Public functions
-
-- `write_cross_judge_agreement(experiment_dir: Path, *, judgments: dict[tuple[str, str], list[tuple[JudgeOutput, JudgeMetadata]]]) -> Path` — declared with `NotImplementedError` body. The dict is keyed by `(trajectory_id, recipe_name)`; each value is the list of seed-varying judgments for that pair. Schema is normative.
-
-### Invariants
-
-- One row per `(trajectory_id, recipe)` pair with `n_judgments >= 2`. Single-judgment pairs do not appear.
-- `primary_blame_agreement` and `outcome_agreement` are in `[0.0, 1.0]`.
-- `seeds` column is semicolon-separated.
-- The runner only re-judges with the **same recipe** at different seeds; cross-recipe agreement is explicitly out of scope for this artifact.
+- Joint CSV: one row per `(experiment_id, trajectory_id)`; atomic write.
+- Agreement CSV: one row per `(trajectory_id, recipe)` with `n_judgments >= 2`; agreements in `[0, 1]`.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/recipe.py`
 
-The seam PR landed `JudgeRecipe(name, system_prompt, model, allowed_tools)`. Auto-CUBE widens the fields and tightens types.
+`JudgeRecipe` gains `user_prompt_template: str`, `audit: bool = False`, `post_judge_survey: bool = True`, `permission_mode: Literal["bypassPermissions", "ask"]`. `allowed_tools` tightens from `list[str] | None` to `tuple[str, ...]`.
 
-### Public types
+**Does NOT gain `driver` or `selector` fields** — both are call-time arguments. No `DRIVER_REGISTRY`.
 
-- `JudgeRecipe` gains fields:
-  - `user_prompt_template: str` — `.format()`-style template; the same kwargs that `analyze.judge.prompt.build_user_prompt` accepts.
-  - `audit: bool` — default `False`. Gates the audit pass (which can also be enabled at call time via `--audit`).
-  - `post_judge_survey: bool` — default `True`. When `False`, the second-pass survey is skipped and `post_judge_survey.json` is written with `recipe=<name>`, `schema_version=1`, all other fields `None`/empty.
-  - `permission_mode: Literal["bypassPermissions", "ask"]` — default `"bypassPermissions"`.
-  - `allowed_tools: tuple[str, ...]` — change from `list[str] | None` to `tuple[str, ...]`. Default `("Read", "Glob", "Grep", "Bash")`. The `None` shape from the seam PR is no longer valid (was a placeholder while the field was unplumbed); migration is mechanical because no production caller passes `None` today.
-
-### NOT added (revision 2)
-
-- **`driver` field is NOT added to `JudgeRecipe`.** Drivers are call-time arguments, not recipe fields. This kills the need for a `DRIVER_REGISTRY` (recipes never reference drivers, so JSON serialisation is straightforward Pydantic; no custom serialiser).
-- **`selector` field is NOT added to `JudgeRecipe`.** Selectors are call-time arguments, mirroring driver placement.
-
-### Invariants
-
-- `JudgeRecipe.allowed_tools` is non-empty.
-- `JudgeRecipe` serialises to JSON without custom serialisers.
-
-### Public constants
-
-- `DEFAULT_RECIPE` — unchanged identity (still the `general_blame` recipe), but now imported from `analyze/judge/use_cases/general_blame/recipe.py` rather than defined inline. `analyze/judge/recipe.py` re-exports it.
+`DEFAULT_RECIPE` is re-exported from `use_cases/general_blame/recipe.py`.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/core.py`
 
-### `judge_episode` signature
+`judge_episode` and `judge_experiment` gain `recipe`, `driver`, `selector`, `audit` keyword arguments; lose `model` (now part of the recipe). `n_parallel` is clamped to `driver.max_parallelism` with a log line.
 
-Adds `recipe: JudgeRecipe | None = None`, `driver: AgentDriver | None = None`, `selector: Selector | None = None`, `audit: bool = False`. When `recipe is None`, `DEFAULT_RECIPE` is used; when `driver is None`, `ClaudeCodeSDKDriver()` is constructed. `audit=True` enables the audit pass for this call (overrides `recipe.audit=False`).
+`_judge_episode_impl`:
+- Calls `find_default_context_file(experiment_dir)` and `validate_context_file(...)`. **Raises** `FileNotFoundError` if the context file is missing or any path doesn't resolve. No fallback to `collect_source_paths`.
+- Calls `selector.select(...)` when a selector is provided.
+- Calls `driver.run(...)` instead of `_run_claude_code(...)`.
+- Runs the survey pass when `recipe.post_judge_survey` is True; writes `post_judge_survey.json`.
+- Runs the audit pass when `audit or recipe.audit`; writes `audit.json`.
 
-```python
-def judge_episode(
-    episode_dir: Path,
-    *,
-    experiment_dir: Path | None = None,
-    recipe: JudgeRecipe | None = None,
-    driver: AgentDriver | None = None,
-    selector: Selector | None = None,
-    audit: bool = False,
-    verbose: bool = False,
-    trace_mode: TraceMode = "actions",
-) -> tuple[JudgeOutput, JudgeMetadata]: ...
-```
-
-The `model: str = DEFAULT_MODEL` kwarg is **removed**: model is part of the recipe. A deprecation note in the function docstring tells callers to migrate to `recipe=`.
-
-The `context_file: Path | None = None` parameter from revision 1 is **removed**: the context file is no longer optional. Its location is derived from `experiment_dir` (or from the `episode_dir`'s parent when `experiment_dir` is `None`) by `find_default_context_file`. If the file is missing, `_judge_episode_impl` raises `FileNotFoundError`.
-
-### `judge_experiment` signature
-
-Adds `recipe: JudgeRecipe | None = None`, `driver: AgentDriver | None = None`, `selector: Selector | None = None`, `audit: bool = False`. Drops `model: str`.
-
-```python
-def judge_experiment(
-    experiment_dir: Path,
-    *,
-    recipe: JudgeRecipe | None = None,
-    driver: AgentDriver | None = None,
-    selector: Selector | None = None,
-    audit: bool = False,
-    ids: list[str] | None = None,
-    sample: float | None = None,
-    n: int | None = None,
-    failures_only: bool = False,
-    overwrite: bool = False,
-    seed: int | None = None,
-    verbose: bool = False,
-    n_parallel: int = 1,
-    trace_mode: TraceMode = "actions",
-) -> dict[str, tuple[JudgeOutput, JudgeMetadata]]: ...
-```
-
-`n_parallel` is silently clamped to `driver.max_parallelism` with a single info-level log line.
-
-### `_judge_episode_impl` (internal)
-
-- Accepts `recipe: JudgeRecipe`, `driver: AgentDriver`, `selector: Selector | None`, and `audit: bool`.
-- Calls `find_default_context_file(experiment_dir)` and then `validate_context_file(...)`. Raises `FileNotFoundError` if the file is missing or any referenced path does not resolve. **No fallback to `collect_source_paths`.**
-- Calls `selector.select(...)` when `selector is not None`, and passes the returned related-trajectory paths to the user-prompt template (the template's `{related_trajectories}` placeholder is added; `general_blame` ignores it).
-- Calls `driver.run(...)` instead of `_run_claude_code(...)` directly.
-- After parsing `JudgeOutput`, when `recipe.post_judge_survey` is `True`, runs a second `driver.run(...)` pass with the survey prompt, parses the result against `PostJudgeSurvey`, and writes `post_judge_survey.json` next to `judge_trace.json`.
-- When `audit or recipe.audit`, runs `audit.run_audit_pass(...)` and writes `audit.json` next to `judge_output.json`.
-
-### Invariants (unchanged from PR #366)
-
-- `_validate_invariants(judge_output)` runs unchanged.
-- `_persist_judgment` writes `judge_output` and `judge_metadata` into `episode_record.json` or a sidecar.
-- Aggregate cost in `experiment_judge_summary.json` excludes survey-pass and audit-pass cost by default; additive `total_survey_cost_usd` and `total_audit_cost_usd` fields are appended so consumers can opt in.
+Aggregate cost in `experiment_judge_summary.json` excludes survey and audit costs by default; additive `total_survey_cost_usd` and `total_audit_cost_usd` fields are appended.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/context.py`
 
-`validate_context_file` is already present (seam PR). Auto-CUBE promotes it from "available when called" to "called by default and required". Helper additions:
+`find_default_context_file(experiment_dir: Path) -> Path` returns `experiment_dir / "judge_context.md"` and raises if absent.
 
-- `find_default_context_file(experiment_dir: Path) -> Path` — returns `experiment_dir / "judge_context.md"`. Raises `FileNotFoundError` when the file is absent. Used by `_judge_episode_impl`.
-
-### REMOVED — `collect_source_paths` from the judge's hot path
-
-`collect_source_paths` continues to exist as the implementation of `ch-judge init-context` (it walks the venv to bootstrap a starter `judge_context.md`). It is **not** called by `_judge_episode_impl` any more. The judge's runtime path is exclusively through `validate_context_file`.
-
-### Invariants
-
-- `validate_context_file` raises `FileNotFoundError` on any missing referenced path. The judge MUST surface this — it is an outer-loop bug, not a judge-time fallback condition.
-- `find_default_context_file` is the only place the filename `judge_context.md` is hardcoded.
+`collect_source_paths` continues to exist as the implementation of the new `ch-judge init-context` subcommand. It is **no longer called by the judge's runtime path**.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/sdk.py`
 
-The free function `_run_claude_code` is **deleted** after its body is moved into `ClaudeCodeSDKDriver.run`. The module retains:
-
-- `_extract_json_block` (still imported by `core.py` and reused by the terminal driver).
-- `_summarise_tool_input` (used by both drivers to populate `ToolAction.input_summary`).
-- `TraceMode`, `JUDGE_ALLOWED_TOOLS` re-exported for backwards compatibility.
-
-### Invariants
-
-- `_extract_json_block`'s public behaviour is unchanged.
-- `_summarise_tool_input` is moved here from `sdk.py` (where it already lives) and made driver-agnostic.
+`_run_claude_code` is deleted; its body moves into `ClaudeCodeSDKDriver.run`. The module retains `_extract_json_block`, `_summarise_tool_input`, and re-exports `TraceMode` / `JUDGE_ALLOWED_TOOLS` for backwards compatibility.
 
 ---
 
 ## MODIFIED — `cube_harness/analyze/judge/cli.py`
 
-The CLI gains four flags and one subcommand. Existing flags (`--summary`, `--overwrite`, `--ids`, `--sample`, `--n`, `--failures-only`, `--seed`, `--verbose`, `--n-parallel`, `--trace-mode`) are unchanged.
+New flags: `--recipe NAME`, `--driver {claude-code-sdk,claude-terminal}`, `--audit`, `--no-survey`. The `--model` flag is removed; a backwards-compatibility shim accepts it with a deprecation warning.
 
-- `--recipe NAME` — name from `RECIPE_CATALOG`. Default `general_blame`.
-- `--driver {claude-code-sdk,claude-terminal}` — driver override. Default `claude-code-sdk`. Always applied uniformly across the invocation.
-- `--audit` — enable the audit pass for this invocation (overrides `recipe.audit`).
-- `--no-survey` — disable the post-judge survey pass for this invocation (override of `recipe.post_judge_survey`).
-
-The `--model` flag is **removed** (model is part of the recipe). A backwards-compatibility shim accepts `--model X` and resolves to a synthetic recipe `JudgeRecipe(name="cli-override", ...).model_copy(update={"model": X})` based on the selected recipe, with a deprecation warning to stderr.
-
-### NEW subcommand — `ch-judge init-context <experiment_dir>`
-
-Walks `experiment_config.json` exactly as `collect_source_paths` does and writes a starter `judge_context.md` containing the discovered `paths` fence (no prose). Exits 0 on success, non-zero if `experiment_config.json` is unreadable. Idempotent — re-running overwrites the file with a warning.
-
-The `--context-file` flag from revision 1 is **removed**: the context file location is fixed at `<experiment_dir>/judge_context.md`. Out-of-tree paths are not supported in V1.
+New subcommand: `ch-judge init-context <experiment_dir>` walks `experiment_config.json` and writes a starter `judge_context.md` (paths fence only).
 
 ---
 
 ## MODIFIED — `openspec/specs/analyze/spec.md`
 
-A new section "Judge subsystem" is added (companion to the trajectory-judge section that lands with PR #366). The section documents:
-
-- The use-case directory layout under `analyze/judge/use_cases/<name>/` and the `RECIPE_CATALOG` assembly.
-- `JudgeRecipe` as the unit of judge configuration; `driver` and `selector` are call-time arguments, not recipe fields.
-- The `AgentDriver` Protocol, the two concrete drivers, the `continue_session` audit seam, and the cost/parallelism trade-offs.
-- The LiteLLM proxy integration via `LITELLM_PROXY_URL` (PS-002).
-- The context-file contract: `judge_context.md` is **required**; `validate_context_file` is the contract enforcer; `ch-judge init-context` is the bootstrap subcommand.
-- The post-judge survey schema (with `schema_version`) and when it is populated.
-- The audit pass (flag-gated), `audit.json` schema, and the pointer to the follow-up batch-audit runner.
-- The CLI surface above.
-- The joint-CSV and cross-judge-agreement output filenames and column lists (schema-normative even when the runners ship in follow-ups).
+Adds a "Judge subsystem" section documenting: the use-case directory layout, `JudgeRecipe` (with driver/selector as call-time arguments), the `AgentDriver` Protocol and its two concrete drivers, LiteLLM proxy routing, the required-context-file contract, the post-judge survey, the audit pass, the CLI surface, and the cross-experiment artifact schemas.
 
 ---
 
 ## MODIFIED — `openspec/specs/storage/spec.md`
 
-One additive sentence under the experiment-root artifacts table:
-
-> When the outer-loop meta-agent dispatches a sweep, the sweep directory may contain `joint_judge_report.csv` (one row per `(experiment, episode)`) and `cross_judge_agreement.csv` (one row per multi-seed (recipe, trajectory) pair). Both are read-mostly; their schemas are fixed in the Auto-CUBE proposal. Per-episode artifacts may include `audit.json` next to `judge_output.json` when the audit pass was enabled.
-
-No change to `EpisodeRecord` (PR #366's `judge_output` / `judge_metadata` already cover the per-episode surface).
+One additive sentence under the experiment-root artifacts table covering `joint_judge_report.csv`, `cross_judge_agreement.csv`, and the per-episode `audit.json` when audit is enabled. No change to `EpisodeRecord`.
 
 ---
 
 ## NOT CHANGED
 
-- `JudgeOutput` schema — taxonomy, evidence, confidence fields, invariants. Recipes that need richer output add sibling fields (e.g. `agent_scaffolding` adds `scaffold_diagnosis`); the core schema is frozen.
-- `JudgeMetadata` schema — unchanged. The terminal driver reports `cost_usd=0.0` per the documented sentinel; no new fields beyond the additive `litellm_proxy_url` carried via `DriverResult`.
-- `EpisodeRecord.judge_output` / `EpisodeRecord.judge_metadata` — same fields, same write path. The seam PR's invariants hold.
-- `Storage` Protocol — Auto-CUBE writes sidecar files (`judge_context.md`, `post_judge_survey.json`, `judge_trace.json`, `audit.json`, `joint_judge_report.csv`, `cross_judge_agreement.csv`); none of them go through the Storage interface.
-- `Episode`, `Experiment`, `exp_runner` — the episode loop and experiment dispatch are untouched. Auto-CUBE is post-hoc only.
-- `Trajectory`, `TrajectoryStep`, `AgentOutput` — no structural changes.
-- `LLM` (`cube_harness.llm`) — the judge calls drivers, not the LLM wrapper. The constitution's LiteLLM requirement (PS-002) is satisfied via the LiteLLM-proxy env-var path that both drivers honour.
-- `meta_agent/recipes/` — experiment-level recipes stay in place. Only judge recipes are new.
-- `.claude/commands/meta-agent.md` — slash command stays. A follow-up RFC may codify its responsibilities into typed Python under `analyze/cross_experiment/meta_agent/`.
-- Any benchmark or agent contracts. Auto-CUBE does not touch cube-standard.
+`JudgeOutput`, `JudgeMetadata`, `EpisodeRecord`, `Storage` Protocol, `Episode`, `Experiment`, `exp_runner`, `Trajectory`, `LLM`, `meta_agent/recipes/`, `.claude/commands/meta-agent.md`, cube-standard.

--- a/openspec/changes/auto-cube/proposal.md
+++ b/openspec/changes/auto-cube/proposal.md
@@ -1,38 +1,66 @@
 # RFC: Auto-CUBE — Use-Case-Driven Judge + Coding-Agent Drivers
 
-**Status:** DRAFT (revision 3 — concise rewrite, design decisions only)
+**Status:** DRAFT (revision 4 — implementation-ready, folds in design feedback)
 **Author:** Alexandre Lacoste
 **Date:** 2026-05-13
 
-**Companions:** `trajectory-judge` (PR #366, the judge this builds on), `agent-owns-loop` (PR #386, orthogonal — touches the episode loop, not the judge).
+**Companions:** `trajectory-judge` (PR #366, the judge this builds on), `agent-owns-loop` (PR #386, orthogonal).
 
 ---
 
 ## Problem
 
-The trajectory judge (PR #366) is monolithic: one hard-coded prompt, one model, one tool surface, one transport (`claude-agent-sdk`). The meta-agent is a slash command that drives experiments and writes journals but has no typed contract with the judge. There is no story for:
+The trajectory judge (PR #366) is monolithic: one prompt, one model, one tool surface, one transport (`claude-agent-sdk`), one output schema. The meta-agent has no typed contract with it. Auto-CUBE adds the seams to:
 
-- Running the judge **per use case** (general blame vs profiling vs scaffolding analysis) without forking the judge module.
-- Running the judge **without an API key** (researcher with only a Claude Code subscription) or on top of a different coding agent (Codex).
-- Letting the meta-agent **inject experiment-specific context** the judge should focus on.
-- A **self-quality signal** — does the judge agree with itself? did it miss evidence?
-- A **cross-experiment view** the outer loop can grep.
+- Run the judge **per use case** (general blame vs profiling vs scaffolding) without forking the judge module.
+- Run the judge **without an API key** (subscription holders) or on top of Codex.
+- Inject **experiment-specific context** automatically via a sub-agent.
+- Get a **self-quality signal** per judgment (audit pass).
+- Get a **cross-experiment view** the outer loop can grep.
 
-Auto-CUBE adds those four seams. It is post-hoc only — episode loop and storage formats are untouched.
+Post-hoc only — episode loop and storage formats are untouched.
 
 ---
 
-## Design — five decisions
+## Design
 
-### 1. Each use case is a directory
+### 1. One directory per use case
 
-`cube_harness/analyze/judge/use_cases/<name>/` holds the `JudgeRecipe` (Pydantic), the meta-agent skill (`SKILL.md`), the prompts, and any supporting scripts for that use case. `RECIPE_CATALOG` is assembled by walking the directory on import. New use cases are one-directory PRs.
+```
+src/cube_harness/analyze/judge/use_cases/<name>/
+├── __init__.py
+├── recipe.py         # exports RECIPE: JudgeRecipe (prompts inline, OutputModel inline)
+├── SKILL.md          # meta-agent skill description
+└── scripts/          # optional helpers (e.g. profiling/summarise_profile.py)
+```
 
-Initial catalog: **`general_blame`**, **`profiling`**, **`agent_scaffolding`**. Others (`hint_harvest`, `auto_verified`) are deferred to follow-up PRs.
+`use_cases/__init__.py` walks subdirectories on import and assembles `RECIPE_CATALOG: dict[str, JudgeRecipe]`. Adding a use case is a one-directory PR.
 
-### 2. `AgentDriver` is our own Protocol — not LiteLLM
+Initial catalog: **`general_blame`**, **`profiling`**, **`agent_scaffolding`**.
 
-LiteLLM is a model gateway, not a coding-agent abstraction. To swap Claude Code SDK ↔ terminal `claude -p` ↔ `codex exec`, we need our own thin Protocol:
+**Why `recipe.py` and not `recipe.json`:** constitution PS-Python-is-config. The recipe owns its `OutputModel` (a type, not data) and its prompts (long strings best edited as Python, not embedded JSON). `.py` gives Go-to-Definition. The runtime *records* which recipe was used in `judge_metadata.json` — that's the JSON side; recipes themselves stay Python.
+
+### 2. `JudgeRecipe` shape
+
+```python
+class JudgeRecipe(TypedBaseModel):
+    name: str
+    system_prompt: str          # describes the use case + ontology + output schema
+    user_prompt_template: str
+    output_model: type[TypedBaseModel]  # per-recipe output schema
+    model: str = "claude-sonnet-4-6"
+    allowed_tools: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
+    permission_mode: Literal["bypassPermissions", "ask"] = "bypassPermissions"
+    audit: bool = False         # run the audit pass
+```
+
+**Each recipe owns its output schema.** `general_blame.OutputModel` is the current `JudgeOutput`; `agent_scaffolding.OutputModel` extends it with scaffold-specific fields; `profiling.OutputModel` is narrower. Aggregation across recipes works on the intersection (`primary_blame`, `outcome`, `confidence`) declared as a base class all `OutputModel`s extend.
+
+**No `driver` or `selector` field on the recipe.** Both are call-time arguments — choice of transport is orthogonal to what the judge is asked to do.
+
+### 3. `AgentDriver` Protocol — our wrapper, not LiteLLM
+
+LiteLLM is a model gateway, not a coding-agent abstraction. To swap Claude SDK ↔ terminal `claude -p` ↔ `codex exec`, we need our own thin Protocol:
 
 ```python
 class AgentDriver(Protocol):
@@ -42,90 +70,111 @@ class AgentDriver(Protocol):
     async def continue_session(...) -> DriverResult   # for audit pass
 ```
 
-Three drivers in scope (Codex is signposted, not built):
-
 | Driver | Auth | Parallelism per host | Cost reported |
 |---|---|---|---|
 | `claude-code-sdk` | API key | ~8 | yes |
 | `claude-terminal` | subscription (`claude -p`) | ~2 | no |
-| `codex-cli` (follow-up) | OpenAI key | ~3 | yes |
+| `codex-cli` | OpenAI key (follow-up) | ~3 | yes |
 
-**Drivers are call-time, not recipe-pinned.** A researcher swaps `--driver claude-terminal` without touching the recipe. Underneath, model calls still route through LiteLLM when `LITELLM_PROXY_URL` is set, but that's per-driver implementation detail, not part of the Protocol.
+Drivers are call-time arguments. Underneath, model calls route through LiteLLM when `LITELLM_PROXY_URL` is set (PS-002 satisfied at the token-routing layer).
 
-### 3. Judge requires a context file — no fallback
+### 4. Benchmark-context sub-agent — automatic context-file generation
 
-The meta-agent writes `<experiment_dir>/judge_context.md` with the paths and prose the judge needs. `validate_context_file` is already seamed; the judge calls it and raises if the file is missing or any path doesn't resolve. The previous `collect_source_paths` venv-walk heuristic is removed from the judge's hot path.
+When `judge_experiment` runs and `<experiment_dir>/judge_context.md` is missing, it spawns a **benchmark-context-agent** (Opus by default, runs through the same `AgentDriver`) that reads `experiment_config.json`, walks the relevant source trees, and writes the file. Output format is the existing `\`\`\`paths` fenced block already understood by `validate_context_file`.
 
-For ad-hoc developer use, a new `ch-judge init-context <experiment_dir>` subcommand bootstraps the file using the old heuristic, then exits.
+The judge then calls `validate_context_file(path)` — extracts paths via the existing `_PATHS_FENCE_RE` regex, verifies each path exists locally, raises `FileNotFoundError` on any miss. Validation is cheap and catches the failure mode where the sub-agent hallucinates a path; the audit pass catches deeper context-quality issues.
 
-### 4. Audit pass — flag-gated, replaces `self_judge`
+Replaces the old `collect_source_paths` venv-walk heuristic. `ch-judge init-context <experiment_dir>` becomes a thin CLI wrapper around the same sub-agent for ad-hoc bootstrap.
 
-When `--audit` is set, the judge issues a follow-up turn (via `driver.continue_session`) asking it to critique its own reasoning. Output: `audit.json` next to `judge_output.json`. Off by default; ~25% cost overhead when on.
+### 5. Audit pass — single unified self-evaluation
 
-This is a flag, not a recipe — it always layers on top of an existing use case. A follow-up PR adds a batch step that walks a sweep, collects all `audit.json`s, re-judges flagged trajectories, and writes a sweep-level quality report.
+Replaces both `self_judge` and the previous separate `post_judge_survey`. One pass, one file, one cost overhead.
 
-### 5. Cross-judge agreement — same recipe, varying seeds
+When `--audit` is set (or `recipe.audit=True`), the judge issues `driver.continue_session(...)` after the primary judgment with an audit prompt. Output: `audit.json` with:
 
-Agreement is `(recipe, trajectory)` × N seeds. Cross-recipe comparison is explicitly out — comparing `general_blame` to `agent_scaffolding` is only well-defined on shared core fields, and the more useful signal is "does this recipe reach the same blame twice?"
+- `verdict`: `sound` / `questionable` / `wrong`
+- `reasoning_quality`: 0-5
+- `ease_of_analysis`: 0-5 (was: survey)
+- `context_quality`: 0-5 (was: survey)
+- `tooling_gaps`: list[str] (was: survey)
+- `missed_evidence`: list[str]
+- `alternative_blames`: list[{blame, rationale}]
+- `notes`: str | None
 
-Output schema (`cross_judge_agreement.csv`) is fixed in this PR; the re-judging runner is a follow-up gated on low primary-blame confidence.
+Off by default; ~25-30% cost overhead when on. Drivers without `continue_session` fall back to a fresh `run` with the prior judgment in the prompt — same `audit.json` output.
+
+### 6. Batch outputs — both CSV and JSON
+
+After `judge_experiment` finishes, two aggregate files are written next to the experiment dir:
+
+- `experiment_judge_report.csv` (already in PR #366) — flat, one row per episode, for grep/spreadsheet.
+- `experiment_judge_report.json` (new) — preserves the per-recipe `OutputModel` shape for downstream consumers that need typed access.
+
+### 7. Cross-judge agreement + joint CSV — runners ship in this PR
+
+The user explicitly asked these be in this PR rather than deferred.
+
+- **Cross-judge runner.** `judge_experiment(..., n_seeds=N)` re-judges each selected episode N times with the **same recipe** at varying seeds. Writes `cross_judge_agreement.csv` keyed by `(trajectory_id, recipe)` with modal blame + agreement fraction across seeds. Cross-recipe comparison stays out of scope (well-defined only on shared base fields; not the most useful signal).
+- **Joint CSV runner.** `cube_harness.analyze.cross_experiment.write_joint_csv(sweep_dir)` walks a sweep directory, reads each experiment's `experiment_judge_report.csv` plus its `cross_judge_agreement.csv` if present, writes one row per `(experiment, episode)` to `<sweep_dir>/joint_judge_report.csv`. Columns include `experiment_id`, `family_id`, `agent_dotted`, `benchmark_dotted`, `driver`, `recipe`, `litellm_proxy_url`, plus the per-experiment columns and joined cross-judge columns.
+
+### 8. Judge script = parallel runner, meta-agent passes a subset
+
+`judge_experiment` already supports `n_parallel`, `ids`, `sample`, `n`, `failures_only` via PR #366. The meta-agent uses these to scope a judging run; default is "all episodes, single recipe, n_parallel=driver.max_parallelism." Auto-CUBE adds `recipe`, `driver`, `selector`, `audit`, `n_seeds` — no other API change.
 
 ---
 
-## Outputs
+## Outputs (full list)
 
-Per episode (inside `<episode_dir>/`):
-- `judge_output.json` — from PR #366, unchanged
-- `judge_trace.json` — from PR #366, unchanged
-- `post_judge_survey.json` — second-pass self-assessment (ease, context quality, tooling gaps)
+Per episode (`<episode_dir>/`):
+- `judge_output.json` (PR #366), `judge_trace.json` (PR #366)
 - `audit.json` — when `--audit` is set
 
 Per experiment (`<experiment_dir>/`):
-- `judge_context.md` — required input, written by meta-agent or `ch-judge init-context`
-- `experiment_judge_report.csv` — from PR #366
-- `cross_judge_agreement.csv` — when multiple seeds were judged
+- `judge_context.md` — auto-generated by benchmark-context-agent if missing
+- `experiment_judge_report.csv` (PR #366)
+- `experiment_judge_report.json` (new — typed-shape mirror)
+- `cross_judge_agreement.csv` — when `n_seeds > 1`
 
-Per sweep (follow-up runner):
-- `joint_judge_report.csv` — one row per (experiment, episode)
-- `audit_quality_report.md` — follow-up batch-audit output
+Per sweep (when meta-agent dispatches one):
+- `joint_judge_report.csv`
 
 ---
 
 ## Scope
 
-**In (this PR):** `AgentDriver` Protocol + two drivers (`claude-code-sdk`, `claude-terminal`); `JudgeRecipe` widening (no `driver`/`selector` fields); the three initial use-case directories; required context file + `init-context` subcommand; survey collection; flag-gated audit pass; selector Protocol with three built-in selectors; fixed schemas for `joint_judge_report.csv` and `cross_judge_agreement.csv` (writers not yet implemented).
+**In (this PR):** `AgentDriver` Protocol + `claude-code-sdk` and `claude-terminal` drivers; three use-case directories; benchmark-context-agent; required + auto-generated context file; merged audit pass; cross-judge runner; joint-CSV runner; selector Protocol with three built-in selectors; `experiment_judge_report.json` aggregate; CLI flags (`--recipe`, `--driver`, `--audit`, `--n-seeds`).
 
-**Out (called-out follow-ups):** cross-judge runner; joint-CSV runner; batch-audit runner; Codex driver; real similarity selector; additional use-case directories; typed meta-agent loop (slash command stays).
+**Out (signposted follow-ups):** Codex driver; real similarity selector; additional use-case directories (`hint_harvest`, `auto_verified`); typed meta-agent loop replacing the slash command.
 
-**Not touched:** cube-standard, episode loop, trajectory format, storage protocol, `Episode`/`Experiment`/`exp_runner`, `LLM` wrapper.
+**Not touched:** cube-standard, episode loop, trajectory format, storage Protocol, `Episode`, `Experiment`, `exp_runner`, `LLM` wrapper, `meta_agent/recipes/`.
 
 ---
 
 ## Constitution alignment
 
-- **PS-002 (LiteLLM).** Drivers honour `LITELLM_PROXY_URL` and export `ANTHROPIC_BASE_URL` to their SDK/CLI when set. The constitution rule is satisfied at the token-routing layer; the agent-runtime abstraction is ours because LiteLLM does not cover it.
-- **EX-002 (no global state).** No driver or recipe registry — `RECIPE_CATALOG` is assembled on import from the directory layout; drivers are passed as arguments.
-- **CC-005 (minimalism).** Three use cases, two drivers, one flag for audit. Larger catalogs and runners come as separate PRs that prove their value.
+- **PS-002 (LiteLLM).** Drivers honour `LITELLM_PROXY_URL`. Agent-runtime abstraction is ours because LiteLLM does not cover it.
+- **PS-Python-is-config.** Recipes are `.py` files exporting Pydantic instances; runtime artifacts are JSON.
+- **EX-002 (no global state).** No registries — `RECIPE_CATALOG` is assembled on import; drivers and selectors are arguments.
+- **CC-005 (minimalism).** Three use cases, two drivers, one audit flag. Larger surfaces are separate PRs.
+- **SR-002 (trace-first).** Driver calls wrapped in `auto_cube.judge.driver_run` OTel spans.
 - **SR-003 (escape hatch).** Both drivers expose `.raw` on `DriverResult`.
-- **SR-002 (trace-first).** Driver calls are wrapped in OTel spans (`auto_cube.judge.driver_run`) with `auto_cube.driver`, `auto_cube.recipe`, `auto_cube.model`, `auto_cube.litellm_proxy` attributes.
 
 ---
 
-## Open questions (for reviewer decision)
+## Open questions
 
-1. **`SKILL.md` registration.** Source-of-truth lives at `use_cases/<name>/SKILL.md`. Symlink them into `.claude/skills/` (lightweight, one source) or copy at build time (no symlink dep)? Recommend symlink unless someone objects.
-2. **Driver Protocol parameter for the survey/audit pass session continuity.** `continue_session` on the SDK driver needs to span the survey-pass call in between the primary judgment and the audit. To verify against the SDK before merging — if continuation across intermediate calls doesn't work cleanly, the audit falls back to a fresh `run` with the prior judgment in the prompt. Either way, the surface area is the same.
+1. **`SKILL.md` registration.** Symlink `use_cases/<name>/SKILL.md` into `.claude/skills/judge-<name>` (lightweight, one source) or copy at build time (no symlink dep)? Recommend symlink.
+2. **`continue_session` behaviour across the audit pass.** Verify against the SDK before merging — if continuation across a closed-and-reopened session doesn't work, the audit fallback is a fresh `run` with prior context serialised in.
 
-Everything else (exact field names, audit prompt content, CLI flag spellings, OTel attribute keys, schema-version mechanics, default thresholds) is implementer's call — flag in PR review if you disagree.
+Everything else is implementer's call.
 
 ---
 
 ## References
 
-- `openspec/changes/trajectory-judge/proposal.md` — PR #366, the judge this extends.
-- `openspec/changes/agent-owns-loop/proposal.md` — PR #386, orthogonal.
-- `.claude/commands/meta-agent.md` — the slash command that drives the outer loop today.
-- `src/cube_harness/analyze/judge/` — the judge package on `feat/trajectory-judge` where the seam PR landed `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories` parameter this RFC builds on.
+- `openspec/changes/trajectory-judge/proposal.md` — PR #366.
+- `openspec/changes/agent-owns-loop/proposal.md` — PR #386.
+- `src/cube_harness/analyze/judge/` — seam PR landed `JudgeRecipe`, `validate_context_file`, `_PATHS_FENCE_RE`.
 - LiteLLM Agent SDKs: https://docs.litellm.ai/docs/agent_sdks
 - Claude Code headless: https://code.claude.com/docs/en/headless
 - Codex non-interactive: https://developers.openai.com/codex/noninteractive

--- a/openspec/changes/auto-cube/proposal.md
+++ b/openspec/changes/auto-cube/proposal.md
@@ -1,0 +1,966 @@
+# RFC: Auto-CUBE — Use-Case-Driven Judge, Coding-Agent Drivers, and the Meta-Agent Outer Loop
+
+**Status:** DRAFT (revision 2 — folds in design-review feedback from 2026-05-13)
+**Author:** Alexandre Lacoste
+**Reviewer:** TBD
+**Date:** 2026-05-13
+
+**Companion RFCs:**
+- `openspec/changes/trajectory-judge/proposal.md` (PR #366) — the inner-loop judge this
+  RFC builds on.
+- `openspec/changes/agent-owns-loop/proposal.md` — orthogonal; touches the episode
+  loop, not the post-hoc judge or the meta-agent.
+
+---
+
+## Problem
+
+cube-harness today has three pieces of post-hoc analysis machinery that were
+designed in isolation and do not compose:
+
+1. The **trajectory judge** in `cube_harness/analyze/judge/` (landing as PR #366).
+   It produces a structured `JudgeOutput` per episode by invoking Claude Code over
+   the `claude-agent-sdk`. Its prompt, model, and tool surface are hard-coded
+   constants in `analyze/judge/prompt.py` and `analyze/judge/sdk.py`. There is one
+   judge, and changing what the judge looks at means editing the module.
+
+2. The **meta-agent** in `meta_agent/`, plus a fleet of `feat/meta-agent-*`
+   branches. Recipes (e.g. `meta_agent/recipes/workarena_l1_full.py`), hints
+   (`meta_agent/hints/swebench-verified.json`), tooling and result journals live
+   side-by-side, but the workflow they implement is held together by a slash
+   command (`.claude/commands/meta-agent.md`) rather than by typed Python.
+
+3. **New ideas** from the user about how these pieces should compose into a
+   long-term, self-improving system: judge use-cases packaged as cohesive units
+   (judge recipe + meta-agent skill + supporting scripts), coding-agent
+   abstraction so the judge can run on a subscription instead of an API key,
+   joint analysis across experiments, an audit pass that closes the loop back to
+   the judge's own quality.
+
+The fragmentation has five concrete costs that this RFC addresses:
+
+1. **The pre-judge owns context that should be the meta-agent's job.**
+   `collect_source_paths` in `analyze/judge/context.py` resolves paths by
+   importing `_type` strings from `experiment_config.json` against the local
+   venv. This is correct for ad-hoc judging on a developer laptop but cannot
+   express the per-experiment shape the meta-agent needs ("for this experiment,
+   focus on the profiling trace; for that one, contrast with these three other
+   trajectories"). The judge re-derives context every run and there is no place
+   for an outer loop to inject curated context.
+
+2. **No coding-agent abstraction.** `_run_claude_code` in `analyze/judge/sdk.py`
+   talks to `claude-agent-sdk` directly. Researchers who hold a Claude Code
+   subscription but no API key cannot run the judge. The Codex CLI cannot be
+   bolted on. Even within the SDK path, there is no way to swap models or tool
+   surfaces — the constants `JUDGE_ALLOWED_TOOLS` and
+   `permission_mode="bypassPermissions"` are inlined.
+
+3. **No feedback loop from judge to tooling.** When the judge runs into a gap —
+   a missing profiling trace, an unparseable observation, a source tree it
+   cannot reach — that experience evaporates. There is no record of *why* a
+   judgment was hard, and no signal that lets us improve the judge's toolchain
+   over time.
+
+4. **No joint view across experiments.** `judge_experiment` writes one CSV per
+   experiment (`experiment_judge_report.csv`). The meta-agent's natural unit of
+   work is a *sweep* of experiments — half a dozen agent configs against the
+   same benchmark, or the same agent across benchmarks. There is no row-per
+   (experiment, episode) table the outer loop can grep.
+
+5. **No agreement signal.** A single judge call is one sample from a noisy
+   distribution; we have no way to ask "would the same recipe at a different
+   seed reach the same blame on this trajectory?" — which is exactly the
+   question the meta-agent needs to answer before recommending an intervention.
+
+Auto-CUBE is the umbrella that unifies these threads. It is not a rewrite. It
+is a contract that says: each use case is a directory containing a judge recipe
+plus the meta-agent skill that drives it; the judge runs against an abstract
+coding-agent driver chosen at call time; the meta-agent owns experiment-level
+context and post-hoc analysis; and a flag-gated audit pass closes the loop
+back to the judge's quality.
+
+---
+
+## Scope
+
+### In (first Auto-CUBE PR)
+
+- A **use-case directory layout** under `cube_harness/analyze/judge/use_cases/`.
+  Each subdirectory contains the judge `recipe.py`, a `SKILL.md` for the
+  meta-agent, and any supporting scripts/configs that use case needs. Initial
+  catalog: `general_blame`, `profiling`, `agent_scaffolding` (three; the rest
+  are deferred — see "Out").
+- `JudgeRecipe` becomes the unit of judge configuration: name, system prompt,
+  user-prompt template, model, allowed tools. The seam PR (forward-compat to
+  #366) lands the Pydantic model with `name/system_prompt/model/allowed_tools`;
+  this RFC widens it with the user-prompt template field. **`driver` is NOT a
+  recipe field** — drivers are chosen at call time (see Driver section).
+- An `AgentDriver` Protocol that abstracts the coding agent the judge runs as.
+  Two implementations: `ClaudeCodeSDKDriver` (today's `_run_claude_code`
+  refactored to fit the Protocol) and `TerminalClaudeDriver` (subprocess
+  wrapper around the `claude` CLI for users with a subscription but no API key).
+  Both route through the LiteLLM proxy when one is configured (see
+  "Constitution alignment: PS-002").
+- A `Selector` interface for related-trajectory selection, with three built-in
+  selectors: `SameTaskDifferentAgent`, `SameAgentPreviousIteration`, and
+  `TopKBySimilarityStub` (a stub that returns N most recent neighbours; real
+  similarity scoring is a follow-up).
+- `validate_context_file` (already seamed in `analyze/judge/context.py`)
+  becomes the **only** context source. The judge requires
+  `<experiment_dir>/judge_context.md` to exist and to validate; otherwise it
+  raises. The current `collect_source_paths` heuristic is removed from the
+  judge's hot path. A new CLI subcommand `ch-judge init-context
+  <experiment_dir>` bootstraps a context file from the venv, so ad-hoc users
+  can produce the file once and then judge against it.
+- `post_judge_survey.json` collection: the empty stub from the seam PR is
+  populated by a deterministic second pass after each judgment, recording how
+  hard the analysis was, whether the context file was useful, and what tooling
+  gaps were hit. Schema fixed in this RFC, with a `schema_version` field that
+  mirrors the existing `JUDGE_SCHEMA_VERSION` convention.
+- An **audit pass** (flag-gated): when a recipe's `audit=True` is set or
+  `--audit` is passed at call time, the judge runs a second pass that
+  *continues the prior judgment's context* — same driver session, same
+  conversation, with a follow-up prompt asking the judge to critique its own
+  reasoning. Output written to `audit.json` next to `judge_output.json`.
+- A `meta_agent/` repackaging that defines what stays as the outer-loop runner
+  vs. what moves into `analyze/judge/use_cases/<name>/` and
+  `analyze/cross_experiment/`. No behaviour change at the meta-agent loop
+  level; this is a re-homing of the modules.
+
+### Out (later PRs, called out explicitly)
+
+- **Codex driver.** The Protocol is shaped to admit it; the implementation is
+  follow-up work. Codex is structurally similar to the terminal Claude case
+  (subprocess, no programmatic streaming API) but has its own auth and
+  config surface. Like the Claude drivers, it would route through LiteLLM's
+  Codex SDK adapter when one is configured.
+- **Cross-judge agreement runner.** The output schema and the columns it adds
+  to the joint CSV are specified here; the runner that re-judges N times per
+  episode at different seeds is a follow-up. Single-judgment runs today still
+  get a stable record that agreement can be appended to later.
+- **Joint CSV across experiments runner.** The schema is fixed here; the
+  outer-loop module that writes it lives in the follow-up PR that wires the
+  meta-agent to multi-experiment dispatch.
+- **Audit-batch analysis.** The per-episode audit pass ships in the first PR.
+  The meta-agent skill + script that *collects* all audits across a sweep,
+  re-judges the previous batch's trajectories, and produces a quality report
+  ships in a follow-up. Schema for the per-episode `audit.json` is fixed here
+  so the batch tool can be written without churn.
+- **Additional use-case directories** beyond the initial three:
+  `hint_harvest`, `auto_verified`. Each is a separate, small follow-up PR that
+  drops a new directory under `use_cases/`. The plumbing change is in this RFC;
+  catalog growth is incremental.
+- **Full meta-agent rewrite.** Use-case skills relocate under their use-case
+  dirs; the loop driver stays as the slash command at
+  `.claude/commands/meta-agent.md` until the dispatch and analysis steps are
+  codified into typed Python under `analyze/cross_experiment/`.
+- **cube-standard contract changes.** None — this entire RFC is harness-side.
+- **Changes to the episode loop, trajectory format, or storage protocol.**
+  Out — see `agent-owns-loop` for the loop work and `atlas-eval-log` for
+  storage.
+
+---
+
+## Design
+
+### Architecture overview
+
+Auto-CUBE has two nested loops. The boundary between them is the experiment.
+
+**Inner loop — per experiment, 5 to 10 episodes typically.**
+
+```
+task → agent → trajectory → judge(recipe, driver) → judge_output.json
+                                                  + judge_trace.json
+                                                  + post_judge_survey.json
+                                                  + audit.json (if --audit)
+```
+
+The judge is configured by a `JudgeRecipe` (system prompt, model, allowed
+tools, user-prompt template). It receives a main trajectory directory, the
+**required** `judge_context.md` produced by the meta-agent (or by `ch-judge
+init-context`), and an optional list of related-trajectory paths produced by
+a `Selector`. The driver is supplied at call time (default
+`ClaudeCodeSDKDriver`). The judge emits a `JudgeOutput` (taxonomy and
+evidence; schema fixed by PR #366), a `judge_trace.json` (the agent's tool
+calls during the judgment), a `post_judge_survey.json` (the second-pass
+self-assessment), and — when audit is enabled — an `audit.json` (the
+self-critique pass).
+
+**Outer loop — per sweep, dispatched by the meta-agent.**
+
+```
+meta-agent dispatch → N experiments → joint CSV + cross-judge agreement
+   → meta-agent analysis → Experiment Judge Report → meta-agent intervention
+   → (optional) audit-batch pass over the previous sweep
+```
+
+The meta-agent generates the context file for each experiment, dispatches the
+runs, lets the inner loop write its per-episode outputs, then concatenates
+them into a row-per (experiment, episode) joint CSV. Optional cross-judge
+agreement is computed by re-running the inner loop with the **same recipe**
+at different seeds and comparing `primary_blame` distributions. The
+meta-agent reads the joint CSV, writes an Experiment Judge Report (a markdown
+document with cited evidence), and proposes interventions: prompt tweaks,
+scaffold edits, hint additions, or recipe changes that feed back into the
+next sweep. A separate audit-batch step (follow-up PR) collects the
+`audit.json` files across the previous sweep, re-judges flagged trajectories,
+and reports on judge quality.
+
+The line between the loops is a single contract: the inner loop trusts the
+context file produced by the outer loop and validates that its paths resolve.
+That is the entirety of the inter-loop dependency. The judge knows nothing
+about sweeps; the meta-agent knows nothing about the judge's internal
+toolchain.
+
+### Use-case directory layout
+
+Each judge use case is a self-contained directory under
+`cube_harness/analyze/judge/use_cases/`. The contents are uniform so the
+catalog can be discovered programmatically and so contributors have one
+template to follow:
+
+```
+use_cases/
+├── __init__.py            # exports RECIPE_CATALOG: dict[str, JudgeRecipe]
+├── general_blame/
+│   ├── __init__.py
+│   ├── recipe.py          # JudgeRecipe instance: RECIPE
+│   ├── SKILL.md           # meta-agent skill description (claude-md-improver style)
+│   ├── prompts/
+│   │   ├── system.md      # JUDGE_SYSTEM_PROMPT for this use case
+│   │   └── user.md        # user-prompt template
+│   └── scripts/           # supporting scripts (optional; empty for general_blame)
+├── profiling/
+│   ├── recipe.py
+│   ├── SKILL.md
+│   ├── prompts/
+│   └── scripts/
+│       └── summarise_profile.py   # py-spy / flameprof helper invoked by the judge
+└── agent_scaffolding/
+    ├── recipe.py
+    ├── SKILL.md
+    ├── prompts/
+    └── scripts/
+```
+
+`use_cases/__init__.py` walks the subdirectories on import, imports each
+`recipe.py` for its `RECIPE` constant, and assembles `RECIPE_CATALOG` keyed by
+directory name. Adding a new use case is a single PR that drops a new
+subdirectory; no central registration code is touched. The `SKILL.md` files
+are the canonical location for the markdown the meta-agent reads when
+deciding which use case to dispatch — symlinked into `.claude/commands/` (or
+its sibling skill location) by a small script committed alongside this RFC,
+so each `SKILL.md` has exactly one source of truth.
+
+The use-case directory is the unit of cohesion: a contributor working on
+`profiling` edits one folder for the recipe, the prompts, the helper scripts,
+and the meta-agent's view of when to use it. The previous proposal split
+recipes (Python), prompts (constants in `analyze/judge/prompt.py`), and
+skills (`.claude/commands/`); the new layout collocates them.
+
+### Recipe surface
+
+A `JudgeRecipe` is a Pydantic `TypedBaseModel` (the seam PR lands the type
+under `cube_harness/analyze/judge/recipe.py`; this RFC widens it). The
+constitution forbids YAML configuration — recipes are Python, instantiated by
+recipe authors in `use_cases/<name>/recipe.py` and aggregated into
+`RECIPE_CATALOG`. There is no recipe loader; you import a `JudgeRecipe` and
+pass it to `judge_episode(..., recipe=...)`.
+
+```python
+class JudgeRecipe(TypedBaseModel):
+    name: str
+    system_prompt: str
+    user_prompt_template: str
+    model: str = "claude-sonnet-4-6"
+    allowed_tools: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
+    audit: bool = False           # gate for the per-episode audit pass
+    post_judge_survey: bool = True
+    permission_mode: Literal["bypassPermissions", "ask"] = "bypassPermissions"
+```
+
+`tuple[str, ...]` rather than `list[str]` for `allowed_tools` because the
+recipe is frozen at instantiation and a tuple makes that obvious; Pydantic
+serialises tuples and lists identically.
+
+**Critical change from revision 1:** there is no `driver` field on
+`JudgeRecipe`. The choice of terminal vs SDK driver is orthogonal to what the
+recipe is asking the judge to do. Drivers are passed to `judge_episode(...,
+driver=...)` and overridden via the CLI's `--driver` flag. This also kills
+the need for a `DRIVER_REGISTRY` to round-trip the recipe through JSON: the
+recipe never references a driver, so JSON serialisation is straightforward
+Pydantic.
+
+Initial catalog (in `use_cases/`):
+
+| Use case | When | Notable settings |
+|---|---|---|
+| `general_blame` | Default. Mirrors today's behaviour from #366. | Stock `JUDGE_SYSTEM_PROMPT`, full taxonomy, claude-sonnet-4-6. |
+| `profiling` | Activated when an experiment is flagged with `profiling=True`. The judge focuses on a profiling trace path listed in the context file. | Adds `BashOutput` to allowed tools (so the judge can run helpers in `scripts/summarise_profile.py`); narrower taxonomy: `agent_scaffolding`, `model_capability`, `none`. |
+| `agent_scaffolding` | Deeper blame ontology aimed at agents themselves (loop subtype, stuck phase, response-vs-action mismatch). | Output schema extends `JudgeOutput` via a sibling `scaffold_diagnosis` field — non-breaking, omitted by other use cases. |
+
+`hint_harvest` and `auto_verified` are deferred to follow-up PRs (one
+directory per PR) as agreed in design review.
+
+### Context file format and requirement
+
+The meta-agent generates one markdown file per experiment, by default at
+`<experiment_dir>/judge_context.md`. The file MAY contain prose for the
+judge's human readers but the only machine-parsed content is fenced code
+blocks named `paths`:
+
+````markdown
+# Judge context for experiment 20260511_workarena_genny_h45
+
+This experiment compares Genny (haiku-4-5) against the new Genny+memory
+variant on WorkArena-L1. Focus on `agent_scaffolding` blames in the explore
+phase.
+
+```paths
+cube_package: /Users/.../cube-harness/cubes/workarena
+agent_package: /Users/.../cube-harness/src/cube_harness/agents
+cube_harness: /Users/.../cube-harness/src/cube_harness
+profiling_trace: /Users/.../runs/20260511_.../profiling.json
+```
+````
+
+`validate_context_file(path)` already exists in `analyze/judge/context.py`
+(seamed). It parses the `paths` fence, resolves relative paths against the
+file's directory, raises `FileNotFoundError` if any path does not resolve,
+and returns a `name -> Path` mapping.
+
+**Critical change from revision 1:** the judge **requires** a context file.
+It does not fall back to `collect_source_paths`. If
+`<experiment_dir>/judge_context.md` is missing or any referenced path does
+not resolve, the judge raises. There is no silent reconstruction path. The
+rationale is that an ad-hoc judgment with mis-resolved venv paths is a class
+of bug we have already paid for; making the context an explicit, validated
+input keeps the judge's behaviour predictable across machines.
+
+To preserve the developer ergonomics that the previous fallback supplied, a
+new CLI subcommand bootstraps the file:
+
+```
+ch-judge init-context <experiment_dir>
+```
+
+This walks the experiment's `experiment_config.json` exactly as the old
+`collect_source_paths` did, writes a `judge_context.md` with the discovered
+paths, and exits. Developers run it once after an experiment finishes;
+re-running the judge then uses the same file the meta-agent would have
+produced. The file is committed-when-meaningful and inspected in PR review.
+
+### Coding-agent driver Protocol
+
+Today's `_run_claude_code` is one of N possible ways to drive a coding agent.
+Auto-CUBE introduces an `AgentDriver` Protocol so the judge becomes a thin
+"build prompt, parse output" layer over whichever driver is supplied.
+
+```python
+class DriverResult(TypedBaseModel):
+    output_text: str
+    prompt_tokens: int
+    completion_tokens: int
+    cost_usd: float            # 0.0 when the driver has no metered billing
+    duration_s: float
+    actions: list[ToolAction]  # tool calls observed during the run
+
+class ToolAction(TypedBaseModel):
+    tool: str
+    input_summary: str
+    raw_input: dict[str, Any] | None   # populated only in trace_mode="full"
+
+class AgentDriver(Protocol):
+    name: str                  # e.g. "claude-code-sdk", "claude-terminal"
+    max_parallelism: int       # advisory ceiling for `judge_experiment(n_parallel=...)`
+
+    async def run(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        cwd: Path,
+        additional_dirs: list[Path],
+        model: str,
+        allowed_tools: Sequence[str],
+        verbose: bool = False,
+        trace_mode: TraceMode = "actions",
+    ) -> DriverResult: ...
+
+    async def continue_session(
+        self,
+        *,
+        follow_up_prompt: str,
+        verbose: bool = False,
+        trace_mode: TraceMode = "actions",
+    ) -> DriverResult: ...
+```
+
+The first method signature mirrors `_run_claude_code` so the SDK refactor is
+mechanical. `continue_session` is the seam used by the audit pass — it
+appends a follow-up turn to the same conversation as the most recent `run`
+call, so the audit prompt sees the prior judgment's context for free. A
+driver that cannot continue a session (e.g. a stateless adapter) raises
+`NotImplementedError` from `continue_session`; the judge catches that and
+falls back to a fresh `run` with the prior judgment serialised into the
+prompt.
+
+`max_parallelism` is an advisory ceiling — `judge_experiment` clamps
+`n_parallel` against `driver.max_parallelism` and emits a single log line on
+clamp. It is advisory rather than enforced because cluster-level concurrency
+caps live above this layer.
+
+#### `ClaudeCodeSDKDriver`
+
+Wraps today's `claude-agent-sdk` calls. `max_parallelism = 8` matches the
+SDK's empirically stable parallel ceiling on a single host; higher numbers
+hit `claude` CLI process churn. Cost is reported through `ResultMessage.usage`
+exactly as today.
+
+#### `TerminalClaudeDriver`
+
+Launches `claude` via `asyncio.subprocess.create_subprocess_exec` with the
+system prompt on the command line, the user prompt on stdin, and the
+working directory set to `cwd`. Captures stdout/stderr, scrapes a final
+JSON block via the same `_extract_json_block` helper the SDK path uses.
+
+Trade-offs that drove the design:
+
+- **Token accounting is unavailable.** `cost_usd` and per-call token counts
+  are set to `0`, and `JudgeMetadata.cost_usd` becomes a lower bound rather
+  than a true sum across an experiment. Documented; the joint CSV gains a
+  `driver` column so downstream reports can scope cost summations to
+  metered drivers.
+- **Parallelism is low.** `max_parallelism = 2`. The terminal CLI uses a
+  shared on-disk session store and is not safe to launch in higher fan-out;
+  two is what the user's machine handles reliably. The clamp warning gives
+  researchers a clear reason for any slowdown.
+- **Tool surface is the CLI's, not the SDK's.** The driver passes
+  `--allowed-tools` through but cannot disable tool categories the CLI
+  doesn't expose. Same allowlist (`Read`, `Glob`, `Grep`, `Bash`) works for
+  V1; recipes that need anything else fall back to the SDK driver.
+- **No streaming progress.** `verbose=True` for the terminal driver streams
+  the CLI's stderr unchanged. The "one line per tool call" formatting that
+  the SDK driver produces is unavailable.
+- **`continue_session` uses `claude --continue`** with the follow-up prompt
+  on stdin. Works for the audit pass on a single host; not safe under
+  parallel use of the same session store, so the audit pass on the terminal
+  driver runs serially per host.
+
+The trade is intentional: a subscription holder loses cost reporting and
+parallelism but gains the ability to run judges at all without an API key.
+Both drivers expose `.raw` on the returned object the caller can use for
+escape-hatch inspection (`SR-003`), but the Protocol does not require it
+because the raw types differ.
+
+#### Codex driver (out of scope, signposted)
+
+Codex would slot in as a third implementation of `AgentDriver`. Its
+session-cookie auth and CLI flags are different enough to want its own
+proposal. The Protocol's `additional_dirs` and `allowed_tools` already
+accommodate the surface; nothing in V1 needs to change to admit it later.
+
+### Constitution alignment: PS-002 (LiteLLM as the standard)
+
+The constitution's PS-002 rule says LLM calls must go through LiteLLM, not
+direct provider SDKs. The judge's `claude-agent-sdk` call is not a classic
+LLM call — it is an *agent runtime* — but the question of "is there a standard
+abstraction we should be using" still applies.
+
+**There is.** LiteLLM ships first-party support for the Claude Agent SDK
+([docs](https://docs.litellm.ai/docs/tutorials/claude_agent_sdk)) via its
+proxy: the SDK is pointed at `ANTHROPIC_BASE_URL=<litellm-proxy>` with a
+LiteLLM-issued auth token, and from then on every call the SDK makes is
+routable through LiteLLM's provider catalog (Anthropic direct, Bedrock,
+Vertex, Azure, …). LiteLLM also has a broader [Agent SDKs
+page](https://docs.litellm.ai/docs/agent_sdks) covering related runtimes.
+
+Auto-CUBE's drivers honour PS-002 by **routing through LiteLLM when a proxy
+is configured**:
+
+- `ClaudeCodeSDKDriver` reads `LITELLM_PROXY_URL` from the environment. When
+  set, it exports `ANTHROPIC_BASE_URL=$LITELLM_PROXY_URL` and the matching
+  auth header to the SDK before invoking it. When unset, it falls back to
+  the SDK's default (direct Anthropic). This matches the integration pattern
+  in the LiteLLM docs and keeps API-key-based developer flows unchanged.
+- `TerminalClaudeDriver` exports the same env vars to the subprocess. The
+  CLI honours them identically.
+
+This is additive: no existing call site changes. The constitution rule is
+satisfied because every billable token now flows through the canonical
+gateway, and the driver Protocol stays small (no LiteLLM types leak into
+`AgentDriver`).
+
+A minor addition to the experiment record: when a LiteLLM proxy is in use,
+the driver records `litellm_proxy_url` (URL only, no credentials) on
+`DriverResult`, surfaced in `judge_metadata.json`. This is an audit signal
+for "did this judgment route through the gateway?" and supports the
+hermetic-reproducibility goal of PS-001.
+
+If at follow-up time we discover LiteLLM's Agent SDK support drifts (model
+list lag, missing parameters), the driver Protocol gives us the seam to fall
+back to a thin internal wrapper without touching call sites. PS-002's
+preferred order — "use LiteLLM if it covers the SDK; otherwise use another
+mature standard; otherwise wrap" — is preserved by the Protocol regardless
+of which path we sit on.
+
+### Related-trajectory selection
+
+A `Selector` is a small typed callable that returns the related-trajectory
+paths the judge will be given alongside the main trajectory:
+
+```python
+class Selector(Protocol):
+    name: str
+    k: int                       # upper bound on returned trajectories
+
+    def select(
+        self,
+        *,
+        main_episode: EpisodeRef,
+        experiment_dir: Path,
+        all_refs: Sequence[EpisodeRef],
+    ) -> list[Path]: ...
+```
+
+Built-in selectors:
+
+- `SameTaskDifferentAgent(k=3)` — returns up to `k` episodes from sibling
+  experiments that share the same `task_id` but differ on
+  `agent_config._type`. Useful for contrastive analysis ("Genny took 30
+  steps, ReAct took 12, why?").
+- `SameAgentPreviousIteration(k=2)` — within the same experiment family
+  (resolved via the experiment-level `family_id` already written into
+  `experiment_config.json`), returns up to `k` predecessors with the same
+  task. Useful for hypothesis-tracking iterations.
+- `TopKBySimilarityStub(k=3)` — placeholder that returns the `k` most
+  recent neighbours by directory mtime. The intent is to swap in a real
+  similarity scorer (trajectory length + outcome + tool-call profile)
+  without changing the selector contract.
+
+Selectors live in `analyze/judge/selection.py` alongside the existing
+`EpisodeRef` / `discover_episodes` / `select_episodes` helpers, which are
+about *which episodes to judge in the current experiment*. Naming is
+deliberate: episode *selection* picks the work pool; related-trajectory
+*selection* picks neighbours per piece of work. Both are operations on
+`EpisodeRef`; sharing the module keeps the file boundary aligned with the
+domain.
+
+A selector is supplied per call (`judge_episode(..., selector=...)`) rather
+than baked into the recipe, mirroring the driver decision: which neighbours
+to pull is an outer-loop policy choice the meta-agent makes, not a property
+of the judging task itself.
+
+### Post-judge survey
+
+After the judge writes its `JudgeOutput`, a second pass runs against the
+same driver, with a short system prompt that asks the judge to fill in
+`post_judge_survey.json`. The schema is fixed:
+
+```python
+class PostJudgeSurvey(TypedBaseModel):
+    schema_version: int = 1     # mirrors JUDGE_SCHEMA_VERSION on JudgeMetadata
+    recipe: str
+    ease_of_analysis: int = Field(..., ge=0, le=5)
+    context_quality: int = Field(..., ge=0, le=5)
+    tooling_gaps: list[str] = Field(default_factory=list)
+    notes: str | None = None
+```
+
+`schema_version` is on the model (not in the filename) to mirror the existing
+`JudgeMetadata.JUDGE_SCHEMA_VERSION` convention, so survey schema and judge
+schema evolve through the same mechanism. Filename versioning would diverge
+from the existing pattern with no win.
+
+The seam PR lands the stub: today, the file is written with `None` integers
+and an empty list. Auto-CUBE populates it. Three design points:
+
+- **Why a second pass and not a single richer schema?** Survey questions
+  pull the judge toward meta-reasoning ("how easy was this?") that
+  contaminates the primary judgment. Splitting the passes keeps `JudgeOutput`
+  free of self-referential noise.
+- **Why not an embedding-based heuristic instead of asking the model?**
+  Tooling-gap detection ("I wanted to see the screenshot but the file was
+  missing") is inherently semantic. A heuristic that grep'd for "I couldn't
+  find" would catch maybe 40% of cases.
+- **Cost.** Roughly +15% on the judgment's total cost. The
+  `JudgeRecipe.post_judge_survey` flag lets recipes that don't care skip it.
+
+The survey is read by the audit pass and by the eventual sweep aggregator
+that produces `tooling_gaps.csv`.
+
+### Audit pass
+
+Replaces the previous `self_judge` recipe. The shape:
+
+- **Trigger.** `audit=True` on the recipe, or `--audit` at the CLI / via
+  `judge_experiment(audit=True)`. Default off.
+- **Mechanism.** After the primary judgment writes `judge_output.json` and
+  the survey writes `post_judge_survey.json`, the judge issues
+  `driver.continue_session(follow_up_prompt=AUDIT_PROMPT)`. The audit prompt
+  asks the judge to critique its own reasoning: were the cited evidence
+  pieces actually load-bearing? Did the judge skip a contradicting tool
+  call? Would a different `primary_blame` be defensible?
+- **Output.** `audit.json` next to `judge_output.json`. Schema:
+
+  ```python
+  class AuditOutput(TypedBaseModel):
+      schema_version: int = 1
+      recipe: str
+      driver: str
+      reasoning_quality: int = Field(..., ge=0, le=5)
+      missed_evidence: list[str] = Field(default_factory=list)
+      alternative_blames: list[BlameAlternative] = Field(default_factory=list)
+      verdict: Literal["sound", "questionable", "wrong"]
+      notes: str | None = None
+
+  class BlameAlternative(TypedBaseModel):
+      blame: str
+      rationale: str
+  ```
+
+- **Driver fallback.** When the driver does not implement
+  `continue_session`, the audit pass calls `driver.run(...)` afresh with the
+  prior judgment, prior trace, and prior survey serialised into the user
+  prompt. Same `audit.json` output; the only loss is that the audit no
+  longer benefits from in-conversation context economy.
+
+The audit is **not** a recipe in the catalog because it always layers on top
+of an existing judgment. Treating it as a flag avoids the temptation to
+fork the catalog (`general_blame`, `general_blame_audit`,
+`profiling_audit`, …).
+
+The follow-up PR — out of scope here — adds the **batch audit step** the
+user asked for: a meta-agent skill (`audit_batch.md`) plus a script
+(`analyze/cross_experiment/audit_batch.py`) that walk a sweep directory,
+collect every `audit.json`, re-judge any trajectory whose verdict is
+`questionable` or `wrong`, and produce a per-sweep
+`audit_quality_report.md`. This RFC fixes the on-disk schema for `audit.json`
+so the batch tool can be written without churn.
+
+### Cross-judge agreement
+
+For a sweep where the meta-agent wants a confidence signal, the inner loop
+is run multiple times per episode **with the same recipe at different
+seeds**. Cross-recipe agreement is intentionally out of scope for this
+artifact — comparing a `general_blame` judgment to an `agent_scaffolding`
+judgment is well-defined only on shared core fields, and the user feedback
+is that the more useful signal is single-recipe variance across seeds (does
+the same recipe reach the same blame on the same trajectory twice?).
+
+The runner that does the re-judging is out of scope for the first PR; the
+**output shape** is fixed here so the joint-CSV consumer never breaks when
+the runner ships.
+
+For each (recipe, trajectory) pair that has more than one judgment, a row
+is written to `<experiment_dir>/cross_judge_agreement.csv`:
+
+| Column | Meaning |
+|---|---|
+| `trajectory_id` | the episode |
+| `recipe` | the recipe name (single value — agreement is per-recipe) |
+| `n_judgments` | how many seeds were run for this (recipe, trajectory) pair |
+| `seeds` | semicolon-separated seed values |
+| `primary_blame_modal` | the modal `primary_blame` across judgments |
+| `primary_blame_agreement` | fraction in `[0, 1]` agreeing with the mode |
+| `outcome_modal` | the modal `outcome` |
+| `outcome_agreement` | fraction agreeing with the mode |
+| `confidence_mean` | mean of `primary_blame_confidence` across judgments |
+
+This file is the meta-agent's confidence signal. Low
+`primary_blame_agreement` flags an episode for human review. It is also the
+input to recipe-quality work: if a single recipe disagrees with itself
+across seeds on a specific failure mode, that recipe's prompt needs
+sharpening.
+
+The choice to put cross-judge state in a sibling CSV rather than nesting it
+inside `EpisodeRecord` mirrors the
+`experiment_judge_summary.json` / `episode_record.judge_output` split from
+PR #366: the per-episode record stays a pure analytical document; aggregate
+artifacts live at the experiment root.
+
+### Joint CSV across experiments
+
+The outer loop concatenates per-experiment `experiment_judge_report.csv`
+files into one row per (experiment, episode), with these added columns:
+
+- `experiment_id` — the experiment directory name.
+- `family_id` — the sweep this experiment belongs to (already written by
+  the experiment runner; copied verbatim here).
+- `agent_dotted` / `benchmark_dotted` — the dotted `_type`s pulled from
+  `experiment_config.json`.
+- `driver` — the driver name (`claude-code-sdk`, `claude-terminal`, ...).
+- `recipe` — the recipe name (`general_blame`, ...).
+- `litellm_proxy_url` — when set; empty string otherwise. Lets reports
+  filter "judgments routed through the gateway" from "judgments that hit
+  Anthropic direct."
+- All columns from `experiment_judge_report.csv` (the per-experiment file
+  produced by PR #366).
+- Cross-judge agreement columns when available, joined on
+  `(trajectory_id, recipe)`.
+
+Written by `cube_harness.analyze.cross_experiment.joint_csv.write_joint_csv`
+to `<sweep_dir>/joint_judge_report.csv`. CSV rather than Parquet because the
+meta-agent reads it with `grep`/`csv.reader`; the row count rarely exceeds
+the low thousands for a sweep. Parquet is a follow-up if and when sweep
+sizes grow.
+
+### Meta-agent integration
+
+The meta-agent owns the outer loop. Its responsibilities, in the order they
+fire:
+
+1. **Plan the sweep.** Pick the experiments to dispatch. This stage is
+   human-in-the-loop today and stays that way for V1 — a researcher writes a
+   recipe under `recipes/` that defines the sweep, or invokes
+   `/meta-agent` interactively.
+2. **Generate context files.** For each experiment, write
+   `<experiment_dir>/judge_context.md` with the paths and prose the judge
+   needs. The meta-agent does this *before* the experiment runs and the
+   context file becomes part of the experiment's artifacts. Required, not
+   optional.
+3. **Dispatch.** Submit experiments via the existing
+   `run_sequentially` / `run_with_ray` path. The meta-agent does not touch
+   the episode loop.
+4. **Judge.** When each experiment finishes, the meta-agent kicks
+   `judge_experiment` with the recipe selected for that experiment and the
+   driver chosen for the cluster (typically `claude-code-sdk` on shared
+   infra; `claude-terminal` on a researcher's laptop). Recipe selection is
+   rule-based for V1, driven by the use-case directories' `SKILL.md`
+   metadata.
+5. **Aggregate.** Write `joint_judge_report.csv` for the sweep. Optionally
+   re-judge for cross-judge agreement (same recipe, multiple seeds).
+6. **Analyse.** Produce an `experiment_judge_report.md` per experiment and a
+   `sweep_judge_report.md` for the whole sweep. These are LLM-authored
+   markdown documents with cited evidence from the joint CSV. The meta-agent
+   is the author; this RFC does not specify the prompt.
+7. **Audit (optional, follow-up).** Run the audit-batch step over the
+   previous sweep — collect all `audit.json` files, re-judge flagged
+   trajectories, produce `audit_quality_report.md`. Schema fixed in this
+   RFC; runner ships in the follow-up.
+8. **Intervene.** Propose interventions: prompt edits, scaffold tweaks, new
+   hints, recipe changes. **All interventions are reviewed by a human
+   before merge.** This is the human-in-the-loop boundary: the meta-agent
+   can author, dispatch, judge, and report; it cannot push to a branch or
+   merge a PR.
+
+The boundary matters. A self-judging system that ships its own fixes is a
+much higher-risk surface than one that ships proposals. Auto-CUBE is the
+latter.
+
+### Migration of `meta_agent/`
+
+The `meta_agent/` directory today holds `recipes/` (one file:
+`workarena_l1_full.py`), `hints/` (one file:
+`swebench-verified.json`), the standalone script `workarena_hints.py`, and a
+`README.md`. The skill at `.claude/commands/meta-agent.md` and the per-session
+journals under `~/cube_meta_agent_journal/` are out of scope for this RFC.
+
+The migration is conservative because there is not much to move:
+
+| Today | Auto-CUBE | Reason |
+|---|---|---|
+| `meta_agent/recipes/workarena_l1_full.py` | stays in place | These are *experiment* recipes (Pydantic `Experiment` instances), not *judge* recipes. They are the outer-loop dispatch artifacts. |
+| `meta_agent/hints/swebench-verified.json` | `cubes/swebench-verified/hints/` (per-cube) | Hints are consumed by the benchmark code at runtime, not by the meta-agent. Per-cube ownership matches the existing pattern documented in `meta_agent/README.md`. |
+| `meta_agent/workarena_hints.py` | `cubes/workarena/scripts/` or deleted | One-off script; not part of the loop contract. |
+| Future judge use cases | `cube_harness/analyze/judge/use_cases/<name>/` | New home. Each use case is a directory with recipe + skill + scripts. |
+| Future cross-experiment tools | `cube_harness/analyze/cross_experiment/` | New module for the joint-CSV, cross-judge, and audit-batch aggregators. |
+| Slash command at `.claude/commands/meta-agent.md` | stays | Until the dispatch / analysis loop is codified into typed Python, the slash command is the runner. Its `SKILL.md`s are now sourced from `use_cases/<name>/SKILL.md`. |
+
+The journals under `~/cube_meta_agent_journal/` remain machine-local; this
+RFC does not propose committing them.
+
+### Trace and telemetry surface
+
+Every Auto-CUBE call sits on the existing OTel tracer (`SR-002`). The driver
+Protocol's `run` and `continue_session` are wrapped in a
+`tracer.span("auto_cube.judge.driver_run")` (or `..._continue`) with
+attributes:
+- `auto_cube.driver` — driver name
+- `auto_cube.recipe` — recipe name
+- `auto_cube.model` — model string
+- `auto_cube.litellm_proxy` — boolean, true when `LITELLM_PROXY_URL` was set
+- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` from the driver
+  result (zero on the terminal driver)
+
+This is purely additive — no spans are removed, no attribute names change.
+
+---
+
+## Trade-offs
+
+### TerminalClaudeDriver parallelism
+
+The driver caps itself at `max_parallelism = 2`. This is a real cost: an
+experiment with 50 episodes that the SDK driver judges in 7 minutes at
+`n_parallel=8` takes ~25 minutes through the terminal driver. The
+alternative — running terminal sessions at higher fan-out — corrupts the
+shared on-disk session store and produces empty judgments. We pay the
+latency for users who do not have an API key. The recipe catalog flags this
+in a docstring on `TerminalClaudeDriver` and the joint CSV's `driver` column
+gives downstream reports a way to scope cost analyses to metered drivers.
+
+### Use-case directory churn
+
+Three use cases at launch (`general_blame`, `profiling`, `agent_scaffolding`)
+is small enough to keep the directory layout legible. The risk is that every
+new analytical question proposes a new use case directory and the catalog
+drifts to dozens of near-duplicates. Three guardrails:
+
+- Use cases are typed Python directories. A new use case must add a
+  directory with `recipe.py`, `SKILL.md`, and (optionally) `prompts/` and
+  `scripts/`. The cost of adding one is visible in a PR diff.
+- The taxonomy in `JudgeOutput` is shared by all use cases. They can extend
+  with sibling fields (as `agent_scaffolding` does with `scaffold_diagnosis`)
+  but cannot fork the core taxonomy. Aggregation in the joint CSV stays
+  meaningful.
+- The post-judge survey's `tooling_gaps` field is the signal for whether a
+  new use case is needed vs. an existing one needs sharpening. If a gap
+  repeats across episodes for an existing use case, sharpen it; if it
+  repeats across use cases, propose a new one.
+
+### Judge cost vs. coverage
+
+Cross-judge agreement multiplies judge cost by the number of seeds per
+episode. A 50-episode experiment judged at `n_seeds=3` costs roughly 3× a
+single-judgment baseline. The first PR does not ship the cross-judge
+runner; when it does, the meta-agent will run cross-judge only on episodes
+flagged by low primary-blame confidence (≤ 2) from the first pass. This
+keeps the cost bounded to the episodes where the signal is worth the spend.
+
+### Survey overhead
+
+The survey adds roughly 15% to judgment cost per episode. The trade is the
+feedback loop into tooling improvements. Use cases that don't need it skip
+the pass via `post_judge_survey=False`; the default in V1 is on.
+
+### Audit overhead
+
+The audit pass adds roughly 25% to per-episode cost (one extra LLM turn that
+re-reads the prior judgment). Off by default. When on, the meta-agent gets
+a per-episode quality signal that the survey alone does not provide
+(survey is the judge's self-report on how easy the analysis was; audit is
+the judge's critique of its own conclusion).
+
+---
+
+## Phasing
+
+### First Auto-CUBE PR (this RFC's deliverable)
+
+- `AgentDriver` Protocol in `cube_harness/analyze/judge/driver.py`, including
+  `continue_session` for the audit pass.
+- `ClaudeCodeSDKDriver` — refactor of today's `_run_claude_code` into the
+  Protocol shape; bit-identical behaviour for the `general_blame` recipe.
+  Honours `LITELLM_PROXY_URL` per PS-002.
+- `TerminalClaudeDriver` — subprocess implementation, capped at
+  `max_parallelism=2`. Honours `LITELLM_PROXY_URL`.
+- `JudgeRecipe` widening: `user_prompt_template`, `audit`,
+  `post_judge_survey`, `permission_mode` fields. **No `driver` field** —
+  drivers are call-time, not recipe-time.
+- Use-case directories under `cube_harness/analyze/judge/use_cases/`:
+  `general_blame`, `profiling`, `agent_scaffolding`. Each contains
+  `recipe.py`, `SKILL.md`, `prompts/`, and (for `profiling`) `scripts/`.
+- `RECIPE_CATALOG` assembled by `use_cases/__init__.py` walking
+  subdirectories.
+- `Selector` Protocol + the three built-in selectors. Selector is supplied
+  per call, not on the recipe.
+- Survey collection: second-pass driver invocation; schema enforcement with
+  `schema_version`.
+- Audit pass: flag-gated; `audit.json` schema with `schema_version`.
+- Context-file as the **only** input to the judge (`validate_context_file`
+  promoted from "fallback when used" to "required, raises if missing"). New
+  CLI subcommand `ch-judge init-context` for ad-hoc bootstrap.
+- `joint_judge_report.csv` schema fixed (no runner yet).
+- `cross_judge_agreement.csv` schema fixed (no runner yet).
+- `meta_agent/` migration: directory layout updated, README rewritten,
+  `hints/swebench-verified.json` moved to `cubes/swebench-verified/`.
+
+### Follow-up PRs (called out in this RFC)
+
+1. **Cross-judge runner** — the `judge_experiment` extension that runs
+   episodes through the same recipe at multiple seeds and writes
+   `cross_judge_agreement.csv`. Gated on `primary_blame_confidence ≤ 2` to
+   keep cost bounded.
+2. **Joint-CSV runner** — the `write_joint_csv(sweep_dir)` helper plus the
+   sweep-discovery walk.
+3. **Audit-batch runner** — the meta-agent skill +
+   `analyze/cross_experiment/audit_batch.py` script that walks a sweep,
+   collects `audit.json` files, re-judges flagged trajectories, and writes
+   `audit_quality_report.md`.
+4. **Codex driver** — third `AgentDriver` implementation, also
+   LiteLLM-routable via the Codex Agent SDK adapter.
+5. **TopK similarity selector** — replace the mtime stub with a real
+   trajectory-feature scorer.
+6. **Additional use cases** — one PR per directory: `hint_harvest`,
+   `auto_verified`, and any new ones the survey/audit signal motivates.
+7. **Typed meta-agent loop** — promotes the slash command's responsibilities
+   into `cube_harness.analyze.cross_experiment.meta_agent` with typed
+   dispatch and analysis steps. The slash command stays as the human-facing
+   entry point.
+
+---
+
+## Open questions
+
+1. **Where does the per-use-case `SKILL.md` get registered?** The Claude
+   Code skill convention expects skills under `.claude/commands/` (or
+   `.claude/skills/`). The use-case directory layout puts the source file
+   under `analyze/judge/use_cases/<name>/SKILL.md`. V1 plan: a small script
+   committed alongside this RFC creates symlinks at
+   `.claude/skills/judge-<name> -> analyze/judge/use_cases/<name>/SKILL.md`.
+   Is the symlink approach acceptable, or do we want a registration step
+   that copies them?
+2. **`continue_session` semantics on the SDK driver.** The
+   `claude-agent-sdk` exposes a continuation API; we want the audit pass to
+   reuse the same session so prior context is in-conversation. Open: does
+   the SDK's continuation handle the case where the session has crossed
+   tool-call boundaries (the survey pass between the primary judgment and
+   the audit pass), or do we need to checkpoint the session ID through
+   `DriverResult` and restore it manually? Verifying against the SDK before
+   the first PR ships.
+3. **Audit prompt design.** This RFC fixes the schema and the trigger but
+   leaves the audit prompt unspecified. The prompt belongs in the
+   `general_blame` use-case directory's `prompts/audit.md` (so each use
+   case can override). V1 ships a single shared `prompts/audit.md` symlinked
+   into each use case until we see divergence.
+4. **`init-context` defaults.** `ch-judge init-context <experiment_dir>`
+   walks `experiment_config.json` and writes a starter file. Open: does it
+   include a prose section template, or just the `paths` fence? V1 plan:
+   paths fence only — the meta-agent fills prose when it generates the file
+   for real; the developer-bootstrap form has empty prose.
+5. **Cross-judge cost gating.** The follow-up cross-judge runner targets
+   episodes with `primary_blame_confidence ≤ 2`. Is the threshold the right
+   one (some recipes systematically run high-confidence even when wrong),
+   or do we need a use-case-specific threshold? Defer to the audit-batch
+   PR, which will have data to calibrate against.
+
+---
+
+## References
+
+- `openspec/changes/trajectory-judge/proposal.md` — PR #366, the inner-loop
+  judge this RFC extends.
+- `openspec/changes/trajectory-judge/deltas.md` — the V1 judge surface area.
+- `openspec/changes/atlas-eval-log/proposal.md` — `EpisodeRecord` and the
+  `judge_output` / `judge_metadata` fields the inner loop writes.
+- `openspec/changes/agent-owns-loop/proposal.md` — orthogonal episode-loop
+  work; does not touch the judge.
+- `.claude/commands/meta-agent.md` — the current slash command driving the
+  outer loop.
+- `.claude/commands/judge-traces.md` — the slash command for invoking the
+  judge directly.
+- `src/cube_harness/analyze/judge/` — the judge package on the
+  `feat/trajectory-judge` branch (PR #366), where the seam PR landed
+  `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the
+  `related_trajectories` parameter that this RFC builds on.
+- `meta_agent/` — the existing outer-loop scaffolding.
+- `.claude/rules/constitution.md` — the principles this RFC honours
+  (Python-as-config; composition over inheritance; LiteLLM via the
+  Anthropic env-var path on the SDK; trace-first; escape hatches on
+  drivers).
+- LiteLLM Claude Agent SDK integration:
+  https://docs.litellm.ai/docs/tutorials/claude_agent_sdk
+- LiteLLM Agent SDKs overview:
+  https://docs.litellm.ai/docs/agent_sdks

--- a/openspec/changes/auto-cube/proposal.md
+++ b/openspec/changes/auto-cube/proposal.md
@@ -1,966 +1,131 @@
-# RFC: Auto-CUBE — Use-Case-Driven Judge, Coding-Agent Drivers, and the Meta-Agent Outer Loop
+# RFC: Auto-CUBE — Use-Case-Driven Judge + Coding-Agent Drivers
 
-**Status:** DRAFT (revision 2 — folds in design-review feedback from 2026-05-13)
+**Status:** DRAFT (revision 3 — concise rewrite, design decisions only)
 **Author:** Alexandre Lacoste
-**Reviewer:** TBD
 **Date:** 2026-05-13
 
-**Companion RFCs:**
-- `openspec/changes/trajectory-judge/proposal.md` (PR #366) — the inner-loop judge this
-  RFC builds on.
-- `openspec/changes/agent-owns-loop/proposal.md` — orthogonal; touches the episode
-  loop, not the post-hoc judge or the meta-agent.
+**Companions:** `trajectory-judge` (PR #366, the judge this builds on), `agent-owns-loop` (PR #386, orthogonal — touches the episode loop, not the judge).
 
 ---
 
 ## Problem
 
-cube-harness today has three pieces of post-hoc analysis machinery that were
-designed in isolation and do not compose:
+The trajectory judge (PR #366) is monolithic: one hard-coded prompt, one model, one tool surface, one transport (`claude-agent-sdk`). The meta-agent is a slash command that drives experiments and writes journals but has no typed contract with the judge. There is no story for:
 
-1. The **trajectory judge** in `cube_harness/analyze/judge/` (landing as PR #366).
-   It produces a structured `JudgeOutput` per episode by invoking Claude Code over
-   the `claude-agent-sdk`. Its prompt, model, and tool surface are hard-coded
-   constants in `analyze/judge/prompt.py` and `analyze/judge/sdk.py`. There is one
-   judge, and changing what the judge looks at means editing the module.
+- Running the judge **per use case** (general blame vs profiling vs scaffolding analysis) without forking the judge module.
+- Running the judge **without an API key** (researcher with only a Claude Code subscription) or on top of a different coding agent (Codex).
+- Letting the meta-agent **inject experiment-specific context** the judge should focus on.
+- A **self-quality signal** — does the judge agree with itself? did it miss evidence?
+- A **cross-experiment view** the outer loop can grep.
 
-2. The **meta-agent** in `meta_agent/`, plus a fleet of `feat/meta-agent-*`
-   branches. Recipes (e.g. `meta_agent/recipes/workarena_l1_full.py`), hints
-   (`meta_agent/hints/swebench-verified.json`), tooling and result journals live
-   side-by-side, but the workflow they implement is held together by a slash
-   command (`.claude/commands/meta-agent.md`) rather than by typed Python.
+Auto-CUBE adds those four seams. It is post-hoc only — episode loop and storage formats are untouched.
 
-3. **New ideas** from the user about how these pieces should compose into a
-   long-term, self-improving system: judge use-cases packaged as cohesive units
-   (judge recipe + meta-agent skill + supporting scripts), coding-agent
-   abstraction so the judge can run on a subscription instead of an API key,
-   joint analysis across experiments, an audit pass that closes the loop back to
-   the judge's own quality.
+---
 
-The fragmentation has five concrete costs that this RFC addresses:
+## Design — five decisions
 
-1. **The pre-judge owns context that should be the meta-agent's job.**
-   `collect_source_paths` in `analyze/judge/context.py` resolves paths by
-   importing `_type` strings from `experiment_config.json` against the local
-   venv. This is correct for ad-hoc judging on a developer laptop but cannot
-   express the per-experiment shape the meta-agent needs ("for this experiment,
-   focus on the profiling trace; for that one, contrast with these three other
-   trajectories"). The judge re-derives context every run and there is no place
-   for an outer loop to inject curated context.
+### 1. Each use case is a directory
 
-2. **No coding-agent abstraction.** `_run_claude_code` in `analyze/judge/sdk.py`
-   talks to `claude-agent-sdk` directly. Researchers who hold a Claude Code
-   subscription but no API key cannot run the judge. The Codex CLI cannot be
-   bolted on. Even within the SDK path, there is no way to swap models or tool
-   surfaces — the constants `JUDGE_ALLOWED_TOOLS` and
-   `permission_mode="bypassPermissions"` are inlined.
+`cube_harness/analyze/judge/use_cases/<name>/` holds the `JudgeRecipe` (Pydantic), the meta-agent skill (`SKILL.md`), the prompts, and any supporting scripts for that use case. `RECIPE_CATALOG` is assembled by walking the directory on import. New use cases are one-directory PRs.
 
-3. **No feedback loop from judge to tooling.** When the judge runs into a gap —
-   a missing profiling trace, an unparseable observation, a source tree it
-   cannot reach — that experience evaporates. There is no record of *why* a
-   judgment was hard, and no signal that lets us improve the judge's toolchain
-   over time.
+Initial catalog: **`general_blame`**, **`profiling`**, **`agent_scaffolding`**. Others (`hint_harvest`, `auto_verified`) are deferred to follow-up PRs.
 
-4. **No joint view across experiments.** `judge_experiment` writes one CSV per
-   experiment (`experiment_judge_report.csv`). The meta-agent's natural unit of
-   work is a *sweep* of experiments — half a dozen agent configs against the
-   same benchmark, or the same agent across benchmarks. There is no row-per
-   (experiment, episode) table the outer loop can grep.
+### 2. `AgentDriver` is our own Protocol — not LiteLLM
 
-5. **No agreement signal.** A single judge call is one sample from a noisy
-   distribution; we have no way to ask "would the same recipe at a different
-   seed reach the same blame on this trajectory?" — which is exactly the
-   question the meta-agent needs to answer before recommending an intervention.
+LiteLLM is a model gateway, not a coding-agent abstraction. To swap Claude Code SDK ↔ terminal `claude -p` ↔ `codex exec`, we need our own thin Protocol:
 
-Auto-CUBE is the umbrella that unifies these threads. It is not a rewrite. It
-is a contract that says: each use case is a directory containing a judge recipe
-plus the meta-agent skill that drives it; the judge runs against an abstract
-coding-agent driver chosen at call time; the meta-agent owns experiment-level
-context and post-hoc analysis; and a flag-gated audit pass closes the loop
-back to the judge's quality.
+```python
+class AgentDriver(Protocol):
+    name: str
+    max_parallelism: int
+    async def run(...) -> DriverResult
+    async def continue_session(...) -> DriverResult   # for audit pass
+```
+
+Three drivers in scope (Codex is signposted, not built):
+
+| Driver | Auth | Parallelism per host | Cost reported |
+|---|---|---|---|
+| `claude-code-sdk` | API key | ~8 | yes |
+| `claude-terminal` | subscription (`claude -p`) | ~2 | no |
+| `codex-cli` (follow-up) | OpenAI key | ~3 | yes |
+
+**Drivers are call-time, not recipe-pinned.** A researcher swaps `--driver claude-terminal` without touching the recipe. Underneath, model calls still route through LiteLLM when `LITELLM_PROXY_URL` is set, but that's per-driver implementation detail, not part of the Protocol.
+
+### 3. Judge requires a context file — no fallback
+
+The meta-agent writes `<experiment_dir>/judge_context.md` with the paths and prose the judge needs. `validate_context_file` is already seamed; the judge calls it and raises if the file is missing or any path doesn't resolve. The previous `collect_source_paths` venv-walk heuristic is removed from the judge's hot path.
+
+For ad-hoc developer use, a new `ch-judge init-context <experiment_dir>` subcommand bootstraps the file using the old heuristic, then exits.
+
+### 4. Audit pass — flag-gated, replaces `self_judge`
+
+When `--audit` is set, the judge issues a follow-up turn (via `driver.continue_session`) asking it to critique its own reasoning. Output: `audit.json` next to `judge_output.json`. Off by default; ~25% cost overhead when on.
+
+This is a flag, not a recipe — it always layers on top of an existing use case. A follow-up PR adds a batch step that walks a sweep, collects all `audit.json`s, re-judges flagged trajectories, and writes a sweep-level quality report.
+
+### 5. Cross-judge agreement — same recipe, varying seeds
+
+Agreement is `(recipe, trajectory)` × N seeds. Cross-recipe comparison is explicitly out — comparing `general_blame` to `agent_scaffolding` is only well-defined on shared core fields, and the more useful signal is "does this recipe reach the same blame twice?"
+
+Output schema (`cross_judge_agreement.csv`) is fixed in this PR; the re-judging runner is a follow-up gated on low primary-blame confidence.
+
+---
+
+## Outputs
+
+Per episode (inside `<episode_dir>/`):
+- `judge_output.json` — from PR #366, unchanged
+- `judge_trace.json` — from PR #366, unchanged
+- `post_judge_survey.json` — second-pass self-assessment (ease, context quality, tooling gaps)
+- `audit.json` — when `--audit` is set
+
+Per experiment (`<experiment_dir>/`):
+- `judge_context.md` — required input, written by meta-agent or `ch-judge init-context`
+- `experiment_judge_report.csv` — from PR #366
+- `cross_judge_agreement.csv` — when multiple seeds were judged
+
+Per sweep (follow-up runner):
+- `joint_judge_report.csv` — one row per (experiment, episode)
+- `audit_quality_report.md` — follow-up batch-audit output
 
 ---
 
 ## Scope
 
-### In (first Auto-CUBE PR)
+**In (this PR):** `AgentDriver` Protocol + two drivers (`claude-code-sdk`, `claude-terminal`); `JudgeRecipe` widening (no `driver`/`selector` fields); the three initial use-case directories; required context file + `init-context` subcommand; survey collection; flag-gated audit pass; selector Protocol with three built-in selectors; fixed schemas for `joint_judge_report.csv` and `cross_judge_agreement.csv` (writers not yet implemented).
 
-- A **use-case directory layout** under `cube_harness/analyze/judge/use_cases/`.
-  Each subdirectory contains the judge `recipe.py`, a `SKILL.md` for the
-  meta-agent, and any supporting scripts/configs that use case needs. Initial
-  catalog: `general_blame`, `profiling`, `agent_scaffolding` (three; the rest
-  are deferred — see "Out").
-- `JudgeRecipe` becomes the unit of judge configuration: name, system prompt,
-  user-prompt template, model, allowed tools. The seam PR (forward-compat to
-  #366) lands the Pydantic model with `name/system_prompt/model/allowed_tools`;
-  this RFC widens it with the user-prompt template field. **`driver` is NOT a
-  recipe field** — drivers are chosen at call time (see Driver section).
-- An `AgentDriver` Protocol that abstracts the coding agent the judge runs as.
-  Two implementations: `ClaudeCodeSDKDriver` (today's `_run_claude_code`
-  refactored to fit the Protocol) and `TerminalClaudeDriver` (subprocess
-  wrapper around the `claude` CLI for users with a subscription but no API key).
-  Both route through the LiteLLM proxy when one is configured (see
-  "Constitution alignment: PS-002").
-- A `Selector` interface for related-trajectory selection, with three built-in
-  selectors: `SameTaskDifferentAgent`, `SameAgentPreviousIteration`, and
-  `TopKBySimilarityStub` (a stub that returns N most recent neighbours; real
-  similarity scoring is a follow-up).
-- `validate_context_file` (already seamed in `analyze/judge/context.py`)
-  becomes the **only** context source. The judge requires
-  `<experiment_dir>/judge_context.md` to exist and to validate; otherwise it
-  raises. The current `collect_source_paths` heuristic is removed from the
-  judge's hot path. A new CLI subcommand `ch-judge init-context
-  <experiment_dir>` bootstraps a context file from the venv, so ad-hoc users
-  can produce the file once and then judge against it.
-- `post_judge_survey.json` collection: the empty stub from the seam PR is
-  populated by a deterministic second pass after each judgment, recording how
-  hard the analysis was, whether the context file was useful, and what tooling
-  gaps were hit. Schema fixed in this RFC, with a `schema_version` field that
-  mirrors the existing `JUDGE_SCHEMA_VERSION` convention.
-- An **audit pass** (flag-gated): when a recipe's `audit=True` is set or
-  `--audit` is passed at call time, the judge runs a second pass that
-  *continues the prior judgment's context* — same driver session, same
-  conversation, with a follow-up prompt asking the judge to critique its own
-  reasoning. Output written to `audit.json` next to `judge_output.json`.
-- A `meta_agent/` repackaging that defines what stays as the outer-loop runner
-  vs. what moves into `analyze/judge/use_cases/<name>/` and
-  `analyze/cross_experiment/`. No behaviour change at the meta-agent loop
-  level; this is a re-homing of the modules.
+**Out (called-out follow-ups):** cross-judge runner; joint-CSV runner; batch-audit runner; Codex driver; real similarity selector; additional use-case directories; typed meta-agent loop (slash command stays).
 
-### Out (later PRs, called out explicitly)
-
-- **Codex driver.** The Protocol is shaped to admit it; the implementation is
-  follow-up work. Codex is structurally similar to the terminal Claude case
-  (subprocess, no programmatic streaming API) but has its own auth and
-  config surface. Like the Claude drivers, it would route through LiteLLM's
-  Codex SDK adapter when one is configured.
-- **Cross-judge agreement runner.** The output schema and the columns it adds
-  to the joint CSV are specified here; the runner that re-judges N times per
-  episode at different seeds is a follow-up. Single-judgment runs today still
-  get a stable record that agreement can be appended to later.
-- **Joint CSV across experiments runner.** The schema is fixed here; the
-  outer-loop module that writes it lives in the follow-up PR that wires the
-  meta-agent to multi-experiment dispatch.
-- **Audit-batch analysis.** The per-episode audit pass ships in the first PR.
-  The meta-agent skill + script that *collects* all audits across a sweep,
-  re-judges the previous batch's trajectories, and produces a quality report
-  ships in a follow-up. Schema for the per-episode `audit.json` is fixed here
-  so the batch tool can be written without churn.
-- **Additional use-case directories** beyond the initial three:
-  `hint_harvest`, `auto_verified`. Each is a separate, small follow-up PR that
-  drops a new directory under `use_cases/`. The plumbing change is in this RFC;
-  catalog growth is incremental.
-- **Full meta-agent rewrite.** Use-case skills relocate under their use-case
-  dirs; the loop driver stays as the slash command at
-  `.claude/commands/meta-agent.md` until the dispatch and analysis steps are
-  codified into typed Python under `analyze/cross_experiment/`.
-- **cube-standard contract changes.** None — this entire RFC is harness-side.
-- **Changes to the episode loop, trajectory format, or storage protocol.**
-  Out — see `agent-owns-loop` for the loop work and `atlas-eval-log` for
-  storage.
+**Not touched:** cube-standard, episode loop, trajectory format, storage protocol, `Episode`/`Experiment`/`exp_runner`, `LLM` wrapper.
 
 ---
 
-## Design
-
-### Architecture overview
-
-Auto-CUBE has two nested loops. The boundary between them is the experiment.
-
-**Inner loop — per experiment, 5 to 10 episodes typically.**
-
-```
-task → agent → trajectory → judge(recipe, driver) → judge_output.json
-                                                  + judge_trace.json
-                                                  + post_judge_survey.json
-                                                  + audit.json (if --audit)
-```
-
-The judge is configured by a `JudgeRecipe` (system prompt, model, allowed
-tools, user-prompt template). It receives a main trajectory directory, the
-**required** `judge_context.md` produced by the meta-agent (or by `ch-judge
-init-context`), and an optional list of related-trajectory paths produced by
-a `Selector`. The driver is supplied at call time (default
-`ClaudeCodeSDKDriver`). The judge emits a `JudgeOutput` (taxonomy and
-evidence; schema fixed by PR #366), a `judge_trace.json` (the agent's tool
-calls during the judgment), a `post_judge_survey.json` (the second-pass
-self-assessment), and — when audit is enabled — an `audit.json` (the
-self-critique pass).
-
-**Outer loop — per sweep, dispatched by the meta-agent.**
-
-```
-meta-agent dispatch → N experiments → joint CSV + cross-judge agreement
-   → meta-agent analysis → Experiment Judge Report → meta-agent intervention
-   → (optional) audit-batch pass over the previous sweep
-```
-
-The meta-agent generates the context file for each experiment, dispatches the
-runs, lets the inner loop write its per-episode outputs, then concatenates
-them into a row-per (experiment, episode) joint CSV. Optional cross-judge
-agreement is computed by re-running the inner loop with the **same recipe**
-at different seeds and comparing `primary_blame` distributions. The
-meta-agent reads the joint CSV, writes an Experiment Judge Report (a markdown
-document with cited evidence), and proposes interventions: prompt tweaks,
-scaffold edits, hint additions, or recipe changes that feed back into the
-next sweep. A separate audit-batch step (follow-up PR) collects the
-`audit.json` files across the previous sweep, re-judges flagged trajectories,
-and reports on judge quality.
-
-The line between the loops is a single contract: the inner loop trusts the
-context file produced by the outer loop and validates that its paths resolve.
-That is the entirety of the inter-loop dependency. The judge knows nothing
-about sweeps; the meta-agent knows nothing about the judge's internal
-toolchain.
-
-### Use-case directory layout
-
-Each judge use case is a self-contained directory under
-`cube_harness/analyze/judge/use_cases/`. The contents are uniform so the
-catalog can be discovered programmatically and so contributors have one
-template to follow:
-
-```
-use_cases/
-├── __init__.py            # exports RECIPE_CATALOG: dict[str, JudgeRecipe]
-├── general_blame/
-│   ├── __init__.py
-│   ├── recipe.py          # JudgeRecipe instance: RECIPE
-│   ├── SKILL.md           # meta-agent skill description (claude-md-improver style)
-│   ├── prompts/
-│   │   ├── system.md      # JUDGE_SYSTEM_PROMPT for this use case
-│   │   └── user.md        # user-prompt template
-│   └── scripts/           # supporting scripts (optional; empty for general_blame)
-├── profiling/
-│   ├── recipe.py
-│   ├── SKILL.md
-│   ├── prompts/
-│   └── scripts/
-│       └── summarise_profile.py   # py-spy / flameprof helper invoked by the judge
-└── agent_scaffolding/
-    ├── recipe.py
-    ├── SKILL.md
-    ├── prompts/
-    └── scripts/
-```
-
-`use_cases/__init__.py` walks the subdirectories on import, imports each
-`recipe.py` for its `RECIPE` constant, and assembles `RECIPE_CATALOG` keyed by
-directory name. Adding a new use case is a single PR that drops a new
-subdirectory; no central registration code is touched. The `SKILL.md` files
-are the canonical location for the markdown the meta-agent reads when
-deciding which use case to dispatch — symlinked into `.claude/commands/` (or
-its sibling skill location) by a small script committed alongside this RFC,
-so each `SKILL.md` has exactly one source of truth.
-
-The use-case directory is the unit of cohesion: a contributor working on
-`profiling` edits one folder for the recipe, the prompts, the helper scripts,
-and the meta-agent's view of when to use it. The previous proposal split
-recipes (Python), prompts (constants in `analyze/judge/prompt.py`), and
-skills (`.claude/commands/`); the new layout collocates them.
-
-### Recipe surface
-
-A `JudgeRecipe` is a Pydantic `TypedBaseModel` (the seam PR lands the type
-under `cube_harness/analyze/judge/recipe.py`; this RFC widens it). The
-constitution forbids YAML configuration — recipes are Python, instantiated by
-recipe authors in `use_cases/<name>/recipe.py` and aggregated into
-`RECIPE_CATALOG`. There is no recipe loader; you import a `JudgeRecipe` and
-pass it to `judge_episode(..., recipe=...)`.
-
-```python
-class JudgeRecipe(TypedBaseModel):
-    name: str
-    system_prompt: str
-    user_prompt_template: str
-    model: str = "claude-sonnet-4-6"
-    allowed_tools: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
-    audit: bool = False           # gate for the per-episode audit pass
-    post_judge_survey: bool = True
-    permission_mode: Literal["bypassPermissions", "ask"] = "bypassPermissions"
-```
-
-`tuple[str, ...]` rather than `list[str]` for `allowed_tools` because the
-recipe is frozen at instantiation and a tuple makes that obvious; Pydantic
-serialises tuples and lists identically.
-
-**Critical change from revision 1:** there is no `driver` field on
-`JudgeRecipe`. The choice of terminal vs SDK driver is orthogonal to what the
-recipe is asking the judge to do. Drivers are passed to `judge_episode(...,
-driver=...)` and overridden via the CLI's `--driver` flag. This also kills
-the need for a `DRIVER_REGISTRY` to round-trip the recipe through JSON: the
-recipe never references a driver, so JSON serialisation is straightforward
-Pydantic.
-
-Initial catalog (in `use_cases/`):
-
-| Use case | When | Notable settings |
-|---|---|---|
-| `general_blame` | Default. Mirrors today's behaviour from #366. | Stock `JUDGE_SYSTEM_PROMPT`, full taxonomy, claude-sonnet-4-6. |
-| `profiling` | Activated when an experiment is flagged with `profiling=True`. The judge focuses on a profiling trace path listed in the context file. | Adds `BashOutput` to allowed tools (so the judge can run helpers in `scripts/summarise_profile.py`); narrower taxonomy: `agent_scaffolding`, `model_capability`, `none`. |
-| `agent_scaffolding` | Deeper blame ontology aimed at agents themselves (loop subtype, stuck phase, response-vs-action mismatch). | Output schema extends `JudgeOutput` via a sibling `scaffold_diagnosis` field — non-breaking, omitted by other use cases. |
-
-`hint_harvest` and `auto_verified` are deferred to follow-up PRs (one
-directory per PR) as agreed in design review.
-
-### Context file format and requirement
-
-The meta-agent generates one markdown file per experiment, by default at
-`<experiment_dir>/judge_context.md`. The file MAY contain prose for the
-judge's human readers but the only machine-parsed content is fenced code
-blocks named `paths`:
-
-````markdown
-# Judge context for experiment 20260511_workarena_genny_h45
-
-This experiment compares Genny (haiku-4-5) against the new Genny+memory
-variant on WorkArena-L1. Focus on `agent_scaffolding` blames in the explore
-phase.
-
-```paths
-cube_package: /Users/.../cube-harness/cubes/workarena
-agent_package: /Users/.../cube-harness/src/cube_harness/agents
-cube_harness: /Users/.../cube-harness/src/cube_harness
-profiling_trace: /Users/.../runs/20260511_.../profiling.json
-```
-````
-
-`validate_context_file(path)` already exists in `analyze/judge/context.py`
-(seamed). It parses the `paths` fence, resolves relative paths against the
-file's directory, raises `FileNotFoundError` if any path does not resolve,
-and returns a `name -> Path` mapping.
-
-**Critical change from revision 1:** the judge **requires** a context file.
-It does not fall back to `collect_source_paths`. If
-`<experiment_dir>/judge_context.md` is missing or any referenced path does
-not resolve, the judge raises. There is no silent reconstruction path. The
-rationale is that an ad-hoc judgment with mis-resolved venv paths is a class
-of bug we have already paid for; making the context an explicit, validated
-input keeps the judge's behaviour predictable across machines.
-
-To preserve the developer ergonomics that the previous fallback supplied, a
-new CLI subcommand bootstraps the file:
-
-```
-ch-judge init-context <experiment_dir>
-```
-
-This walks the experiment's `experiment_config.json` exactly as the old
-`collect_source_paths` did, writes a `judge_context.md` with the discovered
-paths, and exits. Developers run it once after an experiment finishes;
-re-running the judge then uses the same file the meta-agent would have
-produced. The file is committed-when-meaningful and inspected in PR review.
-
-### Coding-agent driver Protocol
-
-Today's `_run_claude_code` is one of N possible ways to drive a coding agent.
-Auto-CUBE introduces an `AgentDriver` Protocol so the judge becomes a thin
-"build prompt, parse output" layer over whichever driver is supplied.
-
-```python
-class DriverResult(TypedBaseModel):
-    output_text: str
-    prompt_tokens: int
-    completion_tokens: int
-    cost_usd: float            # 0.0 when the driver has no metered billing
-    duration_s: float
-    actions: list[ToolAction]  # tool calls observed during the run
-
-class ToolAction(TypedBaseModel):
-    tool: str
-    input_summary: str
-    raw_input: dict[str, Any] | None   # populated only in trace_mode="full"
-
-class AgentDriver(Protocol):
-    name: str                  # e.g. "claude-code-sdk", "claude-terminal"
-    max_parallelism: int       # advisory ceiling for `judge_experiment(n_parallel=...)`
-
-    async def run(
-        self,
-        *,
-        system_prompt: str,
-        user_prompt: str,
-        cwd: Path,
-        additional_dirs: list[Path],
-        model: str,
-        allowed_tools: Sequence[str],
-        verbose: bool = False,
-        trace_mode: TraceMode = "actions",
-    ) -> DriverResult: ...
-
-    async def continue_session(
-        self,
-        *,
-        follow_up_prompt: str,
-        verbose: bool = False,
-        trace_mode: TraceMode = "actions",
-    ) -> DriverResult: ...
-```
-
-The first method signature mirrors `_run_claude_code` so the SDK refactor is
-mechanical. `continue_session` is the seam used by the audit pass — it
-appends a follow-up turn to the same conversation as the most recent `run`
-call, so the audit prompt sees the prior judgment's context for free. A
-driver that cannot continue a session (e.g. a stateless adapter) raises
-`NotImplementedError` from `continue_session`; the judge catches that and
-falls back to a fresh `run` with the prior judgment serialised into the
-prompt.
-
-`max_parallelism` is an advisory ceiling — `judge_experiment` clamps
-`n_parallel` against `driver.max_parallelism` and emits a single log line on
-clamp. It is advisory rather than enforced because cluster-level concurrency
-caps live above this layer.
-
-#### `ClaudeCodeSDKDriver`
-
-Wraps today's `claude-agent-sdk` calls. `max_parallelism = 8` matches the
-SDK's empirically stable parallel ceiling on a single host; higher numbers
-hit `claude` CLI process churn. Cost is reported through `ResultMessage.usage`
-exactly as today.
-
-#### `TerminalClaudeDriver`
-
-Launches `claude` via `asyncio.subprocess.create_subprocess_exec` with the
-system prompt on the command line, the user prompt on stdin, and the
-working directory set to `cwd`. Captures stdout/stderr, scrapes a final
-JSON block via the same `_extract_json_block` helper the SDK path uses.
-
-Trade-offs that drove the design:
-
-- **Token accounting is unavailable.** `cost_usd` and per-call token counts
-  are set to `0`, and `JudgeMetadata.cost_usd` becomes a lower bound rather
-  than a true sum across an experiment. Documented; the joint CSV gains a
-  `driver` column so downstream reports can scope cost summations to
-  metered drivers.
-- **Parallelism is low.** `max_parallelism = 2`. The terminal CLI uses a
-  shared on-disk session store and is not safe to launch in higher fan-out;
-  two is what the user's machine handles reliably. The clamp warning gives
-  researchers a clear reason for any slowdown.
-- **Tool surface is the CLI's, not the SDK's.** The driver passes
-  `--allowed-tools` through but cannot disable tool categories the CLI
-  doesn't expose. Same allowlist (`Read`, `Glob`, `Grep`, `Bash`) works for
-  V1; recipes that need anything else fall back to the SDK driver.
-- **No streaming progress.** `verbose=True` for the terminal driver streams
-  the CLI's stderr unchanged. The "one line per tool call" formatting that
-  the SDK driver produces is unavailable.
-- **`continue_session` uses `claude --continue`** with the follow-up prompt
-  on stdin. Works for the audit pass on a single host; not safe under
-  parallel use of the same session store, so the audit pass on the terminal
-  driver runs serially per host.
-
-The trade is intentional: a subscription holder loses cost reporting and
-parallelism but gains the ability to run judges at all without an API key.
-Both drivers expose `.raw` on the returned object the caller can use for
-escape-hatch inspection (`SR-003`), but the Protocol does not require it
-because the raw types differ.
-
-#### Codex driver (out of scope, signposted)
-
-Codex would slot in as a third implementation of `AgentDriver`. Its
-session-cookie auth and CLI flags are different enough to want its own
-proposal. The Protocol's `additional_dirs` and `allowed_tools` already
-accommodate the surface; nothing in V1 needs to change to admit it later.
-
-### Constitution alignment: PS-002 (LiteLLM as the standard)
-
-The constitution's PS-002 rule says LLM calls must go through LiteLLM, not
-direct provider SDKs. The judge's `claude-agent-sdk` call is not a classic
-LLM call — it is an *agent runtime* — but the question of "is there a standard
-abstraction we should be using" still applies.
-
-**There is.** LiteLLM ships first-party support for the Claude Agent SDK
-([docs](https://docs.litellm.ai/docs/tutorials/claude_agent_sdk)) via its
-proxy: the SDK is pointed at `ANTHROPIC_BASE_URL=<litellm-proxy>` with a
-LiteLLM-issued auth token, and from then on every call the SDK makes is
-routable through LiteLLM's provider catalog (Anthropic direct, Bedrock,
-Vertex, Azure, …). LiteLLM also has a broader [Agent SDKs
-page](https://docs.litellm.ai/docs/agent_sdks) covering related runtimes.
-
-Auto-CUBE's drivers honour PS-002 by **routing through LiteLLM when a proxy
-is configured**:
-
-- `ClaudeCodeSDKDriver` reads `LITELLM_PROXY_URL` from the environment. When
-  set, it exports `ANTHROPIC_BASE_URL=$LITELLM_PROXY_URL` and the matching
-  auth header to the SDK before invoking it. When unset, it falls back to
-  the SDK's default (direct Anthropic). This matches the integration pattern
-  in the LiteLLM docs and keeps API-key-based developer flows unchanged.
-- `TerminalClaudeDriver` exports the same env vars to the subprocess. The
-  CLI honours them identically.
-
-This is additive: no existing call site changes. The constitution rule is
-satisfied because every billable token now flows through the canonical
-gateway, and the driver Protocol stays small (no LiteLLM types leak into
-`AgentDriver`).
-
-A minor addition to the experiment record: when a LiteLLM proxy is in use,
-the driver records `litellm_proxy_url` (URL only, no credentials) on
-`DriverResult`, surfaced in `judge_metadata.json`. This is an audit signal
-for "did this judgment route through the gateway?" and supports the
-hermetic-reproducibility goal of PS-001.
-
-If at follow-up time we discover LiteLLM's Agent SDK support drifts (model
-list lag, missing parameters), the driver Protocol gives us the seam to fall
-back to a thin internal wrapper without touching call sites. PS-002's
-preferred order — "use LiteLLM if it covers the SDK; otherwise use another
-mature standard; otherwise wrap" — is preserved by the Protocol regardless
-of which path we sit on.
-
-### Related-trajectory selection
-
-A `Selector` is a small typed callable that returns the related-trajectory
-paths the judge will be given alongside the main trajectory:
-
-```python
-class Selector(Protocol):
-    name: str
-    k: int                       # upper bound on returned trajectories
-
-    def select(
-        self,
-        *,
-        main_episode: EpisodeRef,
-        experiment_dir: Path,
-        all_refs: Sequence[EpisodeRef],
-    ) -> list[Path]: ...
-```
-
-Built-in selectors:
-
-- `SameTaskDifferentAgent(k=3)` — returns up to `k` episodes from sibling
-  experiments that share the same `task_id` but differ on
-  `agent_config._type`. Useful for contrastive analysis ("Genny took 30
-  steps, ReAct took 12, why?").
-- `SameAgentPreviousIteration(k=2)` — within the same experiment family
-  (resolved via the experiment-level `family_id` already written into
-  `experiment_config.json`), returns up to `k` predecessors with the same
-  task. Useful for hypothesis-tracking iterations.
-- `TopKBySimilarityStub(k=3)` — placeholder that returns the `k` most
-  recent neighbours by directory mtime. The intent is to swap in a real
-  similarity scorer (trajectory length + outcome + tool-call profile)
-  without changing the selector contract.
-
-Selectors live in `analyze/judge/selection.py` alongside the existing
-`EpisodeRef` / `discover_episodes` / `select_episodes` helpers, which are
-about *which episodes to judge in the current experiment*. Naming is
-deliberate: episode *selection* picks the work pool; related-trajectory
-*selection* picks neighbours per piece of work. Both are operations on
-`EpisodeRef`; sharing the module keeps the file boundary aligned with the
-domain.
-
-A selector is supplied per call (`judge_episode(..., selector=...)`) rather
-than baked into the recipe, mirroring the driver decision: which neighbours
-to pull is an outer-loop policy choice the meta-agent makes, not a property
-of the judging task itself.
-
-### Post-judge survey
-
-After the judge writes its `JudgeOutput`, a second pass runs against the
-same driver, with a short system prompt that asks the judge to fill in
-`post_judge_survey.json`. The schema is fixed:
-
-```python
-class PostJudgeSurvey(TypedBaseModel):
-    schema_version: int = 1     # mirrors JUDGE_SCHEMA_VERSION on JudgeMetadata
-    recipe: str
-    ease_of_analysis: int = Field(..., ge=0, le=5)
-    context_quality: int = Field(..., ge=0, le=5)
-    tooling_gaps: list[str] = Field(default_factory=list)
-    notes: str | None = None
-```
-
-`schema_version` is on the model (not in the filename) to mirror the existing
-`JudgeMetadata.JUDGE_SCHEMA_VERSION` convention, so survey schema and judge
-schema evolve through the same mechanism. Filename versioning would diverge
-from the existing pattern with no win.
-
-The seam PR lands the stub: today, the file is written with `None` integers
-and an empty list. Auto-CUBE populates it. Three design points:
-
-- **Why a second pass and not a single richer schema?** Survey questions
-  pull the judge toward meta-reasoning ("how easy was this?") that
-  contaminates the primary judgment. Splitting the passes keeps `JudgeOutput`
-  free of self-referential noise.
-- **Why not an embedding-based heuristic instead of asking the model?**
-  Tooling-gap detection ("I wanted to see the screenshot but the file was
-  missing") is inherently semantic. A heuristic that grep'd for "I couldn't
-  find" would catch maybe 40% of cases.
-- **Cost.** Roughly +15% on the judgment's total cost. The
-  `JudgeRecipe.post_judge_survey` flag lets recipes that don't care skip it.
-
-The survey is read by the audit pass and by the eventual sweep aggregator
-that produces `tooling_gaps.csv`.
-
-### Audit pass
-
-Replaces the previous `self_judge` recipe. The shape:
-
-- **Trigger.** `audit=True` on the recipe, or `--audit` at the CLI / via
-  `judge_experiment(audit=True)`. Default off.
-- **Mechanism.** After the primary judgment writes `judge_output.json` and
-  the survey writes `post_judge_survey.json`, the judge issues
-  `driver.continue_session(follow_up_prompt=AUDIT_PROMPT)`. The audit prompt
-  asks the judge to critique its own reasoning: were the cited evidence
-  pieces actually load-bearing? Did the judge skip a contradicting tool
-  call? Would a different `primary_blame` be defensible?
-- **Output.** `audit.json` next to `judge_output.json`. Schema:
-
-  ```python
-  class AuditOutput(TypedBaseModel):
-      schema_version: int = 1
-      recipe: str
-      driver: str
-      reasoning_quality: int = Field(..., ge=0, le=5)
-      missed_evidence: list[str] = Field(default_factory=list)
-      alternative_blames: list[BlameAlternative] = Field(default_factory=list)
-      verdict: Literal["sound", "questionable", "wrong"]
-      notes: str | None = None
-
-  class BlameAlternative(TypedBaseModel):
-      blame: str
-      rationale: str
-  ```
-
-- **Driver fallback.** When the driver does not implement
-  `continue_session`, the audit pass calls `driver.run(...)` afresh with the
-  prior judgment, prior trace, and prior survey serialised into the user
-  prompt. Same `audit.json` output; the only loss is that the audit no
-  longer benefits from in-conversation context economy.
-
-The audit is **not** a recipe in the catalog because it always layers on top
-of an existing judgment. Treating it as a flag avoids the temptation to
-fork the catalog (`general_blame`, `general_blame_audit`,
-`profiling_audit`, …).
-
-The follow-up PR — out of scope here — adds the **batch audit step** the
-user asked for: a meta-agent skill (`audit_batch.md`) plus a script
-(`analyze/cross_experiment/audit_batch.py`) that walk a sweep directory,
-collect every `audit.json`, re-judge any trajectory whose verdict is
-`questionable` or `wrong`, and produce a per-sweep
-`audit_quality_report.md`. This RFC fixes the on-disk schema for `audit.json`
-so the batch tool can be written without churn.
-
-### Cross-judge agreement
-
-For a sweep where the meta-agent wants a confidence signal, the inner loop
-is run multiple times per episode **with the same recipe at different
-seeds**. Cross-recipe agreement is intentionally out of scope for this
-artifact — comparing a `general_blame` judgment to an `agent_scaffolding`
-judgment is well-defined only on shared core fields, and the user feedback
-is that the more useful signal is single-recipe variance across seeds (does
-the same recipe reach the same blame on the same trajectory twice?).
-
-The runner that does the re-judging is out of scope for the first PR; the
-**output shape** is fixed here so the joint-CSV consumer never breaks when
-the runner ships.
-
-For each (recipe, trajectory) pair that has more than one judgment, a row
-is written to `<experiment_dir>/cross_judge_agreement.csv`:
-
-| Column | Meaning |
-|---|---|
-| `trajectory_id` | the episode |
-| `recipe` | the recipe name (single value — agreement is per-recipe) |
-| `n_judgments` | how many seeds were run for this (recipe, trajectory) pair |
-| `seeds` | semicolon-separated seed values |
-| `primary_blame_modal` | the modal `primary_blame` across judgments |
-| `primary_blame_agreement` | fraction in `[0, 1]` agreeing with the mode |
-| `outcome_modal` | the modal `outcome` |
-| `outcome_agreement` | fraction agreeing with the mode |
-| `confidence_mean` | mean of `primary_blame_confidence` across judgments |
-
-This file is the meta-agent's confidence signal. Low
-`primary_blame_agreement` flags an episode for human review. It is also the
-input to recipe-quality work: if a single recipe disagrees with itself
-across seeds on a specific failure mode, that recipe's prompt needs
-sharpening.
-
-The choice to put cross-judge state in a sibling CSV rather than nesting it
-inside `EpisodeRecord` mirrors the
-`experiment_judge_summary.json` / `episode_record.judge_output` split from
-PR #366: the per-episode record stays a pure analytical document; aggregate
-artifacts live at the experiment root.
-
-### Joint CSV across experiments
-
-The outer loop concatenates per-experiment `experiment_judge_report.csv`
-files into one row per (experiment, episode), with these added columns:
-
-- `experiment_id` — the experiment directory name.
-- `family_id` — the sweep this experiment belongs to (already written by
-  the experiment runner; copied verbatim here).
-- `agent_dotted` / `benchmark_dotted` — the dotted `_type`s pulled from
-  `experiment_config.json`.
-- `driver` — the driver name (`claude-code-sdk`, `claude-terminal`, ...).
-- `recipe` — the recipe name (`general_blame`, ...).
-- `litellm_proxy_url` — when set; empty string otherwise. Lets reports
-  filter "judgments routed through the gateway" from "judgments that hit
-  Anthropic direct."
-- All columns from `experiment_judge_report.csv` (the per-experiment file
-  produced by PR #366).
-- Cross-judge agreement columns when available, joined on
-  `(trajectory_id, recipe)`.
-
-Written by `cube_harness.analyze.cross_experiment.joint_csv.write_joint_csv`
-to `<sweep_dir>/joint_judge_report.csv`. CSV rather than Parquet because the
-meta-agent reads it with `grep`/`csv.reader`; the row count rarely exceeds
-the low thousands for a sweep. Parquet is a follow-up if and when sweep
-sizes grow.
-
-### Meta-agent integration
-
-The meta-agent owns the outer loop. Its responsibilities, in the order they
-fire:
-
-1. **Plan the sweep.** Pick the experiments to dispatch. This stage is
-   human-in-the-loop today and stays that way for V1 — a researcher writes a
-   recipe under `recipes/` that defines the sweep, or invokes
-   `/meta-agent` interactively.
-2. **Generate context files.** For each experiment, write
-   `<experiment_dir>/judge_context.md` with the paths and prose the judge
-   needs. The meta-agent does this *before* the experiment runs and the
-   context file becomes part of the experiment's artifacts. Required, not
-   optional.
-3. **Dispatch.** Submit experiments via the existing
-   `run_sequentially` / `run_with_ray` path. The meta-agent does not touch
-   the episode loop.
-4. **Judge.** When each experiment finishes, the meta-agent kicks
-   `judge_experiment` with the recipe selected for that experiment and the
-   driver chosen for the cluster (typically `claude-code-sdk` on shared
-   infra; `claude-terminal` on a researcher's laptop). Recipe selection is
-   rule-based for V1, driven by the use-case directories' `SKILL.md`
-   metadata.
-5. **Aggregate.** Write `joint_judge_report.csv` for the sweep. Optionally
-   re-judge for cross-judge agreement (same recipe, multiple seeds).
-6. **Analyse.** Produce an `experiment_judge_report.md` per experiment and a
-   `sweep_judge_report.md` for the whole sweep. These are LLM-authored
-   markdown documents with cited evidence from the joint CSV. The meta-agent
-   is the author; this RFC does not specify the prompt.
-7. **Audit (optional, follow-up).** Run the audit-batch step over the
-   previous sweep — collect all `audit.json` files, re-judge flagged
-   trajectories, produce `audit_quality_report.md`. Schema fixed in this
-   RFC; runner ships in the follow-up.
-8. **Intervene.** Propose interventions: prompt edits, scaffold tweaks, new
-   hints, recipe changes. **All interventions are reviewed by a human
-   before merge.** This is the human-in-the-loop boundary: the meta-agent
-   can author, dispatch, judge, and report; it cannot push to a branch or
-   merge a PR.
-
-The boundary matters. A self-judging system that ships its own fixes is a
-much higher-risk surface than one that ships proposals. Auto-CUBE is the
-latter.
-
-### Migration of `meta_agent/`
-
-The `meta_agent/` directory today holds `recipes/` (one file:
-`workarena_l1_full.py`), `hints/` (one file:
-`swebench-verified.json`), the standalone script `workarena_hints.py`, and a
-`README.md`. The skill at `.claude/commands/meta-agent.md` and the per-session
-journals under `~/cube_meta_agent_journal/` are out of scope for this RFC.
-
-The migration is conservative because there is not much to move:
-
-| Today | Auto-CUBE | Reason |
-|---|---|---|
-| `meta_agent/recipes/workarena_l1_full.py` | stays in place | These are *experiment* recipes (Pydantic `Experiment` instances), not *judge* recipes. They are the outer-loop dispatch artifacts. |
-| `meta_agent/hints/swebench-verified.json` | `cubes/swebench-verified/hints/` (per-cube) | Hints are consumed by the benchmark code at runtime, not by the meta-agent. Per-cube ownership matches the existing pattern documented in `meta_agent/README.md`. |
-| `meta_agent/workarena_hints.py` | `cubes/workarena/scripts/` or deleted | One-off script; not part of the loop contract. |
-| Future judge use cases | `cube_harness/analyze/judge/use_cases/<name>/` | New home. Each use case is a directory with recipe + skill + scripts. |
-| Future cross-experiment tools | `cube_harness/analyze/cross_experiment/` | New module for the joint-CSV, cross-judge, and audit-batch aggregators. |
-| Slash command at `.claude/commands/meta-agent.md` | stays | Until the dispatch / analysis loop is codified into typed Python, the slash command is the runner. Its `SKILL.md`s are now sourced from `use_cases/<name>/SKILL.md`. |
-
-The journals under `~/cube_meta_agent_journal/` remain machine-local; this
-RFC does not propose committing them.
-
-### Trace and telemetry surface
-
-Every Auto-CUBE call sits on the existing OTel tracer (`SR-002`). The driver
-Protocol's `run` and `continue_session` are wrapped in a
-`tracer.span("auto_cube.judge.driver_run")` (or `..._continue`) with
-attributes:
-- `auto_cube.driver` — driver name
-- `auto_cube.recipe` — recipe name
-- `auto_cube.model` — model string
-- `auto_cube.litellm_proxy` — boolean, true when `LITELLM_PROXY_URL` was set
-- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` from the driver
-  result (zero on the terminal driver)
-
-This is purely additive — no spans are removed, no attribute names change.
+## Constitution alignment
+
+- **PS-002 (LiteLLM).** Drivers honour `LITELLM_PROXY_URL` and export `ANTHROPIC_BASE_URL` to their SDK/CLI when set. The constitution rule is satisfied at the token-routing layer; the agent-runtime abstraction is ours because LiteLLM does not cover it.
+- **EX-002 (no global state).** No driver or recipe registry — `RECIPE_CATALOG` is assembled on import from the directory layout; drivers are passed as arguments.
+- **CC-005 (minimalism).** Three use cases, two drivers, one flag for audit. Larger catalogs and runners come as separate PRs that prove their value.
+- **SR-003 (escape hatch).** Both drivers expose `.raw` on `DriverResult`.
+- **SR-002 (trace-first).** Driver calls are wrapped in OTel spans (`auto_cube.judge.driver_run`) with `auto_cube.driver`, `auto_cube.recipe`, `auto_cube.model`, `auto_cube.litellm_proxy` attributes.
 
 ---
 
-## Trade-offs
+## Open questions (for reviewer decision)
 
-### TerminalClaudeDriver parallelism
+1. **`SKILL.md` registration.** Source-of-truth lives at `use_cases/<name>/SKILL.md`. Symlink them into `.claude/skills/` (lightweight, one source) or copy at build time (no symlink dep)? Recommend symlink unless someone objects.
+2. **Driver Protocol parameter for the survey/audit pass session continuity.** `continue_session` on the SDK driver needs to span the survey-pass call in between the primary judgment and the audit. To verify against the SDK before merging — if continuation across intermediate calls doesn't work cleanly, the audit falls back to a fresh `run` with the prior judgment in the prompt. Either way, the surface area is the same.
 
-The driver caps itself at `max_parallelism = 2`. This is a real cost: an
-experiment with 50 episodes that the SDK driver judges in 7 minutes at
-`n_parallel=8` takes ~25 minutes through the terminal driver. The
-alternative — running terminal sessions at higher fan-out — corrupts the
-shared on-disk session store and produces empty judgments. We pay the
-latency for users who do not have an API key. The recipe catalog flags this
-in a docstring on `TerminalClaudeDriver` and the joint CSV's `driver` column
-gives downstream reports a way to scope cost analyses to metered drivers.
-
-### Use-case directory churn
-
-Three use cases at launch (`general_blame`, `profiling`, `agent_scaffolding`)
-is small enough to keep the directory layout legible. The risk is that every
-new analytical question proposes a new use case directory and the catalog
-drifts to dozens of near-duplicates. Three guardrails:
-
-- Use cases are typed Python directories. A new use case must add a
-  directory with `recipe.py`, `SKILL.md`, and (optionally) `prompts/` and
-  `scripts/`. The cost of adding one is visible in a PR diff.
-- The taxonomy in `JudgeOutput` is shared by all use cases. They can extend
-  with sibling fields (as `agent_scaffolding` does with `scaffold_diagnosis`)
-  but cannot fork the core taxonomy. Aggregation in the joint CSV stays
-  meaningful.
-- The post-judge survey's `tooling_gaps` field is the signal for whether a
-  new use case is needed vs. an existing one needs sharpening. If a gap
-  repeats across episodes for an existing use case, sharpen it; if it
-  repeats across use cases, propose a new one.
-
-### Judge cost vs. coverage
-
-Cross-judge agreement multiplies judge cost by the number of seeds per
-episode. A 50-episode experiment judged at `n_seeds=3` costs roughly 3× a
-single-judgment baseline. The first PR does not ship the cross-judge
-runner; when it does, the meta-agent will run cross-judge only on episodes
-flagged by low primary-blame confidence (≤ 2) from the first pass. This
-keeps the cost bounded to the episodes where the signal is worth the spend.
-
-### Survey overhead
-
-The survey adds roughly 15% to judgment cost per episode. The trade is the
-feedback loop into tooling improvements. Use cases that don't need it skip
-the pass via `post_judge_survey=False`; the default in V1 is on.
-
-### Audit overhead
-
-The audit pass adds roughly 25% to per-episode cost (one extra LLM turn that
-re-reads the prior judgment). Off by default. When on, the meta-agent gets
-a per-episode quality signal that the survey alone does not provide
-(survey is the judge's self-report on how easy the analysis was; audit is
-the judge's critique of its own conclusion).
-
----
-
-## Phasing
-
-### First Auto-CUBE PR (this RFC's deliverable)
-
-- `AgentDriver` Protocol in `cube_harness/analyze/judge/driver.py`, including
-  `continue_session` for the audit pass.
-- `ClaudeCodeSDKDriver` — refactor of today's `_run_claude_code` into the
-  Protocol shape; bit-identical behaviour for the `general_blame` recipe.
-  Honours `LITELLM_PROXY_URL` per PS-002.
-- `TerminalClaudeDriver` — subprocess implementation, capped at
-  `max_parallelism=2`. Honours `LITELLM_PROXY_URL`.
-- `JudgeRecipe` widening: `user_prompt_template`, `audit`,
-  `post_judge_survey`, `permission_mode` fields. **No `driver` field** —
-  drivers are call-time, not recipe-time.
-- Use-case directories under `cube_harness/analyze/judge/use_cases/`:
-  `general_blame`, `profiling`, `agent_scaffolding`. Each contains
-  `recipe.py`, `SKILL.md`, `prompts/`, and (for `profiling`) `scripts/`.
-- `RECIPE_CATALOG` assembled by `use_cases/__init__.py` walking
-  subdirectories.
-- `Selector` Protocol + the three built-in selectors. Selector is supplied
-  per call, not on the recipe.
-- Survey collection: second-pass driver invocation; schema enforcement with
-  `schema_version`.
-- Audit pass: flag-gated; `audit.json` schema with `schema_version`.
-- Context-file as the **only** input to the judge (`validate_context_file`
-  promoted from "fallback when used" to "required, raises if missing"). New
-  CLI subcommand `ch-judge init-context` for ad-hoc bootstrap.
-- `joint_judge_report.csv` schema fixed (no runner yet).
-- `cross_judge_agreement.csv` schema fixed (no runner yet).
-- `meta_agent/` migration: directory layout updated, README rewritten,
-  `hints/swebench-verified.json` moved to `cubes/swebench-verified/`.
-
-### Follow-up PRs (called out in this RFC)
-
-1. **Cross-judge runner** — the `judge_experiment` extension that runs
-   episodes through the same recipe at multiple seeds and writes
-   `cross_judge_agreement.csv`. Gated on `primary_blame_confidence ≤ 2` to
-   keep cost bounded.
-2. **Joint-CSV runner** — the `write_joint_csv(sweep_dir)` helper plus the
-   sweep-discovery walk.
-3. **Audit-batch runner** — the meta-agent skill +
-   `analyze/cross_experiment/audit_batch.py` script that walks a sweep,
-   collects `audit.json` files, re-judges flagged trajectories, and writes
-   `audit_quality_report.md`.
-4. **Codex driver** — third `AgentDriver` implementation, also
-   LiteLLM-routable via the Codex Agent SDK adapter.
-5. **TopK similarity selector** — replace the mtime stub with a real
-   trajectory-feature scorer.
-6. **Additional use cases** — one PR per directory: `hint_harvest`,
-   `auto_verified`, and any new ones the survey/audit signal motivates.
-7. **Typed meta-agent loop** — promotes the slash command's responsibilities
-   into `cube_harness.analyze.cross_experiment.meta_agent` with typed
-   dispatch and analysis steps. The slash command stays as the human-facing
-   entry point.
-
----
-
-## Open questions
-
-1. **Where does the per-use-case `SKILL.md` get registered?** The Claude
-   Code skill convention expects skills under `.claude/commands/` (or
-   `.claude/skills/`). The use-case directory layout puts the source file
-   under `analyze/judge/use_cases/<name>/SKILL.md`. V1 plan: a small script
-   committed alongside this RFC creates symlinks at
-   `.claude/skills/judge-<name> -> analyze/judge/use_cases/<name>/SKILL.md`.
-   Is the symlink approach acceptable, or do we want a registration step
-   that copies them?
-2. **`continue_session` semantics on the SDK driver.** The
-   `claude-agent-sdk` exposes a continuation API; we want the audit pass to
-   reuse the same session so prior context is in-conversation. Open: does
-   the SDK's continuation handle the case where the session has crossed
-   tool-call boundaries (the survey pass between the primary judgment and
-   the audit pass), or do we need to checkpoint the session ID through
-   `DriverResult` and restore it manually? Verifying against the SDK before
-   the first PR ships.
-3. **Audit prompt design.** This RFC fixes the schema and the trigger but
-   leaves the audit prompt unspecified. The prompt belongs in the
-   `general_blame` use-case directory's `prompts/audit.md` (so each use
-   case can override). V1 ships a single shared `prompts/audit.md` symlinked
-   into each use case until we see divergence.
-4. **`init-context` defaults.** `ch-judge init-context <experiment_dir>`
-   walks `experiment_config.json` and writes a starter file. Open: does it
-   include a prose section template, or just the `paths` fence? V1 plan:
-   paths fence only — the meta-agent fills prose when it generates the file
-   for real; the developer-bootstrap form has empty prose.
-5. **Cross-judge cost gating.** The follow-up cross-judge runner targets
-   episodes with `primary_blame_confidence ≤ 2`. Is the threshold the right
-   one (some recipes systematically run high-confidence even when wrong),
-   or do we need a use-case-specific threshold? Defer to the audit-batch
-   PR, which will have data to calibrate against.
+Everything else (exact field names, audit prompt content, CLI flag spellings, OTel attribute keys, schema-version mechanics, default thresholds) is implementer's call — flag in PR review if you disagree.
 
 ---
 
 ## References
 
-- `openspec/changes/trajectory-judge/proposal.md` — PR #366, the inner-loop
-  judge this RFC extends.
-- `openspec/changes/trajectory-judge/deltas.md` — the V1 judge surface area.
-- `openspec/changes/atlas-eval-log/proposal.md` — `EpisodeRecord` and the
-  `judge_output` / `judge_metadata` fields the inner loop writes.
-- `openspec/changes/agent-owns-loop/proposal.md` — orthogonal episode-loop
-  work; does not touch the judge.
-- `.claude/commands/meta-agent.md` — the current slash command driving the
-  outer loop.
-- `.claude/commands/judge-traces.md` — the slash command for invoking the
-  judge directly.
-- `src/cube_harness/analyze/judge/` — the judge package on the
-  `feat/trajectory-judge` branch (PR #366), where the seam PR landed
-  `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the
-  `related_trajectories` parameter that this RFC builds on.
-- `meta_agent/` — the existing outer-loop scaffolding.
-- `.claude/rules/constitution.md` — the principles this RFC honours
-  (Python-as-config; composition over inheritance; LiteLLM via the
-  Anthropic env-var path on the SDK; trace-first; escape hatches on
-  drivers).
-- LiteLLM Claude Agent SDK integration:
-  https://docs.litellm.ai/docs/tutorials/claude_agent_sdk
-- LiteLLM Agent SDKs overview:
-  https://docs.litellm.ai/docs/agent_sdks
+- `openspec/changes/trajectory-judge/proposal.md` — PR #366, the judge this extends.
+- `openspec/changes/agent-owns-loop/proposal.md` — PR #386, orthogonal.
+- `.claude/commands/meta-agent.md` — the slash command that drives the outer loop today.
+- `src/cube_harness/analyze/judge/` — the judge package on `feat/trajectory-judge` where the seam PR landed `JudgeRecipe`, `PostJudgeSurvey`, `validate_context_file`, and the `related_trajectories` parameter this RFC builds on.
+- LiteLLM Agent SDKs: https://docs.litellm.ai/docs/agent_sdks
+- Claude Code headless: https://code.claude.com/docs/en/headless
+- Codex non-interactive: https://developers.openai.com/codex/noninteractive


### PR DESCRIPTION
## Summary

Adds the **Auto-CUBE** openspec change — an RFC that unifies the trajectory judge (PR #366) with the meta-agent outer loop. Folds in design-review feedback from 2026-05-13:

- **Use-case directory layout** under `analyze/judge/use_cases/<name>/` — each directory holds `recipe.py`, `SKILL.md`, prompts, and supporting scripts. The meta-agent reads `SKILL.md` to pick which use case to dispatch.
- **`AgentDriver` Protocol** (claude-code-sdk + claude-terminal) so the judge runs on either an API key or a subscription. Drivers honour `LITELLM_PROXY_URL` per PS-002.
- **Driver and selector are call-time arguments**, not recipe fields. No `DRIVER_REGISTRY`.
- **`judge_context.md` is required.** No fallback to venv path discovery. New `ch-judge init-context <experiment_dir>` subcommand bootstraps the file.
- **Flag-gated audit pass** replaces the previous `self_judge` recipe. `audit.json` schema fixed; batch-audit runner is a called-out follow-up.
- **Cross-judge agreement is same-recipe / multi-seed only.** One row per `(recipe, trajectory)` pair.
- **Initial catalog: three use cases** — `general_blame`, `profiling`, `agent_scaffolding`. `hint_harvest` and `auto_verified` deferred to follow-up PRs.

## Files

- [openspec/changes/auto-cube/proposal.md](openspec/changes/auto-cube/proposal.md) — the RFC (~700 lines)
- [openspec/changes/auto-cube/deltas.md](openspec/changes/auto-cube/deltas.md) — ADDED / MODIFIED / NOT CHANGED against `analyze/`, `storage/`, `experiment/` specs

## Companion RFCs

- `openspec/changes/trajectory-judge/proposal.md` (PR #366 / merged via #358) — the inner-loop judge this builds on.
- `openspec/changes/agent-owns-loop/proposal.md` (PR #386) — orthogonal episode-loop work.

## Test plan

This PR is docs-only (RFC and deltas markdown).

- [ ] Reviewer reads `proposal.md` end-to-end
- [ ] Reviewer reads `deltas.md` end-to-end
- [ ] Reviewer leaves comments on any item still ambiguous (5 open questions called out at the bottom of `proposal.md`)
- [ ] Decision: merge as draft RFC and proceed to implementation PR, or iterate further on the design

🤖 Generated with [Claude Code](https://claude.com/claude-code)