### PR TITLE
fix(swebench-verified): baseline-subtract p2p so env-broken tests don't fail correct fixes

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -164,12 +164,32 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
 
     def evaluate(self, obs: Observation | None = None) -> tuple[float, dict[str, Any]]:
 
-        # Apply test patch
-        self._apply_patch(self._exec.test_patch)
-
         fail_to_pass = self._exec.fail_to_pass
         pass_to_pass = self._exec.pass_to_pass
         eval_timeout = self._exec.eval_timeout
+
+        # auto-fix(PENDING)↓
+        # Baseline p2p: run pass_to_pass BEFORE applying test_patch so we can
+        # tell whether a post-patch p2p failure is an agent regression or a
+        # pre-existing environmental issue (sphinx linkcheck hits the network
+        # from an offline container → ConnectionResetError; sympy import-time
+        # deprecations; …). Mirrors swebench-live-cube's evaluate() pattern.
+        # Without this, every container with a flaky p2p test silently scores
+        # correct fixes as 0.
+        p2p_baseline_passed = True
+        if pass_to_pass:
+            p2p_baseline_passed, _ = self._run_tests(
+                self.metadata.repo, pass_to_pass, timeout=eval_timeout, strict=False
+            )
+            if not p2p_baseline_passed:
+                logger.warning(
+                    "evaluate: p2p baseline already fails for %s — post-patch p2p will not be counted against the agent",
+                    self.metadata.id,
+                )
+        # /auto-fix(PENDING)
+
+        # Apply test patch
+        self._apply_patch(self._exec.test_patch)
 
         # Run FAIL_TO_PASS tests — these must all pass for resolution
         f2p_passed, f2p_output = self._run_tests(self.metadata.repo, fail_to_pass, timeout=eval_timeout)
@@ -183,6 +203,21 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
             p2p_passed, p2p_output = self._run_tests(
                 self.metadata.repo, pass_to_pass, timeout=eval_timeout, strict=False
             )
+            # auto-fix(PENDING)↓
+            # If baseline p2p was already broken, do not punish the agent for
+            # an unchanged p2p result. Coarse-grain (whole-suite) by design:
+            # accepts that a regression-in-a-mostly-broken-suite can slip
+            # through, but the alternative (silently scoring correct fixes as
+            # 0) was worse. Per-test diff via pytest output parsing is a
+            # follow-up; see swebench-live-cube._get_failing_test_ids.
+            if not p2p_baseline_passed and not p2p_passed:
+                logger.info(
+                    "evaluate: p2p still failing post-patch but baseline was already failing for %s — treating as pass",
+                    self.metadata.id,
+                )
+                p2p_passed = True
+                p2p_output += "\n[NOTE: pre-existing p2p baseline failures; not counted as agent regression]"
+            # /auto-fix(PENDING)
 
         resolved = f2p_passed and p2p_passed
         reward = 1.0 if resolved else 0.0
@@ -192,6 +227,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
             "resolved": resolved,
             "fail_to_pass_passed": f2p_passed,
             "pass_to_pass_passed": p2p_passed,
+            "pass_to_pass_baseline_passed": p2p_baseline_passed,
             "fail_to_pass_output": f2p_output,
             "pass_to_pass_output": p2p_output,
         }
@@ -363,3 +399,7 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
             oracle_mode=self.oracle_mode,
             append_submission_instructions=self.append_submission_instructions,
         )
+
+
+# === auto-fix notes ===
+# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -168,7 +168,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
         pass_to_pass = self._exec.pass_to_pass
         eval_timeout = self._exec.eval_timeout
 
-        # auto-fix(PENDING)↓
+        # auto-fix(423)↓
         # Baseline p2p: run pass_to_pass BEFORE applying test_patch so we can
         # tell whether a post-patch p2p failure is an agent regression or a
         # pre-existing environmental issue (sphinx linkcheck hits the network
@@ -186,7 +186,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
                     "evaluate: p2p baseline already fails for %s — post-patch p2p will not be counted against the agent",
                     self.metadata.id,
                 )
-        # /auto-fix(PENDING)
+        # /auto-fix(423)
 
         # Apply test patch
         self._apply_patch(self._exec.test_patch)
@@ -203,7 +203,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
             p2p_passed, p2p_output = self._run_tests(
                 self.metadata.repo, pass_to_pass, timeout=eval_timeout, strict=False
             )
-            # auto-fix(PENDING)↓
+            # auto-fix(423)↓
             # If baseline p2p was already broken, do not punish the agent for
             # an unchanged p2p result. Coarse-grain (whole-suite) by design:
             # accepts that a regression-in-a-mostly-broken-suite can slip
@@ -217,7 +217,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
                 )
                 p2p_passed = True
                 p2p_output += "\n[NOTE: pre-existing p2p baseline failures; not counted as agent regression]"
-            # /auto-fix(PENDING)
+            # /auto-fix(423)
 
         resolved = f2p_passed and p2p_passed
         reward = 1.0 if resolved else 0.0
@@ -402,4 +402,4 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
 
 
 # === auto-fix notes ===
-# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}
+# auto-fix-note(423) {class=L1 anchor=PR#423 hash=00588ac5 ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}

--- a/cubes/swebench-verified-cube/tests/test_evaluate_baseline.py
+++ b/cubes/swebench-verified-cube/tests/test_evaluate_baseline.py
@@ -1,0 +1,127 @@
+"""Tests for the F2a baseline-subtract behaviour in ``SWEBenchVerifiedTask.evaluate``.
+
+Asserts the invariant: **if pass_to_pass already fails on the unpatched tree,
+a post-patch p2p failure with the same shape must NOT score the agent 0.0**
+(it is a pre-existing environmental issue, not an agent regression).
+
+The other half of the invariant — strict p2p enforcement when baseline passes —
+is also covered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from cube.tools.terminal import TerminalToolConfig
+
+from swebench_verified_cube.task import (
+    SWEBenchVerifiedExecutionInfo,
+    SWEBenchVerifiedTask,
+    SWEBenchVerifiedTaskMetadata,
+)
+
+
+def _make_task() -> SWEBenchVerifiedTask:
+    """Construct a Task without launching a real container.
+
+    Patches ``model_post_init`` so the base ``cube.task.Task`` does not try to
+    provision an infra container or build a tool. The test only exercises
+    ``evaluate``, which we drive by patching ``_run_tests`` and ``_apply_patch``.
+    """
+    with patch.object(SWEBenchVerifiedTask, "model_post_init", lambda *a, **kw: None):
+        task = SWEBenchVerifiedTask(
+            metadata=SWEBenchVerifiedTaskMetadata(
+                id="sphinx-doc__sphinx-8475",
+                description="linkcheck redirect handling",
+                repo="sphinx-doc/sphinx",
+                difficulty="15 min - 1 hour",
+                version="4.0",
+                base_commit="deadbeef",
+            ),
+            execution_info=SWEBenchVerifiedExecutionInfo(
+                problem_statement="x",
+                patch="diff",
+                test_patch="diff",
+                fail_to_pass=["tests/test_linkcheck.py::test_TooManyRedirects"],
+                pass_to_pass=["tests/test_linkcheck.py::test_defaults"],
+                eval_timeout=60,
+            ),
+            tool_config=TerminalToolConfig(working_dir="/testbed"),
+            oracle_mode=False,
+            append_submission_instructions=True,
+        )
+    return task
+
+
+def test_p2p_pre_existing_failure_does_not_penalise_agent() -> None:
+    """When p2p fails on baseline AND post-patch (same env-side root cause),
+    evaluate() must return reward=1.0 if f2p passes — the agent is not at fault."""
+    task = _make_task()
+
+    # Sequence of _run_tests calls: (baseline p2p, f2p, post-patch p2p)
+    run_outputs = [
+        (False, "ConnectionResetError: google.com"),  # baseline p2p fails
+        (True, "1 passed"),  # f2p passes
+        (False, "ConnectionResetError: google.com"),  # post-patch p2p still fails (same shape)
+    ]
+    with patch.object(task, "_apply_patch", return_value=""), patch.object(task, "_run_tests", side_effect=run_outputs):
+        reward, info = task.evaluate()
+
+    assert reward == 1.0
+    assert info["resolved"] is True
+    assert info["fail_to_pass_passed"] is True
+    assert info["pass_to_pass_passed"] is True
+    assert info["pass_to_pass_baseline_passed"] is False
+    assert "pre-existing p2p baseline failures" in info["pass_to_pass_output"]
+
+
+def test_p2p_baseline_passes_then_post_patch_regresses_scores_zero() -> None:
+    """Strict-enforcement half of the invariant: if baseline p2p was clean,
+    a post-patch p2p failure IS the agent's regression — score 0.0."""
+    task = _make_task()
+
+    run_outputs = [
+        (True, "1 passed"),  # baseline p2p passes
+        (True, "1 passed"),  # f2p passes
+        (False, "AssertionError: regression"),  # post-patch p2p fails
+    ]
+    with patch.object(task, "_apply_patch", return_value=""), patch.object(task, "_run_tests", side_effect=run_outputs):
+        reward, info = task.evaluate()
+
+    assert reward == 0.0
+    assert info["resolved"] is False
+    assert info["fail_to_pass_passed"] is True
+    assert info["pass_to_pass_passed"] is False
+    assert info["pass_to_pass_baseline_passed"] is True
+
+
+def test_p2p_empty_skips_baseline_run() -> None:
+    """Tasks with no pass_to_pass list should not run a baseline check."""
+    task = _make_task()
+    task.execution_info.pass_to_pass = []  # type: ignore[union-attr]
+
+    # Only f2p call expected; baseline is skipped because pass_to_pass is empty.
+    run_outputs = [(True, "1 passed")]
+    mock_run = MagicMock(side_effect=run_outputs)
+    with patch.object(task, "_apply_patch", return_value=""), patch.object(task, "_run_tests", mock_run):
+        reward, info = task.evaluate()
+
+    assert mock_run.call_count == 1
+    assert reward == 1.0
+    assert info["pass_to_pass_baseline_passed"] is True
+
+
+def test_f2p_failure_scores_zero_regardless_of_p2p_baseline() -> None:
+    """If f2p fails, resolution is 0 regardless of p2p baseline state."""
+    task = _make_task()
+
+    run_outputs = [
+        (True, "1 passed"),  # baseline p2p passes
+        (False, "AssertionError: f2p"),  # f2p fails
+        (True, "1 passed"),  # post-patch p2p clean
+    ]
+    with patch.object(task, "_apply_patch", return_value=""), patch.object(task, "_run_tests", side_effect=run_outputs):
+        reward, info = task.evaluate()
+
+    assert reward == 0.0
+    assert info["fail_to_pass_passed"] is False


### PR DESCRIPTION
# Fix Report — auto-fix(PENDING)

**Class**: L1 (single-cube layer fix, mirrors existing pattern in sibling cube)
**Anchor**: PR#PENDING (will amend marker after CI assigns the number)
**Context fingerprint**: `daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475`

## Invariant violated

`SWEBenchVerifiedTask.evaluate` must not score a correct agent fix as 0.0
when the only post-patch `pass_to_pass` failure is a test that was *already*
failing on the unpatched baseline (i.e. an environment issue, not an agent
regression).

## Root cause

`evaluate()` ran `_apply_patch(test_patch)` first and then evaluated f2p +
p2p once. The p2p check was strict: any failing test counted as a
regression. But several SWE-bench Verified containers ship with pre-broken
p2p tests:

- **`sphinx-doc__sphinx-8475`**: p2p includes `test_defaults` /
  `test_defaults_json` in `tests/test_linkcheck.py`. These tests do real
  HTTP requests against `google.com` / `www.w3.org`. The eval container has
  no outbound network → `ConnectionResetError` → both tests fail
  *regardless of the agent's patch*. The agent's actual fix
  (`+ TooManyRedirects` in the linkcheck exception list) was correct; the
  new fail_to_pass test passed; reward was scored 0.0 anyway.

Sister cube `swebench-live-cube` already addresses this with a baseline
pre-run (see `swebench_live_cube/task.py:213` — "Step 1: Baseline run —
identify pre-existing p2p failures BEFORE test_patch"). This PR ports
the same idea to verified.

## Why this fix / why this layer

- Run p2p once on the unpatched tree, capture whether it passes.
- If baseline p2p was already failing AND post-patch p2p still fails,
  the failure is environmental — accept it.
- If baseline p2p was clean and post-patch p2p fails, the agent regressed
  — score 0 (existing behaviour preserved).
- Lives in the cube (`swebench-verified-cube/task.py`), not the harness:
  the bug is in *this benchmark's* evaluator semantics, not in cube-harness
  scoring infrastructure.
- Mirrors `swebench-live-cube` instead of inventing a new shape.

## Blast radius

```
$ git grep -nE 'def evaluate|_run_tests' origin/dev -- cubes/swebench-verified-cube/
cubes/swebench-verified-cube/src/swebench_verified_cube/task.py:165:    def evaluate(self, obs: Observation | None = None) ...
cubes/swebench-verified-cube/src/swebench_verified_cube/task.py:228:    def _run_tests(self, ...) -> tuple[bool, str]
```

One call site (`evaluate`). Adds one extra `_run_tests(strict=False)`
invocation before `_apply_patch` — same code path used twice already.
`_run_tests` itself is unchanged.

## Adversarial: the opposite user

A downstream user whose task has a strict-deterministic p2p suite where
every failure IS the agent's fault would object to the relaxation
"swallowing" a regression. Counter:
- If baseline p2p passes, the relaxation never fires — strict behavior
  preserved for the well-formed-task case.
- Only triggers when baseline p2p is *already* broken — in that state
  the suite was already non-deterministic from the agent's viewpoint,
  so the relaxation can only make the evaluation more honest, not less.
- The coarse whole-suite granularity is a known limitation; per-test
  diff (mirror `swebench-live-cube._get_failing_test_ids`) is a clean
  follow-up.

## Registry lookup

No prior `auto-fix(N)` markers in `cubes/swebench-verified-cube/`. First
auto-fix in this area; the parallel sister session
(`tbench2-infra-model-matrix`) shipped #418 / #420 on `terminalbench2-cube`
— different file, different invariant, no conflict.

## Test

`cubes/swebench-verified-cube/tests/test_evaluate_baseline.py`:
- `test_p2p_pre_existing_failure_does_not_penalise_agent` — baseline p2p
  fails, post-patch p2p fails same shape → reward **1.0**, info shows
  `pass_to_pass_baseline_passed=False`.
- `test_p2p_baseline_passes_then_post_patch_regresses_scores_zero` —
  strict half: baseline p2p clean, post-patch p2p regresses → reward
  **0.0** (preserves existing behavior).
- `test_p2p_empty_skips_baseline_run` — tasks with empty p2p don't run
  the baseline.
- `test_f2p_failure_scores_zero_regardless_of_p2p_baseline` — f2p remains
  authoritative; p2p relaxation never overrides f2p failure.

All 4 assertions exercise the invariant directly, not the reproduction:
they cover both branches (baseline-broken / baseline-clean) for both
outcomes (resolved / not-resolved).

---

## Cross-session compatibility

This PR is independent of in-flight terminalbench2 work (#418, #420)
— different cube, different file, no shared lines. The parallel
`tbench2-infra-model-matrix` Auto-CUBE session does not touch
`swebench-verified-cube`. Safe to merge in any order relative to the
tbench2 PRs.

## Empirical context

Surfaced and confirmed across **8 cells** of an
Auto-CUBE session matrix (daytona/toolkit × haiku/gpt-5.4-mini ×
Genny[swe]/Genny[default]). `sphinx-doc__sphinx-8475` failed on
R1/R3/R5/R7/R8 with the same `ConnectionResetError` shape; the few
GREEN runs (R2/R6) produced different patches that happened to dodge
the network test. The R1 Investigator's `general_blame` recipe flagged
the pattern at confidence 4 (`should_have_been_rewarded`). Session
journal: `~/cube_auto_cube_journal/2026-05-20_swebench-verified-r0/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)