### PR TITLE
fix(llm): Anthropic interleaved-thinking beta — per-step thinking in Genny swe mode (auto-fix #412)

### DIFF
--- a/scripts/smoke/reasoning.py
+++ b/scripts/smoke/reasoning.py
@@ -521,8 +521,12 @@ def check_tool_use_roundtrip(provider: Provider) -> CheckResult:
 def _cadence_two_turn(provider: Provider, *, reasoning_effort: str | None, interleaved: bool) -> tuple[int, int]:
     """One mode of the cadence probe — return (turn0_reasoning_tokens, turn1_reasoning_tokens).
 
-    Two turns of a tool-use loop on the same prompt the round-trip check uses, so the
-    only thing varying across calls is the LLMConfig knobs.
+    Pure tool-result continuation, mirroring how Genny actually drives a
+    multi-step tool loop: turn 1's prompt ends with the ``tool`` message,
+    with **no trailing user message**. That's the position where the
+    interleaved-thinking gate engages — a new user message after the
+    tool_result would let Anthropic reopen the turn (and emit thinking)
+    regardless of the beta, defeating the probe.
     """
     common = {
         "model_name": provider.model,
@@ -534,13 +538,14 @@ def _cadence_two_turn(provider: Provider, *, reasoning_effort: str | None, inter
         common["reasoning_effort"] = reasoning_effort
         common["interleaved_thinking"] = interleaved
     user_msg = (
-        f"Use the `note` tool to record one observation, then I'll ask a follow-up. Question: {REASONING_QUESTION}"
+        "Use the `note` tool to record a brief observation, then continue with a "
+        f"one-sentence final answer to: {REASONING_QUESTION}"
     )
     cfg = LLMConfig(**common)
     resp1 = cfg.make()(Prompt(messages=[{"role": "user", "content": user_msg}], tools=[NOTE_TOOL]))
     t0 = resp1.usage.reasoning_tokens
     if not resp1.message.tool_calls:
-        # Can't probe turn 1 without a tool_call to feed back; treat as ambiguous (0, 0).
+        # Can't probe turn 1 without a tool_call to feed back; treat as ambiguous.
         return (t0, 0)
     tc = resp1.message.tool_calls[0]
     prompt2 = Prompt(
@@ -548,7 +553,6 @@ def _cadence_two_turn(provider: Provider, *, reasoning_effort: str | None, inter
             {"role": "user", "content": user_msg},
             resp1.message,
             {"role": "tool", "tool_call_id": tc.id, "content": "noted"},
-            {"role": "user", "content": "Now reflect: in one short sentence, restate what you noted."},
         ],
         tools=[NOTE_TOOL],
     )

--- a/scripts/smoke/reasoning.py
+++ b/scripts/smoke/reasoning.py
@@ -17,6 +17,10 @@ behaves end-to-end against live providers:
   6. Tool-use round-trip: an assistant turn's thinking_blocks (with signature)
      are preserved through Prompt._coerce_messages and accepted back by the API
      on the follow-up call.
+  7. Thinking cadence (Anthropic-only, auto-fix(412)): three modes —
+     off / once / always — distinguished by per-turn reasoning_tokens on a
+     two-turn tool-use loop. Asserts the (turn0, turn1) signature:
+     off=(0,0), once=(>0,0), always=(>0,>0).
 
 Auto-skips providers whose API keys are not set. Costs ~$0.05-$0.10 per provider.
 
@@ -514,6 +518,82 @@ def check_tool_use_roundtrip(provider: Provider) -> CheckResult:
     )
 
 
+def _cadence_two_turn(provider: Provider, *, reasoning_effort: str | None, interleaved: bool) -> tuple[int, int]:
+    """One mode of the cadence probe — return (turn0_reasoning_tokens, turn1_reasoning_tokens).
+
+    Two turns of a tool-use loop on the same prompt the round-trip check uses, so the
+    only thing varying across calls is the LLMConfig knobs.
+    """
+    common = {
+        "model_name": provider.model,
+        "temperature": 1.0,
+        "max_completion_tokens": 2048,
+        "tool_choice": "auto",
+    }
+    if reasoning_effort is not None:
+        common["reasoning_effort"] = reasoning_effort
+        common["interleaved_thinking"] = interleaved
+    user_msg = (
+        f"Use the `note` tool to record one observation, then I'll ask a follow-up. Question: {REASONING_QUESTION}"
+    )
+    cfg = LLMConfig(**common)
+    resp1 = cfg.make()(Prompt(messages=[{"role": "user", "content": user_msg}], tools=[NOTE_TOOL]))
+    t0 = resp1.usage.reasoning_tokens
+    if not resp1.message.tool_calls:
+        # Can't probe turn 1 without a tool_call to feed back; treat as ambiguous (0, 0).
+        return (t0, 0)
+    tc = resp1.message.tool_calls[0]
+    prompt2 = Prompt(
+        messages=[
+            {"role": "user", "content": user_msg},
+            resp1.message,
+            {"role": "tool", "tool_call_id": tc.id, "content": "noted"},
+            {"role": "user", "content": "Now reflect: in one short sentence, restate what you noted."},
+        ],
+        tools=[NOTE_TOOL],
+    )
+    resp2 = cfg.make()(prompt2)
+    return (t0, resp2.usage.reasoning_tokens)
+
+
+def check_thinking_cadence(provider: Provider) -> CheckResult:
+    """Perceive the three thinking cadences end-to-end: off / once / always.
+
+    Each mode runs the same two-turn tool-use loop; we record reasoning_tokens
+    for turn 0 and turn 1. The signature `(t0, t1)` distinguishes the modes:
+
+      off    -> (0, 0)         — reasoning_effort=None
+      once   -> (>0, 0)        — reasoning_effort set, interleaved_thinking=False (provider default)
+      always -> (>0, >0)       — reasoning_effort set, interleaved_thinking=True (auto-fix(412) beta)
+
+    Anthropic-only: OpenAI/Azure don't expose this cadence distinction
+    (gpt-5 reasoning is server-managed), so the check is N/A there.
+    """
+    if provider.name != "anthropic":
+        return CheckResult("thinking cadence (off/once/always)", True, "N/A — no cadence flag for this provider")
+
+    off = _cadence_two_turn(provider, reasoning_effort=None, interleaved=False)
+    once = _cadence_two_turn(provider, reasoning_effort="low", interleaved=False)
+    always = _cadence_two_turn(provider, reasoning_effort="low", interleaved=True)
+    summary = f"off={off} once={once} always={always}"
+
+    if off != (0, 0):
+        return CheckResult("thinking cadence (off/once/always)", False, f"off-mode emitted reasoning tokens: {summary}")
+    if once[0] <= 0 or once[1] != 0:
+        return CheckResult(
+            "thinking cadence (off/once/always)",
+            False,
+            f"once-mode should be (>0, 0) — saw {once}. {summary}",
+        )
+    if always[0] <= 0 or always[1] <= 0:
+        return CheckResult(
+            "thinking cadence (off/once/always)",
+            False,
+            f"always-mode should be (>0, >0) — interleaved beta not engaging? {summary}",
+        )
+    return CheckResult("thinking cadence (off/once/always)", True, summary)
+
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -549,6 +629,7 @@ def run_provider(provider: Provider) -> ProviderResults:
         check_reasoning_tokens(provider, captured),
         *([check_cache_works(provider)] if provider.supports_cache_test else []),
         check_tool_use_roundtrip(provider),
+        check_thinking_cadence(provider),
     ):
         _emit(check)
         out.results.append(check)

--- a/src/cube_harness/agents/genny_configs.py
+++ b/src/cube_harness/agents/genny_configs.py
@@ -55,8 +55,17 @@ def make_agent_config(
     max_actions: int = 150,
     cost_limit: float = 1.0,
 ) -> GennyConfig:
+    """Genny is a multi-step tool-use agent, so the default-built LLMConfig opts
+    into ``interleaved_thinking=True``: when a caller flips on Anthropic
+    extended thinking via ``reasoning_effort``, the model thinks after every
+    tool result rather than only on step 0 (see auto-fix(412)).
+
+    **Recipes that override ``agent.llm_config`` with their own ``LLMConfig``
+    must pass ``interleaved_thinking=True`` themselves** — the raw
+    ``LLMConfig`` default is False (matches the Anthropic provider default).
+    """
     return GennyConfig(
-        llm_config=llm_config or LLMConfig(model_name=DEFAULT_MODEL),
+        llm_config=llm_config or LLMConfig(model_name=DEFAULT_MODEL, interleaved_thinking=True),
         system_prompt=SYSTEM_PROMPT,
         goal_template=INSTANCE_TEMPLATES[template],
         flat_history=True,

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -95,6 +95,14 @@ class LLMConfig(ValidatedConfig):
     max_tokens: int = 128000
     max_completion_tokens: int = 8192
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+    # Thinking cadence (Anthropic only — OpenAI/Azure gpt-5 reasoning is server-managed,
+    # this flag is a no-op there). Combined with ``reasoning_effort`` you get three modes:
+    #   off:    reasoning_effort=None                                   (no thinking)
+    #   once:   reasoning_effort=<level>, interleaved_thinking=False    (think once at turn start; provider default)
+    #   always: reasoning_effort=<level>, interleaved_thinking=True     (think after every tool result; needs the beta)
+    # See auto-fix(412): in a multi-step tool-use loop (e.g. Genny swe), `once` means the
+    # model thinks on step 0 and nowhere else — usually wrong for agents.
+    interleaved_thinking: bool = False
     tool_choice: Literal["auto", "none", "required"] | None = "auto"
     parallel_tool_calls: bool = False
     num_retries: int = 5
@@ -278,12 +286,13 @@ class LLM:
         }
         if self.config.reasoning_effort is not None:
             kwargs["reasoning_effort"] = self.config.reasoning_effort
-            # auto-fix(412)↓ Without the interleaved-thinking beta, Anthropic
-            # emits a thinking block only on the FIRST assistant turn; in a
-            # multi-step tool-use loop (Genny swe/flat_history) every later
-            # step gets 0 reasoning tokens — thinking is effectively off after
-            # step 0. The beta lets Claude think after each tool result.
-            if _is_anthropic_model(self.config.model_name):
+            # auto-fix(412)↓ Anthropic only emits a thinking block AFTER a
+            # tool result when the interleaved-thinking beta is set; without
+            # it, a multi-step tool-use loop (Genny swe/flat_history) gets
+            # thinking only on step 0. Gated by `interleaved_thinking` so
+            # callers can pick: once-per-turn (provider default, cheaper) vs
+            # every-step (this branch, deliberate). No-op for non-Anthropic.
+            if self.config.interleaved_thinking and _is_anthropic_model(self.config.model_name):
                 hdrs = dict(kwargs.get("extra_headers") or {})
                 betas = [b for b in hdrs.get("anthropic-beta", "").split(",") if b.strip()]
                 if _INTERLEAVED_THINKING_BETA not in betas:
@@ -409,8 +418,16 @@ class LLMCall(TypedBaseModel):
 #              to think on every step, not only the first assistant turn.
 #   why:       Anthropic only emits thinking after a tool result when the
 #              interleaved-thinking beta is set; llm.py passed
-#              reasoning_effort but not the beta. Right layer = the LLM
-#              wrapper that owns provider params. No contract change -> L1.
-#   tested:    tests/test_llm.py::TestInterleavedThinkingBeta (beta present
-#              for anthropic+reasoning_effort, absent otherwise) + live
-#              probe re-run: 15/15 steps think, 255 -> 846 reasoning tokens.
+#              reasoning_effort but not the beta. Exposed as an opt-in
+#              `LLMConfig.interleaved_thinking` flag (default False = match
+#              provider default ("once"); set True = "always"), so callers
+#              can pick a deliberate cadence instead of being silently
+#              pinned to either one. Right layer = the LLM wrapper that
+#              owns provider params. No contract change -> L1.
+#   tested:    tests/test_llm.py::TestInterleavedThinkingBeta (beta gated
+#              on the flag: present iff anthropic + reasoning_effort +
+#              interleaved_thinking; absent otherwise) + scripts/smoke/
+#              reasoning.py adds an off/once/always cadence probe (live
+#              Anthropic, asserts per-turn reasoning_token pattern) +
+#              original validation probe: 15/15 steps think with the
+#              flag on, 255 -> 846 reasoning tokens.

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -173,6 +173,12 @@ class LLMResponse(TypedBaseModel):
         return get_reasoning(self.message)
 
 
+# auto-fix(412): Anthropic beta that lets Claude emit a thinking block
+# after every tool result, not only on the first assistant turn. Required
+# for per-step thinking in a multi-step tool-use agent (Genny swe mode).
+_INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14"
+
+
 def _is_anthropic_model(model_name: str) -> bool:
     """Does this model route to Anthropic's API (direct, Bedrock, or Vertex)?
 
@@ -272,6 +278,19 @@ class LLM:
         }
         if self.config.reasoning_effort is not None:
             kwargs["reasoning_effort"] = self.config.reasoning_effort
+            # auto-fix(412)↓ Without the interleaved-thinking beta, Anthropic
+            # emits a thinking block only on the FIRST assistant turn; in a
+            # multi-step tool-use loop (Genny swe/flat_history) every later
+            # step gets 0 reasoning tokens — thinking is effectively off after
+            # step 0. The beta lets Claude think after each tool result.
+            if _is_anthropic_model(self.config.model_name):
+                hdrs = dict(kwargs.get("extra_headers") or {})
+                betas = [b for b in hdrs.get("anthropic-beta", "").split(",") if b.strip()]
+                if _INTERLEAVED_THINKING_BETA not in betas:
+                    betas.append(_INTERLEAVED_THINKING_BETA)
+                hdrs["anthropic-beta"] = ",".join(betas)
+                kwargs["extra_headers"] = hdrs
+            # /auto-fix(412)
         if self.config.set_cache_control == "auto" and _is_anthropic_model(self.config.model_name):
             injection_points = _build_cache_injection_points(prompt.messages)
             if injection_points:
@@ -378,3 +397,20 @@ class LLMCall(TypedBaseModel):
     prompt: Prompt
     output: Message
     usage: Usage = Field(default_factory=Usage)
+
+
+# === auto-fix notes ===
+# auto-fix-note(412) {class=L1 issue=412 hash=PENDING ctx=anthropic/claude-haiku-4-5/genny-swe/cube-harness@5ca4e565}
+#   symptoms:  Genny swe/flat_history + claude-haiku-4-5 + reasoning_effort
+#              on terminalbench2: extended thinking fired ONLY on step 0
+#              (step0=145 reasoning tokens, steps 1-14 = exactly 0,
+#              thinking_blocks=0). 15-step probe: 1/15 steps thought.
+#   invariant: a reasoning-enabled multi-step tool-use agent must be able
+#              to think on every step, not only the first assistant turn.
+#   why:       Anthropic only emits thinking after a tool result when the
+#              interleaved-thinking beta is set; llm.py passed
+#              reasoning_effort but not the beta. Right layer = the LLM
+#              wrapper that owns provider params. No contract change -> L1.
+#   tested:    tests/test_llm.py::TestInterleavedThinkingBeta (beta present
+#              for anthropic+reasoning_effort, absent otherwise) + live
+#              probe re-run: 15/15 steps think, 255 -> 846 reasoning tokens.

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -740,3 +740,37 @@ class TestUsageReasoningTokens:
         llm = LLM(config=sample_llm_config)
         resp = llm(sample_prompt)
         assert resp.usage.reasoning_tokens == 0
+
+
+class TestInterleavedThinkingBeta:
+    """auto-fix(412): Anthropic per-step thinking needs the interleaved beta."""
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_anthropic_reasoning_sets_interleaved_beta(self, mock_completion, sample_prompt) -> None:
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
+        )
+        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0, reasoning_effort="low")
+        LLM(config=cfg)(sample_prompt)
+        hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
+        assert "interleaved-thinking-2025-05-14" in hdrs.get("anthropic-beta", "")
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_non_anthropic_reasoning_no_beta(self, mock_completion, sample_prompt) -> None:
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
+        )
+        cfg = LLMConfig(model_name="gpt-5-nano", reasoning_effort="low")
+        LLM(config=cfg)(sample_prompt)
+        hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
+        assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_anthropic_no_reasoning_no_beta(self, mock_completion, sample_prompt) -> None:
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
+        )
+        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0)  # reasoning_effort=None
+        LLM(config=cfg)(sample_prompt)
+        hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
+        assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -743,34 +743,58 @@ class TestUsageReasoningTokens:
 
 
 class TestInterleavedThinkingBeta:
-    """auto-fix(412): Anthropic per-step thinking needs the interleaved beta."""
+    """auto-fix(412): the interleaved-thinking beta is gated on the flag.
+
+    Three modes:
+      off    = reasoning_effort=None                                   -> no beta
+      once   = reasoning_effort=<level>, interleaved_thinking=False    -> no beta (default)
+      always = reasoning_effort=<level>, interleaved_thinking=True     -> beta present
+    """
+
+    @staticmethod
+    def _ok() -> MagicMock:
+        return MagicMock(choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None)
 
     @patch("cube_harness.llm.litellm.completion")
-    def test_anthropic_reasoning_sets_interleaved_beta(self, mock_completion, sample_prompt) -> None:
-        mock_completion.return_value = MagicMock(
-            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
+    def test_always_mode_sets_beta(self, mock_completion, sample_prompt) -> None:
+        mock_completion.return_value = self._ok()
+        cfg = LLMConfig(
+            model_name="claude-haiku-4-5",
+            temperature=1.0,
+            reasoning_effort="low",
+            interleaved_thinking=True,
         )
-        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0, reasoning_effort="low")
         LLM(config=cfg)(sample_prompt)
         hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
         assert "interleaved-thinking-2025-05-14" in hdrs.get("anthropic-beta", "")
 
     @patch("cube_harness.llm.litellm.completion")
-    def test_non_anthropic_reasoning_no_beta(self, mock_completion, sample_prompt) -> None:
-        mock_completion.return_value = MagicMock(
-            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
+    def test_once_mode_no_beta(self, mock_completion, sample_prompt) -> None:
+        """Default cadence: anthropic + reasoning_effort but interleaved_thinking=False."""
+        mock_completion.return_value = self._ok()
+        cfg = LLMConfig(
+            model_name="claude-haiku-4-5",
+            temperature=1.0,
+            reasoning_effort="low",  # interleaved_thinking defaults to False
         )
-        cfg = LLMConfig(model_name="gpt-5-nano", reasoning_effort="low")
         LLM(config=cfg)(sample_prompt)
         hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
         assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")
 
     @patch("cube_harness.llm.litellm.completion")
-    def test_anthropic_no_reasoning_no_beta(self, mock_completion, sample_prompt) -> None:
-        mock_completion.return_value = MagicMock(
-            choices=[MagicMock(message=Message(role="assistant", content="x"))], usage=None
-        )
-        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0)  # reasoning_effort=None
+    def test_non_anthropic_flag_is_noop(self, mock_completion, sample_prompt) -> None:
+        """The flag has no effect on non-Anthropic models (gpt-5 reasoning is server-managed)."""
+        mock_completion.return_value = self._ok()
+        cfg = LLMConfig(model_name="gpt-5-nano", reasoning_effort="low", interleaved_thinking=True)
+        LLM(config=cfg)(sample_prompt)
+        hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
+        assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")
+
+    @patch("cube_harness.llm.litellm.completion")
+    def test_off_mode_no_beta(self, mock_completion, sample_prompt) -> None:
+        """No reasoning_effort -> no beta even if interleaved_thinking=True (degenerate)."""
+        mock_completion.return_value = self._ok()
+        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0, interleaved_thinking=True)
         LLM(config=cfg)(sample_prompt)
         hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
         assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")


### PR DESCRIPTION
# Fix Dossier — auto-fix(412)

**Class**: L1 · **Issue**: #412 · close on merge (L1 archive)
**Context fingerprint**: anthropic/claude-haiku-4-5/genny-swe/cube-harness@5ca4e565

## Invariant violated
A reasoning-enabled multi-step tool-use agent must be able to think on
**every** step, and callers must be able to express *which* cadence
they want — not be silently pinned to one of the two hardcoded
extremes.

## Root cause vs symptom
Anthropic only emits a thinking block after a tool result when the
`interleaved-thinking-2025-05-14` beta is set; without it Claude thinks
once at the top of a turn and never again in the tool-use loop.
`llm.py` passed `reasoning_effort` but not the beta → Genny
swe/flat_history + claude-haiku-4-5 thought **only on step 0** (15-step
probe: 1/15 steps; reasoning_tokens 145 → 0,0,0…).

Initial scope of this PR was to inject the beta unconditionally
whenever `reasoning_effort` was set + Anthropic. Per design review, that
trades one hardcoded cadence (provider-default "once") for the opposite
("always"), forecloses the cheaper mode, and silently ~3× reasoning-token
cost for every existing caller. So the PR now exposes the cadence as a
flag instead.

## Fix & layer
`cube_harness/llm.py` (the LiteLLM wrapper — correct layer; per the
constitution LiteLLM is the only gateway and provider params belong here):

```python
LLMConfig.interleaved_thinking: bool = False   # default = provider-honest
```

Three modes via `(reasoning_effort, interleaved_thinking)`:

| mode | `reasoning_effort` | `interleaved_thinking` | what happens (Anthropic) |
|---|---|---|---|
| **off** | `None` | (n/a) | no thinking |
| **once** | `"low"…"high"` | `False` *(default)* | think once at turn 0, then no more |
| **always** | `"low"…"high"` | `True` | think after every tool result (beta injected) |

Non-Anthropic models: flag is a no-op (gpt-5 reasoning is
server-managed, no cadence distinction). `make_agent_config` (the
default-built LLMConfig in `GENNY_CONFIGS["default"]` and `["swe"]`)
opts into `interleaved_thinking=True` because Genny is a multi-step
tool agent and "once-only" is a footgun there. **Recipes that override
`agent.llm_config` with their own `LLMConfig` must pass
`interleaved_thinking=True`** — documented loudly in the
`make_agent_config` docstring.

## Test
- `tests/test_llm.py::TestInterleavedThinkingBeta` — four cases:
  always (beta present), once (no beta — default), non-Anthropic (flag
  no-op), off (no beta even if flag True).
- `scripts/smoke/reasoning.py` gains check **#7: thinking cadence**.
  Two-turn tool-use loop run in each of the three modes against the
  live Anthropic API; asserts the per-turn reasoning_token signature
  `off=(0,0)`, `once=(>0,0)`, `always=(>0,>0)`. This is the empirical
  way to **perceive** the three cadences end-to-end — same signal the
  original #412 finding was rooted in.
- Live probe re-run (separate from CI): 15/15 steps think with the flag
  on, **255 → 846 reasoning tokens**, task still solved.

## Adversarial: the opposite user
A caller who *wants* "once" cadence (cheap, matches Anthropic's
default). The previous shape of this PR removed their ability to
express it. Current shape: default `False` matches their expectation;
agent recipes opt in explicitly where the multi-step cadence matters.

Closes #412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
