### PR TITLE
refactor(experiment): retype benchmark_config to AbstractBenchmarkConfig

### DIFF
--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any
 
 import cube
-from cube.benchmark import BenchmarkConfig
+from cube.benchmark import AbstractBenchmarkConfig
 from cube.core import TypedBaseModel
 from pydantic import Field
 
@@ -301,8 +301,8 @@ class BenchmarkSubset(TypedBaseModel):
     )
 
     @classmethod
-    def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset":
-        """Derive BenchmarkSubset from a cube BenchmarkConfig object."""
+    def from_benchmark_config(cls, benchmark_config: AbstractBenchmarkConfig) -> "BenchmarkSubset":
+        """Derive BenchmarkSubset from a cube benchmark config (leaf or composite)."""
         name = benchmark_config.benchmark_metadata.name
         n_tasks = len(benchmark_config.task_metadata)
         return cls(name=name, n_tasks=n_tasks)
@@ -462,7 +462,7 @@ class ExperimentRecord(TypedBaseModel):
         exp_name: str,
         output_dir: Path,
         agent_config: Any,
-        benchmark_config: BenchmarkConfig,
+        benchmark_config: AbstractBenchmarkConfig,
         git_cwd: str | None = None,
     ) -> "ExperimentRecord":
         """Build ExperimentRecord from experiment parameters."""

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Self
 from uuid import uuid4
 
-from cube.benchmark import Benchmark, BenchmarkConfig
+from cube.benchmark import AbstractBenchmarkConfig, Benchmark
 from cube.core import TypedBaseModel
 from cube.resource import InfraConfig
 from pydantic import Field, SerializeAsAny, model_validator
@@ -62,7 +62,7 @@ class Experiment(TypedBaseModel):
     name: str
     output_dir: Path | None = None
     agent_config: AgentConfig
-    benchmark_config: SerializeAsAny[BenchmarkConfig]
+    benchmark_config: SerializeAsAny[AbstractBenchmarkConfig]
     infra: SerializeAsAny[InfraConfig] | None = None
     resume: bool = False
     max_steps: int = MAX_STEPS


### PR DESCRIPTION
## Summary

Companion to **cube-standard #172**, which splits `CompositeBenchmarkConfig`
out of the `BenchmarkConfig` hierarchy into a **sibling** under a new
`AbstractBenchmarkConfig`. The "any benchmark, leaf or composite" annotations
in cube-harness move to the new base.

## Changes (3 sites — pure annotation retypes)

- `experiment.py`: import + `Experiment.benchmark_config:
  SerializeAsAny[AbstractBenchmarkConfig]`
- `eval_log.py`: import + `BenchmarkSubset.from_benchmark_config(...)` +
  `ExperimentRecord` builder arg

No behavioral change: every attribute accessed on these objects
(`benchmark_metadata`, `task_metadata`, `get_task_configs`, `make`) is on
`AbstractBenchmarkConfig`. Leaf-cube subclassing and the `Benchmark` runtime
class are untouched. No `isinstance(..., BenchmarkConfig)` exists on any
composite-bearing path in this repo.

## Test plan

- [x] `make lint` clean
- [x] `tests/test_experiment.py` + `tests/test_eval_log.py` — 92 passed
- [x] `tests/test_cube_experiment.py` — 4 passed
  (validated against the cube-standard #172 branch via PYTHONPATH shadow)
- [ ] CI: `make review` will wire the `Depends-on` cube-standard branch

Depends-on: cube-standard/refactor/abstract-benchmark-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)