### PR TITLE
docs(tbench2): label the two non-root-Docker workaround blocks explicitly

### DIFF
--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
@@ -78,6 +78,15 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
         return self.execution_info
 
     def _build_tool(self) -> None:
+        # NON-ROOT DOCKER WORKAROUND
+        # tbench2 task images assume root-by-default Docker semantics (Daytona,
+        # local Docker, AWS, Azure all give the container `USER root`). On
+        # non-root backends — EAI Toolkit enforces uid 13011 by cluster policy
+        # — `/app` is often read-only and `git` may not be installed in the
+        # image. The block below copies `/app` to `/tmp/app` only if needed,
+        # and configures git identity *best-effort* so images without git
+        # still set up cleanly. Daytona/local short-circuit at the writable-
+        # /app probe and never execute the extra_setup chain.
         # auto-fix(418)↓
         new_wd = relocate_if_readonly(
             self._container,
@@ -315,6 +324,14 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
             timeout=15,
         )
         if "YES" in assets_probe:
+            # NON-ROOT DOCKER WORKAROUND
+            # The `/opt/cube` data mount and the surrounding fast-path exist
+            # entirely to serve non-root Docker backends where the image lacks
+            # `curl` / `apt` / `astral.sh` egress and the test.sh's upstream
+            # `curl install.sh | sh` route cannot complete. On root-capable
+            # backends (Daytona, local, AWS, Azure) `apt-get install curl`
+            # + `curl install.sh` runs inside the test image directly and
+            # this entire fast-path is unreached.
             # auto-fix(420)↓
             # Verify /opt/cube/uvx is new enough to handle test.sh's `uvx -w`
             # (a.k.a. `--with`) syntax. Older cube_assets bundles (uv ≲0.4) fail


### PR DESCRIPTION
## Summary

Adds a single-line banner above each of the merged \`auto-fix(418)\` and
\`auto-fix(420)\` regions in \`cubes/terminalbench2-cube/.../task.py\`,
identifying them clearly as **non-root Docker workarounds**. Pure comment
addition; no behaviour change; 11 tbench2 tests still pass; ruff clean.

## Why

Both blocks exist *only* to make tbench2 runnable on non-root Docker
backends (notably EAI Toolkit, which enforces uid 13011 by cluster
policy). Root-capable backends never execute them:

- \`auto-fix(418)\` (best-effort git config inside \`relocate_if_readonly\`):
  daytona/local/aws/azure have a writable \`/app\`, so \`relocate_if_readonly\`
  short-circuits before \`extra_setup\` runs.
- \`auto-fix(420)\` (version-probe on \`/opt/cube/uvx\` before fast-path
  copy): root-capable backends complete the upstream
  \`apt-get install curl && curl install.sh | sh\` route inside the image
  and never reach the \`/opt/cube\` mount.

A reader scanning the file should be able to recognise these as
toolkit-specific *immediately*, without having to read the full Fix
Report in [#418](https://github.com/The-AI-Alliance/cube-harness/pull/418) /
[#420](https://github.com/The-AI-Alliance/cube-harness/pull/420). The
existing comments mention uid 13011 and toolkit-specifics but the cost-
of-existence framing was buried.

## Diff shape

Two banner comments, ~8 lines each, immediately above the existing
\`# auto-fix(...)↓\` markers.

## AF-001 acknowledgement

Per review rule AF-001 (\`auto-fix marker integrity\`), this diff
touches code inside auto-fix regions and crosses marker boundaries.
Explicit acknowledgement:

- The auto-fix(176) / auto-fix(418) / auto-fix(420) invariants are
  intact — no logic edited, only adjacent comments added.
- The footnotes' \`hash=\` field remains \`PENDING\` (lint will stamp on
  the next \`scripts/auto_fix_lint.py\` run; not regressing it here).
- The change is *unrelated to a code-rotting concern* but does count as
  "unrelated churn" per the spec — the AF-001 line about "footnote
  hash= should be re-stamped" applies. Since \`hash=PENDING\` is the
  current state (lint has not been run since the fixes landed yesterday),
  no re-stamp is needed; the next lint pass will stamp both at once.

## Test plan

- [x] \`pytest cubes/terminalbench2-cube/tests/\` — 11/11 pass
- [x] \`uvx ruff check cubes/terminalbench2-cube/\` — clean
- [x] \`uvx ruff format --check cubes/terminalbench2-cube/\` — clean
- [x] No runtime imports / signatures touched — no smoke test needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)