### PR TITLE
fix(investigator): per-episode timeout — a hung driver can't stall the batch (auto-fix 409)

### DIFF
--- a/src/cube_harness/analyze/investigator/core.py
+++ b/src/cube_harness/analyze/investigator/core.py
@@ -89,6 +89,11 @@ class InvestigationConfig(TypedBaseModel):
     selector: Selector | None = None
     audit: bool = False
     n_seeds: int = 1
+    # Hard wall-clock cap per episode (context-agent + primary + audit). A
+    # hung driver subprocess raises nothing, so without this the serial
+    # batch blocks forever (observed: 8h+). On timeout the episode is
+    # logged + skipped and the batch continues. See auto-fix(409).
+    episode_timeout_s: float = 1800.0
 
     # Selection — explicit only. No sampling / no seed; the meta-agent
     # builds `ids` lists programmatically when it needs a subset.
@@ -482,6 +487,7 @@ def investigate_experiment(
             n_seeds=max(1, cfg.n_seeds),
             verbose=cfg.verbose,
             trace_mode=cfg.trace_mode,
+            episode_timeout_s=cfg.episode_timeout_s,
             seeded_runs_out=seeded_runs,
             audit_costs_out=audit_costs,
             all_refs=refs,
@@ -538,6 +544,7 @@ async def _investigate_experiment_async(
     n_seeds: int,
     verbose: bool,
     trace_mode: TraceMode,
+    episode_timeout_s: float,
     seeded_runs_out: dict[tuple[str, str], list[tuple[BaseFindings, InvestigationMetadata]]],
     audit_costs_out: dict[str, float],
     all_refs: list[EpisodeRef],
@@ -549,17 +556,22 @@ async def _investigate_experiment_async(
     async def _one(ref: EpisodeRef, seed_index: int) -> None:
         async with semaphore:
             try:
-                findings, investigation_metadata, actions, _, audit_cost = await _investigate_episode_impl(
-                    ref.episode_dir,
-                    experiment_dir,
-                    recipe=recipe,
-                    driver=driver,
-                    selector=selector,
-                    audit=audit,
-                    verbose=verbose,
-                    trace_mode=trace_mode,
-                    all_refs=all_refs,
+                # auto-fix(409)↓
+                findings, investigation_metadata, actions, _, audit_cost = await asyncio.wait_for(
+                    _investigate_episode_impl(
+                        ref.episode_dir,
+                        experiment_dir,
+                        recipe=recipe,
+                        driver=driver,
+                        selector=selector,
+                        audit=audit,
+                        verbose=verbose,
+                        trace_mode=trace_mode,
+                        all_refs=all_refs,
+                    ),
+                    timeout=episode_timeout_s,
                 )
+                # /auto-fix(409)
             except Exception as e:
                 logger.exception("Investigator failed on %s (seed %d): %s", ref.trajectory_id, seed_index, e)
                 return
@@ -733,3 +745,26 @@ def write_json_report(
         "rows": rows,
     }
     path.write_text(json.dumps(payload, indent=2))
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(409) {class=L1 issue=409 hash=PENDING ctx=macos-arm64/claude-sonnet-4-6/cube-harness@5ca4e565}
+#   symptoms:  Autonomous overnight Round 4 (ch-investigate run --audit,
+#              detached): the bundled claude SDK subprocess hung 8h12m on
+#              episode 1 (count-dataset-tokens_ep1) under bypassPermissions
+#              — a genuinely unbounded wait, not a perms prompt. The serial
+#              batch never advanced. Trigger non-deterministic (long model
+#              loop or SDK/network stall); the defect is the unbounded wait.
+#   invariant: one episode's investigation cannot stall the batch — a
+#              non-terminating driver/audit/context call is time-bounded
+#              and becomes a logged failure so later episodes still run.
+#   why:       agent_driver.py awaits the subprocess with no timeout;
+#              core.py:563 already logs+continues on per-episode Exception
+#              (the #2 crash-symmetry) but a hang raises nothing. Wrapping
+#              the per-episode await in asyncio.wait_for makes the hang
+#              *reach* that existing guard — minimal, right layer (the
+#              batch runner owns "one episode can't stall the batch").
+#   tested:    tests/test_investigator.py — a hanging fake driver is
+#              bounded; the batch records nothing for it and completes the
+#              rest (asserts the invariant, not a reproduction).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -867,6 +867,39 @@ def test_investigate_episode_pipeline(tmp_path: Path) -> None:
     assert "_investigation_transcript" in driver.last_call["user_prompt"]
 
 
+class _HangingDriver:
+    """AgentDriver whose run() never returns in test time — simulates a hung
+    SDK subprocess (the auto-fix(409) failure mode)."""
+
+    name = "hanging-driver"
+    max_parallelism = 4
+
+    async def run(self, **kwargs: Any) -> DriverResult:
+        await asyncio.sleep(30)  # far longer than the test's episode_timeout_s
+        raise AssertionError("unreachable: should be cancelled by the timeout")
+
+    async def continue_session(self, **kwargs: Any) -> DriverResult:
+        raise NotImplementedError
+
+
+def test_investigate_experiment_bounds_a_hung_episode(tmp_path: Path) -> None:
+    """Regression for auto-fix(409): a hung driver must be time-bounded so
+    the batch completes instead of stalling forever. Asserts the invariant
+    (batch returns; hung episode absent), not a reproduction."""
+    exp, _ = _make_episode_dir(tmp_path, "task1_ep0")
+    cfg = InvestigationConfig(
+        driver=_HangingDriver(),
+        ids=["task1_ep0"],
+        synthesis_model="",
+        episode_timeout_s=0.2,
+    )
+
+    # Must return promptly (well under the driver's 30s sleep) and not raise.
+    results = investigate_experiment(exp, cfg)
+
+    assert results == {}  # the hung episode is logged + skipped, not recorded
+
+
 # ---------------------------------------------------------------------------
 # TerminalClaudeDriver — subprocess shape
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> Fix Dossier — `auto-fix(409)`. Spec: `openspec/specs/auto-fix/spec.md`. Issue #409.

**Class**: L1 · **Context fingerprint**: macos-arm64 / claude-sonnet-4-6 / cube-harness@dev

## Invariant violated
One episode's investigation cannot stall the batch — a non-terminating driver/audit/context call must be time-bounded and become a recorded failure so later episodes still run.

## Root cause vs symptom (+ triggering context)
`agent_driver.py` awaits the bundled `claude` subprocess with **no timeout**. `core.py` already has a per-episode `except Exception` that logs + continues (the #2 crash-symmetry lesson) — but a *hung* subprocess raises nothing, so the guard never fires. Symptom: an **8h12m stall**. Triggering context: the **PI loop found this on itself** — autonomous overnight Round 4, `ch-investigate run --audit` detached, investigator=claude-sonnet-4-6 over 3 large `--add-dir` trees, episode `count-dataset-tokens_ep1`, under `--permission-mode bypassPermissions` (so genuinely unbounded, not a perms prompt). Exact hang trigger is non-deterministic (long model loop vs SDK/network stall); the defect is the unbounded wait, independent of trigger.

## Blast radius
`_investigate_episode_impl` has exactly one caller — `_one` in `_investigate_experiment_async` (`git grep _investigate_episode_impl origin/dev`). The fix wraps that single await; `InvestigationConfig.episode_timeout_s` is additive (default preserves behaviour for every non-pathological run).

## Adversarial: the opposite user
A legitimately >30 min investigation would be cut off. Ruled out: observed normal ≈ 3–5 min/episode (Round 3); 1800 s is ~6–10× that and is a config field (escape hatch). An investigation exceeding 30 min is itself pathological and better surfaced as a logged timeout than an invisible infinite hang.

## Registry lookup
No existing `auto-fix` in `investigator/core.py` (the only other cube-harness marker, #406, is in `episode_discovery.py`). Not an accretion site.

## Fix & layer
`InvestigationConfig.episode_timeout_s` (default 1800.0) + wrap the per-episode await in `asyncio.wait_for`; `TimeoutError` → existing `except Exception` → logged + continue. Correct layer: the batch runner owns "one episode can't stall the batch". Mirrors #2 exactly.

## Test
`tests/test_investigator.py::test_investigate_experiment_bounds_a_hung_episode` — a 30 s-hanging fake driver is bounded by `episode_timeout_s=0.2`; the batch returns `{}` and doesn't raise/hang. Asserts the invariant, not a reproduction. Full investigator suite: 51 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)