### PR TITLE
fix(investigator): repair judge→investigator rename grammar artifacts

### DIFF
--- a/src/cube_harness/analyze/investigator/cli.py
+++ b/src/cube_harness/analyze/investigator/cli.py
@@ -95,7 +95,7 @@ def run_cmd(
         str, typer.Option("--synthesis-model", help="Model for the post-batch meta-analysis. Opus by default.")
     ] = "claude-opus-4-7",
     audit: Annotated[bool, typer.Option(help="Run the audit pass after each finding (writes audit.json).")] = False,
-    n_seeds: Annotated[int, typer.Option("--n-seeds", help="Investigator each episode this many times.")] = 1,
+    n_seeds: Annotated[int, typer.Option("--n-seeds", help="Investigate each episode this many times.")] = 1,
     ids: Annotated[
         str | None,
         typer.Option(help="Comma-separated trajectory IDs (or task IDs). Default: all eligible episodes."),
@@ -104,7 +104,7 @@ def run_cmd(
         bool, typer.Option("--failures-only", help="Restrict to episodes where is_correct=False.")
     ] = False,
     overwrite: Annotated[
-        bool, typer.Option("--overwrite", help="Re-investigator episodes that already have findings.")
+        bool, typer.Option("--overwrite", help="Re-investigate episodes that already have findings.")
     ] = False,
     n_parallel: Annotated[int, typer.Option("--n-parallel", help="Concurrent investigator sub-processes.")] = 1,
     trace_mode: Annotated[

--- a/src/cube_harness/analyze/investigator/use_cases/general_blame/recipe.py
+++ b/src/cube_harness/analyze/investigator/use_cases/general_blame/recipe.py
@@ -48,7 +48,7 @@ No other text after the closing fence."""
 _FINDINGS_JSON = model_to_json_example(BaseFindings).replace("{", "{{").replace("}", "}}")
 
 
-INVESTIGATOR_USER_PROMPT_TEMPLATE = f"""Investigator this episode.
+INVESTIGATOR_USER_PROMPT_TEMPLATE = f"""Investigate this episode.
 
 # Episode
 

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -406,6 +406,12 @@ def test_recipe_catalog_assembly() -> None:
         assert recipe.name == name
         assert recipe.system_prompt.strip()
         assert recipe.user_prompt_template.strip()
+        # Regression guard: a blanket judge→investigator rename twice mangled
+        # the opening imperative verb into the noun "Investigator " (e.g.
+        # "Investigator this episode."). The prompt must open with a verb.
+        assert not recipe.user_prompt_template.lstrip().startswith("Investigator "), (
+            f"{name} user prompt opens with the noun 'Investigator ' — rename artifact"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #366's blanket `judge`→`investigator` rename turned the opening **imperative verb** into the **noun** `Investigator ` in three live spots:

- **`general_blame` user-prompt template** opened `"Investigator this episode."` — shipped on **every default-recipe investigation**, so the model's first instruction was ungrammatical. (Other recipes correctly open `"Profile…"` / `"Diagnose…"` / `"Harvest…"`.)
- `ch-investigate` `--n-seeds` help: `"Investigator each episode this many times."`
- `ch-investigate` `--overwrite` help: `"Re-investigator episodes that already have findings."`

All → `"Investigate"`. Added a regression guard in `test_recipe_catalog_assembly` (this mangling has now recurred twice across renames — cli.py:124 in #366, then these) asserting no recipe's user-prompt template opens with the noun `"Investigator "`.

Found during PI methodology evaluation on terminalbench2 (journal Round 3).

## Test plan

- [x] `tests/test_investigator.py`: 47 passed, 1 skipped
- [x] New regression assertion fails on the old text, passes on the fix
- [x] `ruff check` clean
- [x] Text-only (prompt + CLI help); no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)