### PR TITLE
feat(eval_log): capture cube-standard git hash in AgentInfo

### DIFF
--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -69,6 +69,8 @@ class AgentInfo(TypedBaseModel):
     git_commit: str | None
     git_remote_url: str | None           # permanent GitHub permalink
     git_is_dirty: bool | None
+    cube_standard_git_commit: str | None   # cube-standard repo HEAD (editable/source checkout only)
+    cube_standard_git_is_dirty: bool | None
 
     # LLM warm-start embedding (ATLAS cold-start)
     description: str | None

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -29,6 +29,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+import cube
 from cube.benchmark import BenchmarkConfig
 from cube.core import TypedBaseModel
 from pydantic import Field
@@ -221,6 +222,18 @@ class AgentInfo(TypedBaseModel):
             "from git_commit alone. None when git info is unavailable."
         ),
     )
+    cube_standard_git_commit: str | None = Field(
+        default=None,
+        description=(
+            "Git SHA-1 of the installed cube-standard (`cube`) package's repo HEAD. Populated only "
+            "when cube-standard is an editable/source checkout (the common case while it tracks an "
+            "unreleased branch); None for a released wheel — use dependency_versions['cube'] then."
+        ),
+    )
+    cube_standard_git_is_dirty: bool | None = Field(
+        default=None,
+        description="True when the cube-standard checkout had uncommitted changes. None when unavailable.",
+    )
     description: str | None = Field(
         default=None,
         description="Free-form prose description of the agent for Atlas LLM embedding warm-start.",
@@ -244,6 +257,12 @@ class AgentInfo(TypedBaseModel):
         config_type = config_dict.get("_type", type(agent_config).__name__)
         llm_model = _extract_llm_model(config_dict)
         git_commit, git_remote_url, git_is_dirty = _get_git_info(cwd=git_cwd)
+        # cube-standard is a separate repo; capturing its hash matters because it is
+        # frequently run from an unreleased branch (dependency_versions only has the
+        # PyPI version string). Probe the installed `cube` package's source dir —
+        # yields a commit only for an editable/source checkout, None for a wheel.
+        cube_standard_dir = str(Path(cube.__file__).resolve().parent)
+        cube_standard_git_commit, _, cube_standard_git_is_dirty = _get_git_info(cwd=cube_standard_dir)
 
         return cls(
             agent_id=agent_id,
@@ -255,6 +274,8 @@ class AgentInfo(TypedBaseModel):
             git_commit=git_commit,
             git_remote_url=git_remote_url,
             git_is_dirty=git_is_dirty,
+            cube_standard_git_commit=cube_standard_git_commit,
+            cube_standard_git_is_dirty=cube_standard_git_is_dirty,
         )
 
 

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -1,6 +1,7 @@
 """Tests for cube_harness.eval_log — Atlas EvalLog system."""
 
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -241,6 +242,19 @@ def test_agent_info_from_agent_config_basic(mock_agent_config) -> None:
     assert isinstance(info.config, dict)
     assert isinstance(info.dependency_versions, dict)
     assert isinstance(info.framework_version, str)
+
+
+def test_agent_info_captures_cube_standard_git(mock_agent_config) -> None:
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    # Populated only for an editable/source cube-standard checkout; None for a
+    # released wheel. Either way the field exists and the (commit, dirty) pair
+    # is internally consistent with the _get_git_info contract.
+    assert hasattr(info, "cube_standard_git_commit")
+    if info.cube_standard_git_commit is None:
+        assert info.cube_standard_git_is_dirty is None
+    else:
+        assert re.fullmatch(r"[0-9a-f]{40}", info.cube_standard_git_commit)
+        assert isinstance(info.cube_standard_git_is_dirty, bool)
 
 
 def test_agent_info_agent_id_is_stable(mock_agent_config) -> None:


### PR DESCRIPTION
## What
`AgentInfo` gains `cube_standard_git_commit` + `cube_standard_git_is_dirty`, probed from the installed `cube` package's source dir via the existing `_get_git_info` helper.

## Why
`AgentInfo` already captures cube-harness git provenance and the cube-standard *version* (`dependency_versions["cube"]`), but not cube-standard's git commit. cube-standard is frequently run from an **unreleased branch** (the recurring `ValidatedConfig`/rc8 situation), where the PyPI version string can't identify the exact code that ran. This closes that reproducibility gap.

This is the lean follow-up to the discussion on #266 / closed PR #399: provenance stays consolidated in `eval_log` instead of growing parallel fields on `EpisodeConfig`.

## Behavior
- Editable/source cube-standard checkout → real commit + dirty flag.
- Released wheel → `None`; `dependency_versions["cube"]` is authoritative there. Graceful, no errors.

## Changes
- `src/cube_harness/eval_log.py` — `import cube`; two new `AgentInfo` fields; probe in `from_agent_config`.
- `openspec/specs/eval_log/spec.md` — documents the two fields.
- `tests/test_eval_log.py` — `test_agent_info_captures_cube_standard_git` (asserts the (commit, dirty) pair is internally consistent for both the editable and wheel cases).

## Verification
- `ruff check` + `ruff format`: clean.
- `tests/test_eval_log.py`: 51 passed.
- Full CI-equivalent suite (`-m "not slow and not live_api"`, `-n 10`): **843 passed, 7 skipped**.

No new cube-standard dependency (uses the already-installed `cube` package's path); `pyproject.toml` unchanged, so no `Depends-on:` required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)