### PR TITLE
fix(episode): classify permanent LLM errors as non-retriable (INVALID_CONFIG)

### DIFF
--- a/openspec/specs/experiment/spec.md
+++ b/openspec/specs/experiment/spec.md
@@ -58,8 +58,12 @@ may omit `benchmark`; the resulting episodes carry no `runtime_context` and no
 | `False`  | All episodes from scratch                                                                                                                 |
 | `True`   | Episodes with no `status.json` (never started), plus retriable statuses (`FAILED`, `CANCELLED`, `STALE`) with `retry_count < max_retries` |
 
-`RUNNING` / `QUEUED` (in-flight) are never returned. `COMPLETED` and
-`MAX_STEPS_REACHED` (terminal, non-retriable) are always skipped.
+`RUNNING` / `QUEUED` (in-flight) are never returned. `COMPLETED`,
+`MAX_STEPS_REACHED`, and `INVALID_CONFIG` (terminal, non-retriable) are always
+skipped. `INVALID_CONFIG` is set when the episode died from a permanent provider
+error (typo'd model name, bad key, malformed/oversized/policy-violating request —
+classified by `is_permanent_llm_error` in `llm.py`); retrying it would fail
+identically, so it terminates with `retry_count=0`.
 
 When `resume=True`, `sweep_stale_statuses` runs first so orphaned `RUNNING`/`QUEUED`
 entries become `STALE` and are eligible for retry. The runner threads its own

--- a/scripts/experiments_report.py
+++ b/scripts/experiments_report.py
@@ -31,7 +31,7 @@ DEFAULT_RESULTS_DIR = Path.home() / "cube_harness_results"
 
 # Status display order — terminal-valid first, in-flight, then terminal-error.
 _DONE_STATUSES = ("COMPLETED", "MAX_STEPS_REACHED")
-_ERROR_STATUSES = ("FAILED", "STALE", "CANCELLED")
+_ERROR_STATUSES = ("FAILED", "STALE", "CANCELLED", "INVALID_CONFIG")
 
 
 def _load_json(path: Path) -> dict:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -90,6 +90,7 @@ _RAW_STATUS_MAP: dict[str, str] = {
     "FAILED": "failed",
     "STALE": "stale",
     "CANCELLED": "cancelled",
+    "INVALID_CONFIG": "failed",  # permanent provider error — render as a failure
 }
 
 

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -14,6 +14,7 @@ from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.eval_log import EpisodeRecord
+from cube_harness.llm import is_permanent_llm_error
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import EPISODES_DIR, FileStorage, Storage
 from cube_harness.summary import SummaryProcessor
@@ -303,7 +304,10 @@ class Episode:
             ep_status.status = "MAX_STEPS_REACHED" if max_steps_reached else "COMPLETED"
         except Exception as e:
             logger.exception(f"Error during agent run: {e}")
-            ep_status.status = "FAILED"
+            # Permanent provider errors (bad model name, bad key, malformed request)
+            # will fail identically on retry — mark them terminal & non-retriable so
+            # the runner stops instead of burning the whole retry budget.
+            ep_status.status = "INVALID_CONFIG" if is_permanent_llm_error(e) else "FAILED"
             ep_status.error_type = type(e).__name__
             ep_status.error_message = str(e)[:500]
             raise e

--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -15,15 +15,23 @@ from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Literal
 
-Status = Literal["QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"]
+Status = Literal[
+    "QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED", "INVALID_CONFIG"
+]
 
 # In-flight: episode hasn't reached a terminal state yet. Driver poll should
 # leave these alone (subject to orphan/heartbeat sweeps for dead-worker cleanup).
 IN_FLIGHT_STATUSES: frozenset[Status] = frozenset({"QUEUED", "RUNNING"})
 
-TERMINAL_STATUSES: frozenset[Status] = frozenset({"COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED"})
-# MAX_STEPS_REACHED is terminal but NOT retriable: the agent legitimately ran out of
-# its step budget, retrying would just truncate again from a fresh initial state.
+TERMINAL_STATUSES: frozenset[Status] = frozenset(
+    {"COMPLETED", "FAILED", "CANCELLED", "STALE", "MAX_STEPS_REACHED", "INVALID_CONFIG"}
+)
+# Two terminal statuses are deliberately NOT retriable:
+# - MAX_STEPS_REACHED: the agent legitimately ran out of its step budget; retrying
+#   would just truncate again from a fresh initial state.
+# - INVALID_CONFIG: a permanent provider error (e.g. typo'd model name, bad API key,
+#   malformed request). The identical request will fail identically on retry, so
+#   replaying the episode only burns the retry budget. See is_permanent_llm_error.
 RETRIABLE_STATUSES: frozenset[Status] = frozenset({"FAILED", "CANCELLED", "STALE"})
 
 STATUS_FILENAME = "status.json"
@@ -41,6 +49,7 @@ STATUS_ICONS: dict[Status, str] = {
     "FAILED": "✗",
     "STALE": "👻",
     "CANCELLED": "🚫",
+    "INVALID_CONFIG": "⛔",
 }
 
 
@@ -128,7 +137,7 @@ def next_retry_count(prior: "EpisodeStatus | None") -> int:
 
     - No prior: 0 (original attempt).
     - Prior in-flight (QUEUED / RUNNING): same retry_count (idempotent re-pre-claim).
-    - Prior terminal (FAILED/CANCELLED/STALE/COMPLETED/MAX_STEPS_REACHED): prior + 1.
+    - Prior terminal (FAILED/CANCELLED/STALE/COMPLETED/MAX_STEPS_REACHED/INVALID_CONFIG): prior + 1.
     """
     if prior is None:
         return 0

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -12,7 +12,10 @@ from cube.core import TypedBaseModel, ValidatedConfig
 from litellm import BadRequestError, Message, get_llm_provider
 from litellm.exceptions import (
     APIConnectionError,
+    AuthenticationError,
     InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
     RateLimitError,
     ServiceUnavailableError,
     Timeout,
@@ -24,6 +27,34 @@ from pydantic import Field, field_validator, model_validator
 # When no TracerProvider is configured, litellm falls back to ConsoleSpanExporter
 # which dumps huge JSON span dicts to stdout. Instead, enable the callback only
 # after a proper TracerProvider has been set up (see metrics/tracer.py).
+
+# Provider errors that will fail identically on retry — a typo'd model name, a bad
+# API key, an unauthorized/oversized/policy-violating request. They are the
+# complement of the transient set retried in `LLM._completion_with_retry`
+# (5xx / 429 / timeouts / connection). `episode.py` maps these to the terminal,
+# non-retriable INVALID_CONFIG status so the runner stops instead of burning the
+# whole retry budget on a request that cannot succeed.
+_PERMANENT_LLM_ERRORS: tuple[type[BaseException], ...] = (
+    AuthenticationError,  # 401 — bad / missing key
+    PermissionDeniedError,  # 403 — key lacks access to the model
+    NotFoundError,  # 404 — model / endpoint does not exist (typo)
+    BadRequestError,  # 400/422 — incl. ContextWindowExceeded, ContentPolicyViolation
+)
+_PERMANENT_HTTP_STATUS = frozenset({400, 401, 403, 404, 422})
+
+
+def is_permanent_llm_error(exc: BaseException) -> bool:
+    """True iff `exc` is an LLM provider error that will fail identically on retry.
+
+    Classifies on the HTTP ``status_code`` first — provider-agnostic and set by the
+    OpenAI-SDK base class that every litellm exception subclasses — then falls back
+    to the exception type when no status is attached (e.g. connection errors, which
+    are transient and correctly return False).
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status in _PERMANENT_HTTP_STATUS
+    return isinstance(exc, _PERMANENT_LLM_ERRORS)
 
 
 class Prompt(TypedBaseModel):

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -496,11 +496,12 @@ def test_max_retries_zero_disables_auto_retry(tmp_dir: Path) -> None:
 def test_bad_model_does_not_waste_retries(tmp_dir: Path) -> None:
     """A permanent LLM provider error (e.g. typo'd model name) must not be retried.
 
-    Today every exception raised inside the episode loop becomes status=FAILED, which
-    is in RETRIABLE_STATUSES. So a permanent error like `litellm.NotFoundError`
-    ("model does not exist") gets retried max_retries times — wasting compute, money,
-    and wall-clock with zero chance of success. This test pins the desired behaviour:
-    permanent provider errors should terminate the episode with retry_count=0.
+    A permanent error like `litellm.NotFoundError` ("model does not exist") would
+    fail identically on every retry. `episode.py` classifies it via
+    `is_permanent_llm_error` and tags the episode with the terminal, non-retriable
+    `INVALID_CONFIG` status instead of `FAILED`, so the runner stops immediately
+    (retry_count=0) instead of burning `max_retries` worker slots with zero chance
+    of success.
     """
     scenarios = {"task_bad_model": ["bad_model"]}
     benchmark = make_debug_benchmark(scenarios)
@@ -523,7 +524,7 @@ def test_bad_model_does_not_waste_retries(tmp_dir: Path) -> None:
     statuses = storage.list_episode_statuses()
     traj_id, final = next(iter(statuses.items()))
 
-    assert final.status == "FAILED"
+    assert final.status == "INVALID_CONFIG"
     assert final.error_type == "NotFoundError"
     assert final.retry_count == 0, (
         f"permanent provider error was retried {final.retry_count} times; "

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -21,6 +21,7 @@ import fcntl
 import time
 from pathlib import Path
 
+import litellm
 import pytest
 import ray
 from cube.benchmark import Benchmark as CubeBenchmark
@@ -173,6 +174,12 @@ class DebugAgent(Agent):
         if behavior == "loop":
             # Non-terminating action — drives the runner toward max_steps.
             return AgentOutput(actions=[Action(name="click", arguments={"element_id": "x"})])
+        if behavior == "bad_model":
+            raise litellm.NotFoundError(
+                message="model 'gpt-5-mini-typo-this-model-does-not-exist' does not exist",
+                model="gpt-5-mini-typo-this-model-does-not-exist",
+                llm_provider="openai",
+            )
         raise ValueError(f"Unknown behavior: {behavior}")
 
 
@@ -483,6 +490,46 @@ def test_max_retries_zero_disables_auto_retry(tmp_dir: Path) -> None:
     assert final.status == "FAILED"
     assert final.retry_count == 0
     assert _archive_count(tmp_dir, traj_id) == 0  # only one attempt was ever made
+    assert traj_id in result.failures
+
+
+def test_bad_model_does_not_waste_retries(tmp_dir: Path) -> None:
+    """A permanent LLM provider error (e.g. typo'd model name) must not be retried.
+
+    Today every exception raised inside the episode loop becomes status=FAILED, which
+    is in RETRIABLE_STATUSES. So a permanent error like `litellm.NotFoundError`
+    ("model does not exist") gets retried max_retries times — wasting compute, money,
+    and wall-clock with zero chance of success. This test pins the desired behaviour:
+    permanent provider errors should terminate the episode with retry_count=0.
+    """
+    scenarios = {"task_bad_model": ["bad_model"]}
+    benchmark = make_debug_benchmark(scenarios)
+    agent_config = DebugAgentConfig(
+        counter_dir=str(tmp_dir / "_counters"),
+        scenarios=scenarios,
+        hang_seconds=0.0,
+    )
+    exp = Experiment(
+        name="bad_model_retry_waste",
+        output_dir=tmp_dir,
+        agent_config=agent_config,
+        benchmark_config=benchmark,
+        max_retries=3,
+    )
+
+    result = run_sequentially(exp)
+
+    storage = FileStorage(tmp_dir)
+    statuses = storage.list_episode_statuses()
+    traj_id, final = next(iter(statuses.items()))
+
+    assert final.status == "FAILED"
+    assert final.error_type == "NotFoundError"
+    assert final.retry_count == 0, (
+        f"permanent provider error was retried {final.retry_count} times; "
+        f"the harness must classify NotFoundError as non-retriable"
+    )
+    assert _archive_count(tmp_dir, traj_id) == 0
     assert traj_id in result.failures
 
 


### PR DESCRIPTION
Closes #357.

## Problem

Every exception escaping the episode loop was tagged `FAILED`, and `FAILED ∈ RETRIABLE_STATUSES`. So a **permanent** provider error — a typo'd model name (`litellm.NotFoundError`), a bad API key, a malformed request — was retried `max_retries × max_retry_rounds` times per episode, across the whole benchmark, with zero chance of success. On a large run this can burn the entire budget before anyone notices the typo.

This is the episode/runner-level retry layer. It is **distinct** from the LLM-call-level retry fixed by #370 (tenacity backoff): even with #370, the exception still bubbles to `episode.py`, becomes `FAILED`, and the runner replays the whole episode.

## Fix (narrow scope: permanent LLM errors only)

- **`llm.py`** — `is_permanent_llm_error(exc)`: classifies on the HTTP `status_code` (400/401/403/404/422 → permanent) that every litellm exception carries via its OpenAI-SDK base, falling back to the litellm exception type. Transient errors (5xx / 429 / timeouts / connection — already retried in `_completion_with_retry`) return `False`.
- **`episode_status.py`** — new terminal status `INVALID_CONFIG`, in `TERMINAL_STATUSES` but deliberately **not** in `RETRIABLE_STATUSES`.
- **`episode.py`** — the except branch sets `INVALID_CONFIG` (vs `FAILED`) for permanent errors.
- **`xray_utils.py` / `experiments_report.py`** — recognize the new status in display/report maps.
- **`experiment/spec.md`** — lean update to the resume/retry section.

The three retry predicates (`exp_runner._has_retriable_episodes`, `experiment._should_relaunch`, `analyze/reset_episodes`) all key off `status ∈ RETRIABLE_STATUSES` and require **no change** — `INVALID_CONFIG` simply isn't in the set.

## Note on the pinned test

The test commit from #357 (retained, original author attribution) asserted both `status == "FAILED"` and `retry_count == 0`, which are contradictory once a distinct status exists. Per #357's own suggested follow-up ("a terminal `INVALID_CONFIG` status … set that status instead of `FAILED`"), that one assertion is now `status == "INVALID_CONFIG"`; `retry_count == 0` and `error_type == "NotFoundError"` are unchanged.

## Test plan

- [x] `pytest tests/test_retry_integration.py::test_bad_model_does_not_waste_retries` — **passes** (was the failing pin)
- [x] `pytest tests/test_retry_integration.py` — 10/10 pass
- [x] `test_experiment.py` + xray + llm + cube_experiment — 301 pass, no regressions
- [x] `make lint` / `make lint-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)