### PR TITLE
docs(pi): mandate human-readable REPORT.md at session end

### DIFF
--- a/.claude/skills/auto-cube/SKILL.md
+++ b/.claude/skills/auto-cube/SKILL.md
@@ -33,8 +33,19 @@ synthesize → conclude → next hypothesis.
 4. **Conclude & iterate.** Write the round's conclusion. If a root cause is
    confirmed, decide the fix. Start round `N+1` with the next hypothesis.
 
-5. **Session end.** `session.md` carries the narrative: what was learned,
-   what was fixed (commits), what's still open.
+5. **Session end** (most bugs in scope found, or strong diminishing
+   returns). Write **`<session-slug>/REPORT.md`** from
+   `templates/report.md` — the single human-readable rollup someone reads
+   top-to-bottom to understand the whole session: scope, the arc across
+   rounds, findings ledger with dispositions, shipped vs open PRs, the
+   consolidated design signal, key learnings, cost. `session.md` stays
+   the live scope+tracker; `REPORT.md` is the durable, compaction-proof
+   final summary.
+
+A session = `session.md` (scope/target + round index, set at start) ·
+`round_<N>/notes.md` (one per round) · `REPORT.md` (final summary).
+(Old-era single-`.md` sessions are already their own report — no
+separate file.)
 
 ## Intervention discipline
 
@@ -73,5 +84,6 @@ journal entry that explains *why*.
 ## Templates
 
 `templates/session.md`, `templates/notes.md`, `templates/exp_config.py`,
-`templates/fix_report.md`. Copy, fill, evolve. Refine these templates as
-the methodology matures — this skill is expected to change.
+`templates/fix_report.md`, `templates/report.md`. Copy, fill, evolve.
+Refine these templates as the methodology matures — this skill is
+expected to change.

--- a/.claude/skills/auto-cube/templates/report.md
+++ b/.claude/skills/auto-cube/templates/report.md
@@ -1,0 +1,37 @@
+# Session Report — <title>
+
+**Span:** <start> → <end> · **Rounds:** <0–N> · **Status:** <closed: most
+bugs found / diminishing returns | paused: reason>
+
+The single human-readable rollup of this session. Per-round detail is in
+`round_<N>/notes.md`; the live tracker is in `session.md`.
+
+## Scope & objective
+<What this session set out to understand/fix; benchmark, models, infra,
+budget. 2–4 sentences.>
+
+## What happened (arc)
+<One short bullet per round (or phase): hypothesis → what the experiment
++ investigation showed → what was decided/shipped. A reader should grasp
+the trajectory without opening any round file.>
+
+## Findings ledger
+<Table: # | one-liner | disposition (MERGED PR# / open-flagged /
+documented / superseded). Outcome-focused, not a re-narration.>
+
+## Shipped vs open
+- **Merged:** <PRs + what landed>
+- **Open PRs:** <#, one line each>
+- **Awaiting decision (design-significant, not auto-changed):** <items>
+
+## Consolidated design signal (if any)
+<Did findings cluster on one design area? If so: the systemic issue + the
+recommended refactor direction (the methodology's escalation output).
+Omit if findings were independent.>
+
+## Methodology learnings
+<What this session taught about the PI loop / auto-fix methodology
+itself — what worked, what was adjusted, discipline that held or slipped.>
+
+## Cost
+<Recorded per-round/total spend; any economic finding.>


### PR DESCRIPTION
Codifies the session structure the user described: `session.md` (scope + live tracker) · `round_<N>/notes.md` (per round) · **`REPORT.md`** (the single human-readable final summary). Adds `templates/report.md` and makes writing it step 5 of the loop. Worked exemplar already on disk for the tbench2 session. Docs/skill only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)