### PR TITLE
fix(integration-ci): source cube-browser-tool from cube-standard git

### DIFF
--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -19,6 +19,11 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/miniwob_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
+cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -20,7 +20,8 @@ build-backend = "uv_build"
 include = ["src/miniwob_cube/task_metadata.json"]
 
 [tool.uv.sources]
-# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# TODO: drop once cube-browser-tool 0.3.0 ships to PyPI.
+# Until then, 0.3.0 lives on cube-standard's dev branch
 # (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
 cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
 

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -20,6 +20,11 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/webarena_verified_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
+cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
+
 [tool.ruff]
 fix = true
 line-length = 120

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -21,7 +21,8 @@ build-backend = "uv_build"
 include = ["src/webarena_verified_cube/task_metadata.json"]
 
 [tool.uv.sources]
-# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# TODO: drop once cube-browser-tool 0.3.0 ships to PyPI.
+# Until then, 0.3.0 lives on cube-standard's dev branch
 # (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
 cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
 

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -23,6 +23,11 @@ build-backend = "uv_build"
 [tool.uv-build]
 include = ["src/workarena_cube/task_metadata.json"]
 
+[tool.uv.sources]
+# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
+cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
+
 [dependency-groups]
 dev = ["pytest>=8.0"]
 

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -24,7 +24,8 @@ build-backend = "uv_build"
 include = ["src/workarena_cube/task_metadata.json"]
 
 [tool.uv.sources]
-# cube-browser-tool 0.3.0 lives on cube-standard's dev branch
+# TODO: drop once cube-browser-tool 0.3.0 ships to PyPI.
+# Until then, 0.3.0 lives on cube-standard's dev branch
 # (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
 cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
 


### PR DESCRIPTION
## Summary

Fix `integration (local)` CI failing on `dev` since PR #398 merged (2026-05-15).

`uv sync` in [integration-tests/](integration-tests/) fails because `webarena-verified-cube` (pulled in by the `aws` / `azure` dependency groups) now requires `cube-browser-tool[bgym]>=0.3.0`, but PyPI only ships `<=0.2.0`. The 0.3.0 source lives in cube-standard's repo at `cube-tools/cube-browser-tool/`.

The bgym-migration CI patch in commit 09721bf added a workaround to `cube-ci-fast.yml` but explicitly skipped `integration-local.yml` on the (incorrect) assumption that its matrix only exercises SWE cubes. The matrix runs SWE cubes, but `uv sync` still resolves the full lockfile across all dependency groups, so the unresolvable `aws/azure` split breaks the local-matrix jobs too.

## Fix

Add `[tool.uv.sources]` to each of the three cubes that pins `cube-browser-tool[bgym]>=0.3.0`:

- [cubes/webarena-verified/pyproject.toml](cubes/webarena-verified/pyproject.toml)
- [cubes/workarena/pyproject.toml](cubes/workarena/pyproject.toml)
- [cubes/miniwob/pyproject.toml](cubes/miniwob/pyproject.toml)

```toml
[tool.uv.sources]
cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
```

Mirrors the existing pattern at [cubes/osworld-cube/pyproject.toml:81](cubes/osworld-cube/pyproject.toml#L81) for `cube-computer-tool`. The source has to live on each cube — declaring it on the integration-tests root does **not** override transitive deps; only the package where a dep is declared honors `[tool.uv.sources]` for it.

## Test plan

- [x] `uv sync --group local --group dev` in `integration-tests/` resolves cleanly
- [x] Lockfile shows `cube-browser-tool 0.3.0` from `git+...cube-standard?subdirectory=cube-tools/cube-browser-tool`
- [ ] `integration (local)` GHA matrix passes on this PR

## Follow-up (optional)

Once this lands, the `Cross-repo deps from cube-standard@dev` pre-install step in `cube-ci-fast.yml` (added in 09721bf for miniwob/workarena jobs) can be simplified — `uv pip install -e cubes/...` will now resolve `cube-browser-tool` from git directly.