### PR TITLE
feat(episode): capture git_hash + seed in EpisodeConfig for reproducibility

### DIFF
--- a/openspec/specs/episode/spec.md
+++ b/openspec/specs/episode/spec.md
@@ -24,10 +24,15 @@ class EpisodeConfig(TypedBaseModel):
     output_dir: Path
     max_steps: int
     task_config: TaskConfig          # cube.task.TaskConfig
+    seed: int | None = None          # task_config.seed, captured for reproducibility
+    git_hash: str | None = None      # cube-harness HEAD sha at episode-creation time
+    git_is_dirty: bool | None = None # True if the worktree had uncommitted changes
 ```
 
 Saved to disk at `{output_dir}/episodes/{trajectory_id}/episode_config.json` before
-the episode runs, so experiments can resume after crashes.
+the episode runs, so experiments can resume after crashes. The `seed` / `git_hash` /
+`git_is_dirty` fields capture hermetic-reproducibility provenance (constitution
+PS-001); all default `None` so older V1 configs still deserialize.
 
 ### `Episode`
 ```python

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -13,7 +13,7 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.eval_log import EpisodeRecord
+from cube_harness.eval_log import EpisodeRecord, git_info
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -32,6 +32,11 @@ class EpisodeConfig(TypedBaseModel):
     output_dir: Path
     max_steps: int
     task_config: TaskConfig
+    # Hermetic-reproducibility capture (constitution PS-001). All optional and
+    # default None so V1 / pre-existing episode_config.json files still load.
+    seed: int | None = None
+    git_hash: str | None = None
+    git_is_dirty: bool | None = None
 
 
 class Episode:
@@ -48,6 +53,7 @@ class Episode:
         storage: Storage | None,
         runtime_context: RuntimeContext | None,
     ) -> None:
+        git_hash, _, git_is_dirty = git_info(cwd=str(Path(__file__).parent))
         self.config = EpisodeConfig(
             id=id,
             agent_config=agent_config,
@@ -55,6 +61,9 @@ class Episode:
             output_dir=output_dir,
             max_steps=max_steps,
             task_config=task_config,
+            seed=getattr(task_config, "seed", None),
+            git_hash=git_hash,
+            git_is_dirty=git_is_dirty,
         )
         self._runtime_context = runtime_context
         self.storage = storage or FileStorage(output_dir)
@@ -179,7 +188,7 @@ class Episode:
                     metadata={
                         "task_id": task_id,
                         "agent_name": agent_name,
-                        "seed": getattr(self.config.task_config, "seed", None),
+                        "seed": self.config.seed,
                         **env_output.info,
                         **(extra_metadata or {}),
                     },

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -82,7 +82,7 @@ def _to_github_url(remote_url: str, commit: str) -> str | None:
     return None
 
 
-def _get_git_info(cwd: str | None = None) -> tuple[str | None, str | None, bool | None]:
+def git_info(cwd: str | None = None) -> tuple[str | None, str | None, bool | None]:
     """Return (commit_sha, github_permalink, is_dirty) for the repo at cwd.
 
     All three values are None when git is unavailable or cwd is not inside a repo.
@@ -243,7 +243,7 @@ class AgentInfo(TypedBaseModel):
         agent_id = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
         config_type = config_dict.get("_type", type(agent_config).__name__)
         llm_model = _extract_llm_model(config_dict)
-        git_commit, git_remote_url, git_is_dirty = _get_git_info(cwd=git_cwd)
+        git_commit, git_remote_url, git_is_dirty = git_info(cwd=git_cwd)
 
         return cls(
             agent_id=agent_id,

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -1,6 +1,7 @@
 """Tests for cube_harness.episode module."""
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,7 @@ from cube.task import TaskConfig, TaskMetadata
 from cube_harness.agent import AgentConfig
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode import Episode
-from cube_harness.storage import _read_step_file
+from cube_harness.storage import FileStorage, _read_step_file
 from tests.conftest import MockAgent, MockAgentConfig, MockCubeTask, MockCubeTaskConfig, MockToolConfig
 
 
@@ -415,3 +416,57 @@ class TestEpisode:
         assert len(archived) == 1
         current_dirs = [d for d in episodes_dir.iterdir() if d.is_dir() and ".archived_" not in d.name]
         assert len(current_dirs) == 1
+
+
+class _SeededTaskConfig(MockCubeTaskConfig):
+    """MockCubeTaskConfig that carries a seed (most TaskConfigs do not)."""
+
+    seed: int = 7
+
+
+class TestEpisodeConfigReproducibility:
+    """EpisodeConfig captures git + seed provenance (constitution PS-001 / issue #266)."""
+
+    def test_captures_git_provenance(
+        self, tmp_dir: Path, mock_agent_config: AgentConfig, mock_cube_task_config: MockCubeTaskConfig
+    ) -> None:
+        episode = _make_test_episode(0, tmp_dir, mock_agent_config, mock_cube_task_config)
+        # The test suite runs inside the cube-harness git repo/worktree.
+        assert episode.config.git_hash is not None
+        assert re.fullmatch(r"[0-9a-f]{40}", episode.config.git_hash), episode.config.git_hash
+        assert isinstance(episode.config.git_is_dirty, bool)
+
+    def test_seed_pulled_from_task_config_when_present(self, tmp_dir: Path, mock_agent_config: AgentConfig) -> None:
+        task_config = _SeededTaskConfig(metadata=TaskMetadata(id="seeded_task"))
+        episode = _make_test_episode(0, tmp_dir, mock_agent_config, task_config)
+        assert episode.config.seed == 7
+
+    def test_seed_none_when_task_config_has_no_seed(
+        self, tmp_dir: Path, mock_agent_config: AgentConfig, mock_cube_task_config: MockCubeTaskConfig
+    ) -> None:
+        episode = _make_test_episode(0, tmp_dir, mock_agent_config, mock_cube_task_config)
+        assert episode.config.seed is None
+
+    def test_backward_compat_and_roundtrip(
+        self, tmp_dir: Path, mock_agent_config: AgentConfig, mock_cube_task_config: MockCubeTaskConfig
+    ) -> None:
+        # Exercise the real persistence path (save_episode_config / load_episode_config).
+        storage = FileStorage(tmp_dir)
+        episode = _make_test_episode(0, tmp_dir, mock_agent_config, mock_cube_task_config)
+        storage.save_episode_config(episode.config)
+        cfg_path = next((tmp_dir / "episodes").glob("*/episode_config.json"))
+
+        loaded = storage.load_episode_config(cfg_path)
+        assert loaded.git_hash == episode.config.git_hash
+        assert loaded.git_is_dirty == episode.config.git_is_dirty
+        assert loaded.seed == episode.config.seed
+
+        # A V1 / pre-existing config written before these fields existed still loads.
+        data = json.loads(cfg_path.read_text())
+        for key in ("seed", "git_hash", "git_is_dirty"):
+            data.pop(key, None)
+        cfg_path.write_text(json.dumps(data))
+        legacy = storage.load_episode_config(cfg_path)
+        assert legacy.seed is None
+        assert legacy.git_hash is None
+        assert legacy.git_is_dirty is None

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -1,6 +1,7 @@
 """Tests for cube_harness.eval_log — Atlas EvalLog system."""
 
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from cube_harness.eval_log import (
     _extract_llm_model,
     _extract_tool_names,
     _to_github_url,
+    git_info,
 )
 
 # ---------------------------------------------------------------------------
@@ -557,3 +559,21 @@ def test_export_eval_log_integration(tmp_dir, mock_agent_config, mock_cube_bench
     eval_log.to_jsonl(jsonl_path)
     lines = jsonl_path.read_text().strip().splitlines()
     assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# git_info
+# ---------------------------------------------------------------------------
+
+
+def test_git_info_in_repo_returns_sha_and_dirty_flag() -> None:
+    # The test runs from inside the cube-harness git repo/worktree.
+    commit, _github_url, is_dirty = git_info(cwd=str(Path(__file__).parent))
+    assert commit is not None
+    assert re.fullmatch(r"[0-9a-f]{40}", commit), commit
+    assert isinstance(is_dirty, bool)
+
+
+def test_git_info_outside_repo_returns_all_none(tmp_path: Path) -> None:
+    commit, github_url, is_dirty = git_info(cwd=str(tmp_path))
+    assert (commit, github_url, is_dirty) == (None, None, None)


### PR DESCRIPTION
## What
`EpisodeConfig` now captures hermetic-reproducibility provenance: the cube-harness HEAD sha (`git_hash`), the worktree dirty flag (`git_is_dirty`), and the task `seed`. Populated in `Episode.__init__` and serialized into `episode_config.json` (and the upfront `save_episode_config()` planning path) automatically.

Closes #266 — the episode-dir move for `episode_config.json` already landed in PR #262; this PR adds the remaining "enrich with git_hash + seed" half and closes the documented **constitution PS-001** git-hash gap.

## Approach (lean / no duplication)
- Promoted the existing `eval_log._get_git_info` → public `git_info()` and reuse it from `episode.py` instead of duplicating the `git rev-parse` / `git diff` probe. `_to_github_url` stays private (unaffected; its test still imports it).
- All three new `EpisodeConfig` fields default `None`, so V1 / pre-existing `episode_config.json` files still deserialize.
- Trajectory metadata `seed` now reads the single captured `self.config.seed` instead of a second `getattr`.
- `openspec/specs/episode/spec.md` updated to document the new fields.

## Verification
- `ruff check` + `ruff format`: clean.
- Targeted: `tests/test_episode.py` + `tests/test_eval_log.py` — 74 passed (new tests: git provenance capture, seed-present/absent, real save/load round-trip + V1 backward-compat, `git_info` in-repo vs outside-repo).
- Full CI-equivalent suite (`-m "not slow and not live_api"`, `-n 10`): **903 passed, 7 skipped**.

## Notes
No new cube-standard dependency introduced — `pyproject.toml` is unchanged, so no `Depends-on:` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)