### PR TITLE
refactor: drop container_backend (removed in cube-standard #94 Track 1)

### DIFF
--- a/.github/workflows/cube-ci-fast.yml
+++ b/.github/workflows/cube-ci-fast.yml
@@ -73,8 +73,15 @@ jobs:
       - name: Install Playwright browsers
         run: uv run playwright install chromium
 
+      # Cross-repo dep override: this PR depends on a cube-standard change that
+      # is on dev but not yet in a published rc. Mirrors integration-local.yml.
+      # TODO: remove once cube-standard ships an rc that includes it.
+      - name: Override cube-standard with dev branch (cross-repo dep)
+        run: uv pip install --force-reinstall --no-deps 'cube-standard @ git+https://github.com/The-AI-Alliance/cube-standard.git@dev'
+
       - name: Run MiniWob debug suite
-        run: uv run cube test miniwob-cube --no-reset-check
+        # --no-sync: keep the cube-standard@dev override from the previous step.
+        run: uv run --no-sync cube test miniwob-cube --no-reset-check
 
   workarena:
     name: WorkArena debug suite
@@ -106,7 +113,14 @@ jobs:
       - name: Install Playwright browsers
         run: uv run playwright install chromium
 
+      # Cross-repo dep override: this PR depends on a cube-standard change that
+      # is on dev but not yet in a published rc. Mirrors integration-local.yml.
+      # TODO: remove once cube-standard ships an rc that includes it.
+      - name: Override cube-standard with dev branch (cross-repo dep)
+        run: uv pip install --force-reinstall --no-deps 'cube-standard @ git+https://github.com/The-AI-Alliance/cube-standard.git@dev'
+
       - name: Run WorkArena debug suite
-        run: uv run cube test workarena-cube --no-reset-check
+        # --no-sync: keep the cube-standard@dev override from the previous step.
+        run: uv run --no-sync cube test workarena-cube --no-reset-check
         env:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -27,18 +27,6 @@ grep -r "legacy_generic_agent\|GenericAgent\|GenericPromptFlags" recipes/ cubes/
 
 ## Legacy parameters / migration debt
 
-### `container_backend` passthrough
-- [src/cube_harness/episode.py:48](src/cube_harness/episode.py#L48) (parameter)
-- [src/cube_harness/episode.py:113](src/cube_harness/episode.py#L113) (forward to `task_config.make`)
-- [src/cube_harness/experiment.py:87](src/cube_harness/experiment.py#L87) (populate from benchmark)
-
-Flagged as legacy upstream (cube-standard [DEPRECATED.md](../cube-standard/DEPRECATED.md)).
-Only used as a passthrough from `Benchmark` to `Task`; adds parameter clutter.
-
-**Action:** remove from `Episode`, `EpisodeConfig`, and `Experiment` in lockstep
-with the upstream removal. ~8 usages across 3 files — minimal refactor once
-upstream lands.
-
 ### V1 storage format read paths
 [src/cube_harness/storage.py](src/cube_harness/storage.py) — all `_v1_*` methods (~150 LOC)
 
@@ -105,8 +93,7 @@ complete, delete the background loader.
 [src/cube_harness/episode.py:64-104](src/cube_harness/episode.py#L64-L104)
 
 `load_episode_from_config` accepts an optional `benchmark`, then checks
-`if benchmark is not None` twice to decide whether to forward `runtime_context`
-and `container_backend`.
+`if benchmark is not None` to decide whether to forward `runtime_context`.
 
 **Action:** split into two classmethods — `load_from_config(path)` (bare) and
 `load_from_config_with_benchmark(path, benchmark)` (full). Clearer contract, no

--- a/cubes/arithmetic-cube/src/arithmetic_cube/task.py
+++ b/cubes/arithmetic-cube/src/arithmetic_cube/task.py
@@ -1,7 +1,6 @@
 from typing import Any, Literal
 
 from cube.benchmark import RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Observation
 from cube.task import Task, TaskConfig, TaskMetadata
 from arithmetic_cube.tool import ArithmeticTool, ArithmeticToolConfig
@@ -45,12 +44,10 @@ class ArithmeticTaskConfig(TaskConfig[ArithmeticTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> SolveArithmeticTask:
         tool_cfg = self.tool_config or ArithmeticToolConfig()
         return SolveArithmeticTask(
             metadata=self.metadata,
             tool_config=tool_cfg,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )

--- a/cubes/browsercomp/src/browsercomp_cube/debug.py
+++ b/cubes/browsercomp/src/browsercomp_cube/debug.py
@@ -12,7 +12,6 @@ import logging
 from typing import ClassVar, Generator
 
 from cube.benchmark import Benchmark, BenchmarkMetadata, RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Action, ActionSchema, Observation
 from cube.resource import InfraConfig
 from cube.task import TaskConfig, TaskMetadata
@@ -81,7 +80,6 @@ class DebugBrowseCompTaskConfig(BrowseCompTaskConfig):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> DebugBrowseCompTask:
         idx = int(self.metadata.id.rsplit("-", 1)[-1])
         record = _DEBUG_RECORDS[idx]
@@ -93,7 +91,6 @@ class DebugBrowseCompTaskConfig(BrowseCompTaskConfig):
             tool_config=tool_cfg,
             scorer_model=self.scorer_model,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )
 
 

--- a/cubes/browsercomp/src/browsercomp_cube/task.py
+++ b/cubes/browsercomp/src/browsercomp_cube/task.py
@@ -6,7 +6,6 @@ from typing import Any
 import litellm
 
 from cube.benchmark import RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Observation
 from cube.task import Task, TaskConfig, TaskExecutionInfo, TaskMetadata
 from cube.tool import Toolbox, ToolboxConfig
@@ -152,7 +151,6 @@ class BrowseCompTaskConfig(TaskConfig[BrowseCompTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> BrowseCompTask:
         self.verify_installed()
         encrypted = self.load_task_execution_info()
@@ -171,5 +169,4 @@ class BrowseCompTaskConfig(TaskConfig[BrowseCompTaskMetadata]):
             tool_config=tool_cfg,
             scorer_model=self.scorer_model,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )

--- a/cubes/miniwob/src/miniwob_cube/task.py
+++ b/cubes/miniwob/src/miniwob_cube/task.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any
 
 from cube.benchmark import RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Content, Observation
 from cube.task import Task, TaskConfig, TaskMetadata  # noqa: F401 — TaskMetadata kept for typing
 from cube.tools.browser import BrowserTool
@@ -70,9 +69,8 @@ class MiniWobTaskConfig(TaskConfig[MiniWobTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> MiniWobTask:
-        _ = runtime_context, container_backend
+        _ = runtime_context
         assert self.tool_config is not None, "tool_config must be set"
         return MiniWobTask(
             metadata=self.metadata,

--- a/cubes/osworld-cube/src/osworld_cube/benchmark.py
+++ b/cubes/osworld-cube/src/osworld_cube/benchmark.py
@@ -34,7 +34,6 @@ from typing import ClassVar, cast
 from dotenv import load_dotenv
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
-from cube.container import ContainerBackend
 from cube.infra_local import LocalInfraConfig
 from cube.resource import InfraConfig, ResourceConfig
 from cube.task import RuntimeContext, TaskConfig, TaskMetadata
@@ -207,7 +206,6 @@ class OSWorldTaskConfig(TaskConfig[OSWorldTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> OSWorldTask:
         """Instantiate OSWorldTask from this config.
 
@@ -223,7 +221,6 @@ class OSWorldTaskConfig(TaskConfig[OSWorldTaskMetadata]):
             execution_info=execution_info,
             tool_config=self.tool_config or ComputerConfig(),
             runtime_context=runtime_context,
-            container_backend=container_backend,
             use_som=self.use_som,
         )
 

--- a/cubes/osworld-cube/src/osworld_cube/debug.py
+++ b/cubes/osworld-cube/src/osworld_cube/debug.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import ClassVar
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
-from cube.container import ContainerBackend
 from cube.core import Action, ActionSchema, Observation
 from cube.resource import InfraConfig, ResourceConfig
 from cube.task import RuntimeContext, TaskConfig, TaskMetadata
@@ -89,7 +88,6 @@ class DebugOSWorldTaskConfig(OSWorldTaskConfig):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> OSWorldTask:
         execution_info = _DEBUG_EXECUTION_INFO.get(self.task_id)
         if execution_info is None:
@@ -101,7 +99,6 @@ class DebugOSWorldTaskConfig(OSWorldTaskConfig):
             execution_info=execution_info,
             tool_config=self.tool_config or ComputerConfig(),
             runtime_context=runtime_context,
-            container_backend=container_backend,
             use_som=self.use_som,
         )
 

--- a/cubes/swebench-live-cube/src/swebench_live_cube/task.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/task.py
@@ -12,7 +12,7 @@ import logging
 import re
 from typing import Any
 
-from cube.container import ContainerBackend, relocate_if_readonly
+from cube.container import relocate_if_readonly
 from cube.core import ActionSchema, Observation
 from cube.task import STOP_ACTION, RuntimeContext, Task, TaskConfig, TaskExecutionInfo, TaskMetadata
 
@@ -414,14 +414,9 @@ class SWEBenchLiveTaskConfig(TaskConfig[SWEBenchLiveTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> SWEBenchLiveTask:
         if runtime_context is None or "infra" not in runtime_context:
-            if container_backend is None:
-                raise ValueError(
-                    "SWEBenchLiveTaskConfig.make() requires runtime_context['infra'] "
-                    "(preferred) or a legacy container_backend."
-                )
+            raise ValueError("SWEBenchLiveTaskConfig.make() requires runtime_context['infra'].")
 
         self.verify_installed()
         raw = self.load_task_execution_info()
@@ -432,7 +427,6 @@ class SWEBenchLiveTaskConfig(TaskConfig[SWEBenchLiveTaskMetadata]):
             execution_info=execution_info,
             tool_config=self.tool_config or TerminalToolConfig(working_dir="/testbed", enable_file_actions=True),
             runtime_context=runtime_context,
-            container_backend=container_backend,
             include_hints=self.include_hints,
             oracle_mode=self.oracle_mode,
             append_submission_instructions=self.append_submission_instructions,

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -8,7 +8,7 @@ import re
 import shlex
 from typing import Any
 
-from cube.container import ContainerBackend, relocate_if_readonly
+from cube.container import relocate_if_readonly
 from cube.core import ActionSchema, Observation
 from cube.task import STOP_ACTION, RuntimeContext, Task, TaskConfig, TaskExecutionInfo, TaskMetadata
 
@@ -356,14 +356,9 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> SWEBenchVerifiedTask:
         if runtime_context is None or "infra" not in runtime_context:
-            if container_backend is None:
-                raise ValueError(
-                    "SWEBenchVerifiedTaskConfig.make() requires runtime_context['infra'] "
-                    "(preferred) or a legacy container_backend."
-                )
+            raise ValueError("SWEBenchVerifiedTaskConfig.make() requires runtime_context['infra'].")
 
         self.verify_installed()
         raw = self.load_task_execution_info()
@@ -374,7 +369,6 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
             execution_info=execution_info,
             tool_config=self.tool_config or TerminalToolConfig(working_dir="/testbed", enable_file_actions=True),
             runtime_context=runtime_context,
-            container_backend=container_backend,
             include_hints=self.include_hints,
             oracle_mode=self.oracle_mode,
             append_submission_instructions=self.append_submission_instructions,

--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import PrivateAttr
 
-from cube.container import ContainerBackend, relocate_if_readonly
+from cube.container import relocate_if_readonly
 from cube.core import Observation
 from cube.task import RuntimeContext, Task, TaskConfig, TaskExecutionInfo, TaskMetadata
 from cube.tools.terminal import ContainerTerminalTool, TerminalToolConfig
@@ -447,14 +447,9 @@ class TerminalBench2TaskConfig(TaskConfig[TerminalBench2TaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> TerminalBench2Task:
-        has_infra = runtime_context is not None and "infra" in runtime_context
-        if not has_infra and container_backend is None:
-            raise ValueError(
-                "TerminalBench2TaskConfig.make() requires runtime_context['infra'] "
-                "(preferred) or a legacy container_backend."
-            )
+        if runtime_context is None or "infra" not in runtime_context:
+            raise ValueError("TerminalBench2TaskConfig.make() requires runtime_context['infra'].")
 
         self.verify_installed()
         raw = self.load_task_execution_info()
@@ -470,6 +465,5 @@ class TerminalBench2TaskConfig(TaskConfig[TerminalBench2TaskMetadata]):
                 enable_file_actions=True,
             ),
             runtime_context=runtime_context,
-            container_backend=container_backend,
             oracle_mode=self.oracle_mode,
         )

--- a/cubes/webarena-verified/src/webarena_verified_cube/task.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/task.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, overload
 
 from cube.benchmark import RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Observation
 from cube.task import Task, TaskConfig, TaskMetadata
 from cube.tools.browser import BrowserTool
@@ -126,9 +125,8 @@ class WebArenaVerifiedTaskConfig(TaskConfig[WebArenaVerifiedTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> WebArenaVerifiedTask:
-        _ = runtime_context, container_backend
+        _ = runtime_context
         wav = WebArenaVerified(config=self.wav_config)
         wav_task = wav.get_task(int(self.task_id))
         return WebArenaVerifiedTask(

--- a/cubes/windows-agent-arena-cube/src/waa_cube/benchmark.py
+++ b/cubes/windows-agent-arena-cube/src/waa_cube/benchmark.py
@@ -43,7 +43,6 @@ from typing import ClassVar
 
 from cube import LocalInfraConfig
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
-from cube.container import ContainerBackend
 from cube.resource import InfraConfig, ResourceConfig
 from cube.task import TaskConfig, TaskMetadata
 from pydantic import Field, SerializeAsAny
@@ -78,7 +77,6 @@ class WAATaskConfig(TaskConfig):
     def make(
         self,
         runtime_context: dict | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> WAATask:
         if self.tool_config is None:
             raise ValueError(
@@ -94,7 +92,6 @@ class WAATaskConfig(TaskConfig):
             infra=self.infra,
             use_som=self.use_som,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )
 
 

--- a/cubes/windows-agent-arena-cube/src/waa_cube/debug.py
+++ b/cubes/windows-agent-arena-cube/src/waa_cube/debug.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import ClassVar
 
 from cube.benchmark import BenchmarkConfig
-from cube.container import ContainerBackend
 from cube.core import Action, ActionSchema, Observation
 from cube.task import TaskConfig, TaskMetadata
 
@@ -43,7 +42,6 @@ class DebugWAATaskConfig(WAATaskConfig):
     def make(
         self,
         runtime_context: dict | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> WAATask:
         metadata = DebugWAABenchmark.task_metadata[self.task_id]
         return WAATask(
@@ -51,7 +49,6 @@ class DebugWAATaskConfig(WAATaskConfig):
             tool_config=self.tool_config or ComputerConfig(),
             infra=self.infra,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )
 
 

--- a/cubes/workarena/src/workarena_cube/task.py
+++ b/cubes/workarena/src/workarena_cube/task.py
@@ -7,7 +7,6 @@ from typing import Any, List, Literal, override
 import browsergym.workarena
 from browsergym.workarena.tasks.base import AbstractServiceNowTask
 from cube.benchmark import RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import Action, EnvironmentOutput, Observation
 from cube.task import Task, TaskConfig, TaskMetadata
 from cube.tool import Toolbox
@@ -187,9 +186,8 @@ class WorkArenaTaskConfig(TaskConfig[WorkArenaTaskMetadata]):
     def make(
         self,
         runtime_context: RuntimeContext | None = None,
-        container_backend: ContainerBackend | None = None,
     ) -> WorkArenaTask:
-        _ = runtime_context, container_backend
+        _ = runtime_context
         assert self.tool_config, f"WorkArenaTaskConfig requires a tool_config, got {self.tool_config}"
         return WorkArenaTask(
             metadata=self.metadata,

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -1,11 +1,9 @@
 import logging
 import time
-import warnings
 from pathlib import Path
 from typing import Callable, Self
 
 from cube.benchmark import Benchmark, RuntimeContext
-from cube.container import ContainerBackend
 from cube.core import EnvironmentOutput, StepError, TypedBaseModel
 from cube.task import TaskConfig
 from opentelemetry.trace import StatusCode
@@ -49,7 +47,6 @@ class Episode:
         max_steps: int,
         storage: Storage | None,
         runtime_context: RuntimeContext | None,
-        container_backend: ContainerBackend | None,
     ) -> None:
         self.config = EpisodeConfig(
             id=id,
@@ -60,7 +57,6 @@ class Episode:
             task_config=task_config,
         )
         self._runtime_context = runtime_context
-        self._container_backend = container_backend
         self.storage = storage or FileStorage(output_dir)
         self.allow_overwrite = False
 
@@ -71,11 +67,11 @@ class Episode:
 
         The full TaskConfig is stored in EpisodeConfig and is self-contained
         (call task_config.make()). `benchmark` is optional — if provided, its
-        runtime_context and container_backend are forwarded to the episode.
+        runtime_context is forwarded to the episode.
 
         Args:
             config_path: Path to the episode config JSON file
-            benchmark: Benchmark instance (optional; used for runtime_context/container_backend)
+            benchmark: Benchmark instance (optional; used for runtime_context)
 
         Returns:
             Episode instance ready to run
@@ -94,14 +90,6 @@ class Episode:
         if benchmark is not None and not isinstance(benchmark, Benchmark):
             raise ValueError(f"benchmark must be a cube.benchmark.Benchmark instance or None, got {type(benchmark)}")
         runtime_context = benchmark._runtime_context if benchmark is not None else None
-        # ``container_backend`` is a deprecated field on ``BenchmarkConfig``;
-        # reading it raises a DeprecationWarning. Forward it for backwards
-        # compatibility until cube-standard removes it.
-        container_backend = None
-        if benchmark is not None:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                container_backend = benchmark.config.container_backend
         return cls(
             id=episode_config.id,
             output_dir=episode_config.output_dir,
@@ -111,7 +99,6 @@ class Episode:
             max_steps=episode_config.max_steps,
             storage=storage,
             runtime_context=runtime_context,
-            container_backend=container_backend,
         )
 
     def run(self) -> Trajectory:
@@ -120,9 +107,7 @@ class Episode:
         Returns:
             Trajectory containing the full history of the run.
         """
-        task = self.config.task_config.make(
-            runtime_context=self._runtime_context, container_backend=self._container_backend
-        )
+        task = self.config.task_config.make(runtime_context=self._runtime_context)
         action_set = task.action_set
         step_fn = task.step
         close_fn = task.close

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import time
-import warnings
 from pathlib import Path
 from typing import Self
 from uuid import uuid4
@@ -104,8 +103,7 @@ class Experiment(TypedBaseModel):
         ``benchmark`` is the live ``Benchmark`` returned by
         ``self.benchmark_config.make(self.infra)``; the runner is responsible
         for the make/close lifecycle and passes the live instance in so
-        episodes can pick up its ``_runtime_context`` and
-        ``config.container_backend``.
+        episodes can pick up its ``_runtime_context``.
 
         Decisions are driven by `status.json` per episode (no trajectory deserialisation).
 
@@ -170,12 +168,6 @@ class Experiment(TypedBaseModel):
         """Create all episodes from scratch and save their configs to disk."""
         task_configs = list(self.benchmark_config.get_task_configs())
         runtime_context = benchmark._runtime_context
-        # ``container_backend`` is a deprecated field on ``BenchmarkConfig``;
-        # reading it raises a DeprecationWarning. We have to forward it for
-        # backwards compatibility until cube-standard removes it.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            container_backend = benchmark.config.container_backend
         episodes = [
             Episode(
                 id=i,
@@ -185,7 +177,6 @@ class Experiment(TypedBaseModel):
                 exp_name=self.name,
                 max_steps=self.max_steps,
                 runtime_context=runtime_context,
-                container_backend=container_backend,
                 storage=None,
             )
             for i, tc in enumerate(task_configs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,8 +255,8 @@ class MockCubeTask(CubeTask):
 class MockCubeTaskConfig(CubeTaskConfig):
     """Cube TaskConfig that instantiates a MockCubeTask."""
 
-    def make(self, runtime_context=None, container_backend=None) -> MockCubeTask:
-        _ = runtime_context, container_backend
+    def make(self, runtime_context=None) -> MockCubeTask:
+        _ = runtime_context
         return MockCubeTask(
             metadata=TaskMetadata(id=self.task_id),
             tool_config=self.tool_config or MockToolConfig(),
@@ -309,7 +309,6 @@ def mock_episode(tmp_dir, mock_agent_config, mock_cube_task_config) -> Episode:
         output_dir=tmp_dir,
         agent_config=mock_agent_config,
         task_config=mock_cube_task_config,
-        container_backend=None,
         exp_name="mock-episode",
         max_steps=5,
         runtime_context=None,

--- a/tests/test_cube_episode.py
+++ b/tests/test_cube_episode.py
@@ -28,7 +28,6 @@ class TestCubeEpisode:
             max_steps=5,
             storage=None,
             runtime_context=None,
-            container_backend=None,
         )
 
         assert episode.config.task_config == mock_cube_task_config
@@ -51,7 +50,6 @@ class TestCubeEpisode:
             max_steps=5,
             storage=None,
             runtime_context=None,
-            container_backend=None,
         )
 
         with warnings.catch_warnings():
@@ -88,7 +86,6 @@ class TestCubeEpisode:
             max_steps=5,
             storage=None,
             runtime_context=None,
-            container_backend=None,
         )
         episode.storage.save_episode_config(episode.config)
 

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -26,7 +26,6 @@ def _make_test_episode(
         max_steps=max_steps,
         runtime_context=None,
         storage=None,
-        container_backend=None,
     )
 
 
@@ -194,8 +193,8 @@ class TestEpisode:
                 super().close()
 
         class TrackCloseConfig(MockCubeTaskConfig):
-            def make(self, runtime_context=None, container_backend=None):
-                _ = runtime_context, container_backend
+            def make(self, runtime_context=None):
+                _ = runtime_context
                 return TrackCloseTask(
                     metadata=TaskMetadata(id=self.task_id),
                     tool_config=MockToolConfig(),
@@ -221,8 +220,8 @@ class TestEpisode:
                 super().close()
 
         class TrackCloseConfig(MockCubeTaskConfig):
-            def make(self, runtime_context=None, container_backend=None):
-                _ = runtime_context, container_backend
+            def make(self, runtime_context=None):
+                _ = runtime_context
                 return TrackCloseTask(
                     metadata=TaskMetadata(id=self.task_id),
                     tool_config=MockToolConfig(),
@@ -319,8 +318,8 @@ class TestEpisode:
                 raise ValueError("Environment validation failed")
 
         class ErrorEvalConfig(MockCubeTaskConfig):
-            def make(self, runtime_context=None, container_backend=None):
-                _ = runtime_context, container_backend
+            def make(self, runtime_context=None):
+                _ = runtime_context
                 return ErrorEvalTask(
                     metadata=TaskMetadata(id=self.task_id),
                     tool_config=MockToolConfig(),
@@ -367,7 +366,6 @@ class TestEpisode:
             max_steps=5,
             runtime_context=None,
             storage=None,
-            container_backend=None,
         )
         episode.run()
 
@@ -381,7 +379,6 @@ class TestEpisode:
             max_steps=5,
             runtime_context=None,
             storage=None,
-            container_backend=None,
         )
         with pytest.raises(FileExistsError):
             episode2.run()
@@ -397,7 +394,6 @@ class TestEpisode:
             max_steps=5,
             runtime_context=None,
             storage=None,
-            container_backend=None,
         )
         episode.run()
 
@@ -410,7 +406,6 @@ class TestEpisode:
             max_steps=5,
             runtime_context=None,
             storage=None,
-            container_backend=None,
         )
         episode2.allow_overwrite = True
         episode2.run()

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -375,7 +375,7 @@ def test_episode_record_with_task_config(mock_tool_config) -> None:
     from cube.task import TaskConfig
 
     class MockTaskConfig(TaskConfig):
-        def make(self, runtime_context=None, container_backend=None):  # type: ignore[override]
+        def make(self, runtime_context=None):  # type: ignore[override]
             raise NotImplementedError
 
     traj = _trajectory(task_id="t1")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -35,7 +35,7 @@ def _make_failing_benchmark() -> CubeBenchmarkConfig:
             raise RuntimeError("injected step failure")
 
     class _FailingTaskConfig(MockCubeTaskConfig):
-        def make(self, runtime_context=None, container_backend=None) -> _FailingTask:
+        def make(self, runtime_context=None) -> _FailingTask:
             return _FailingTask(
                 metadata=self.metadata,
                 tool_config=self.tool_config or MockToolConfig(),
@@ -58,7 +58,7 @@ def _make_neverending_benchmark(max_steps: int) -> CubeBenchmarkConfig:
             return EnvironmentOutput(obs=Observation.from_text("still going"), reward=0.0, done=False)
 
     class _NeverDoneTaskConfig(MockCubeTaskConfig):
-        def make(self, runtime_context=None, container_backend=None) -> _NeverDoneTask:
+        def make(self, runtime_context=None) -> _NeverDoneTask:
             return _NeverDoneTask(
                 metadata=self.metadata,
                 tool_config=self.tool_config or MockToolConfig(),

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -68,7 +68,7 @@ class DebugCubeTask(CubeTask):
 
 
 class DebugCubeTaskConfig(CubeTaskConfig):
-    def make(self, runtime_context=None, container_backend=None) -> DebugCubeTask:
+    def make(self, runtime_context=None) -> DebugCubeTask:
         return DebugCubeTask(
             metadata=self.metadata,
             tool_config=self.tool_config or MockToolConfig(),


### PR DESCRIPTION
## Summary

Paired consumer change for the cube-standard `ContainerBackend` removal (cube-standard #94 Track 1). **No behavior change** — no cube provisioned via `container_backend`; every cube already uses `InfraConfig`.

- Drop the vestigial `container_backend` parameter from every cube's `TaskConfig.make()`/`Task` and from `Episode` / `Experiment` threading (the latter previously read the now-removed `BenchmarkConfig.container_backend`, which would have raised `AttributeError`).
- `swebench-verified`, `swebench-live`, `terminalbench`: the legacy dual-path `raise` is gone — they now require `runtime_context["infra"]` directly.
- Update `tests/conftest.py` and test fakes.

## Test plan

- [x] `make lint` (ruff check + format) clean
- [x] Full `pytest tests/` — **826 passed** against the paired cube-standard branch
- [x] `tests/test_retry_integration.py` (Ray) passes against the new cube-standard when run the documented Ray-safe way (`.venv/bin/python -m pytest`). The transient "Failed to startup worker" seen under `uv run --no-sync` is the documented uv/Ray `.pth` ephemeral-env pitfall, not a regression.

## Cross-repo

This PR only builds/tests against the unreleased cube-standard branch below; `pyproject.toml` stays pinned to PyPI per the cross-repo convention.

Depends-on: cube-standard/cleanup/remove-container-backend

Pairs with The-AI-Alliance/cube-standard#163. Refs The-AI-Alliance/cube-standard#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)