### PR TITLE
chore(auto-fix): backfill provenance for Finding #5 (issue #406)

### DIFF
--- a/src/cube_harness/analyze/investigator/episode_discovery.py
+++ b/src/cube_harness/analyze/investigator/episode_discovery.py
@@ -70,8 +70,10 @@ def discover_episodes(experiment_dir: Path) -> list[EpisodeRef]:
         # episodes — they have no `steps/` — and enumerating them yields
         # phantom EpisodeRefs that crash transcript extraction. The live
         # attempt keeps the un-suffixed name; skip the archives.
+        # auto-fix(406)↓
         if ".archived_" in ep_dir.name:
             continue
+        # /auto-fix(406)
         record_path = ep_dir / EPISODE_RECORD_FILENAME
         refs.append(
             EpisodeRef(
@@ -114,3 +116,20 @@ def select_episodes(
 
 
 __all__ = ["EpisodeRef", "discover_episodes", "select_episodes", "load_episode_record"]
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(406) {class=L1 issue=406 hash=PENDING ctx=logic/cube-harness@79efdb22}
+#   symptoms:  Surfaced in the terminalbench2 PI shakeout. The retry machinery
+#              archives a failed attempt as `<tid>.archived_<ts>/` (no `steps/`);
+#              discover_episodes enumerated them, yielding phantom EpisodeRefs
+#              that crashed transcript extraction downstream. Trigger is the
+#              retry-archive naming convention — benchmark-/OS-/infra-agnostic
+#              (pure directory-name logic; no env fingerprint is load-bearing).
+#   invariant: discover_episodes returns only investigable episodes (a real
+#              attempt dir with steps/), never retry-archive dirs.
+#   why:       Fixed in discovery, the layer that owns "what is an episode" —
+#              not a downstream guard at the extraction call site.
+#   tested:    tests/test_investigator.py::test_discover_episodes_skips_archived_retry_dirs
+#              (asserts the invariant: archive dirs excluded; not a reproduction).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.


### PR DESCRIPTION
## Summary

First real dogfood of the **auto-fix methodology** (`openspec/specs/auto-fix/spec.md`, landed in #404). Retroactively adds provenance to the already-merged **Finding #5** fix (`discover_episodes` skipping `.archived_` retry dirs; original commit `79efdb22` via #366):

- `# auto-fix(406)↓ … # /auto-fix(406)` markers around the skip in `episode_discovery.py`
- module-bottom footnote: machine line (`class=L1 issue=406 hash=PENDING ctx=…`) + prose (symptoms **with judged triggering context**, invariant, why-this-layer, regression test)
- backing issue **#406** holds the full Dossier

**Pure provenance — comments only, zero behaviour change.** The existing `#5` regression test (`test_discover_episodes_skips_archived_retry_dirs`) still passes; ruff clean.

`hash=PENDING` until the Tier-1 lint (`scripts/auto_fix_lint.py`, next increment) computes the canonical normalized hash — consistent with the spec's "lint may rewrite hash; never hand-edit".

Closes #406 on merge (L1 → archive).

## Why one fix, not all of them

The methodology's own principle (and what was agreed): dogfood one end-to-end to pressure-test the format before fan-out. Remaining shipped fixes (#9 merged; #1–4/#6 in open cube-standard PRs) raise a real scope decision — the methodology/lint/`auto-fix` label currently exist in **cube-harness only**, so cube-standard fixes need either the methodology ported there or an explicit cube-harness-only scope. Bringing that decision separately rather than mass-applying by hand without the Tier-1 lint.

## Test plan

- [x] ruff check + format clean
- [x] `tests/test_investigator.py -k archived_retry` passes (markers are comments; no behaviour change)
- [ ] Reviewer: confirm the footnote schema/format is what we want before fan-out (this is the format-validation dogfood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)