### PR TITLE
docs(swebench): explain why _build_tool exists — non-root docker workaround

### DIFF
--- a/cubes/swebench-live-cube/src/swebench_live_cube/task.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/task.py
@@ -140,6 +140,14 @@ class SWEBenchLiveTask(Task[SWEBenchLiveTaskMetadata, ContainerTerminalTool]):
     def _build_tool(self) -> None:
         """Ensure /testbed files are writable and git-safe, then build the tool.
 
+        NON-ROOT DOCKER WORKAROUND. Upstream SWE-bench-Live images assume
+        `USER root` (matched by Daytona, local Docker, AWS, Azure). On non-root
+        infras — the EAI Toolkit enforces uid 13011 by cluster policy — the
+        runtime user can't `chmod` root-owned files in place, can't write to a
+        read-only /testbed, and Git 2.35.2+ rejects repos owned by a different
+        user. This block normalises all three before the tool is constructed.
+        Root-running infras short-circuit at the writability probes.
+
         Two pre-flight fixes applied unconditionally (mirrors swebench-verified-cube):
         1. git safe.directory: Git 2.35.2+ refuses to operate in repos owned by a
            different user. Configure /testbed as safe so agents can run `git diff`.
@@ -147,6 +155,10 @@ class SWEBenchLiveTask(Task[SWEBenchLiveTaskMetadata, ContainerTerminalTool]):
            a world-writable /testbed. mv unlinks via the writable parent and recreates
            with the runtime user's ownership, making every file writable without sudo.
            Running before relocate_if_readonly keeps conda editable-install paths stable.
+
+        The trailing ``relocate_if_readonly`` call falls back to /tmp/testbed
+        when /testbed itself is not writable (toolkit case); on root-running
+        infras the probe returns immediately with the original path.
         """
         self._container.exec(
             f"git config --global --add safe.directory {self.tool_config.working_dir}",

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -118,6 +118,15 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
     def _build_tool(self) -> None:
         """Ensure /testbed files are writable and git-safe, then build the tool.
 
+        NON-ROOT DOCKER WORKAROUND. Upstream SWE-bench images assume `USER root`
+        (matched by Daytona, local Docker, AWS, Azure) and bake conda+sources
+        into a root-owned /testbed. On non-root infras — the EAI Toolkit enforces
+        uid 13011 by cluster policy — the runtime user can't `chmod` root-owned
+        files in place, can't write to a read-only /testbed, and Git 2.35.2+
+        rejects repos owned by a different user. This block normalises all three
+        before the tool is constructed. Root-running infras short-circuit at the
+        writability probes and pay essentially nothing.
+
         Two pre-flight fixes applied unconditionally:
         1. git safe.directory: Git 2.35.2+ refuses to operate in repos owned by a
            different user. Configure /testbed as safe so agents can run `git diff`.
@@ -125,6 +134,10 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
            world-writable /testbed. mv unlinks via the writable parent and recreates
            with the runtime user's ownership, making every file writable without sudo.
            Running before relocate_if_readonly keeps conda editable-install paths stable.
+
+        The trailing ``relocate_if_readonly`` call falls back to /tmp/testbed
+        when /testbed itself is not writable (toolkit case); on root-running
+        infras the probe returns immediately with the original path.
         """
         self._container.exec(
             f"git config --global --add safe.directory {self.tool_config.working_dir}",


### PR DESCRIPTION
## Why

Both `swebench-verified-cube` and `swebench-live-cube` have a `_build_tool` block that does three things (chmod-via-cp/mv, git safe.directory, `relocate_if_readonly`). The docstrings describe **what** each step does but don't say **why** the block exists at all. A reader diff'ing the file can't tell whether to keep or simplify it.

## What

Add a leading **"NON-ROOT DOCKER WORKAROUND"** paragraph to each `_build_tool` docstring, mirroring the existing style in [`terminalbench2_cube/task.py:80-89`](cubes/terminalbench2-cube/src/terminalbench2_cube/task.py#L80-L89):

- Upstream SWE-bench images bake `USER root` → Daytona / local Docker / AWS / Azure short-circuit the writability probes and pay essentially nothing.
- The EAI Toolkit's uid-13011 cluster policy is the case the block exists to handle: can't chmod root-owned files in place, can't write to a read-only /testbed, Git 2.35.2+ rejects foreign-uid repos.

Empirically validated by the Auto-CUBE matrix run (session `2026-05-20_swebench-verified-r0`): both swebench cubes reach toolkit parity with daytona because of this block. Tbench2's F7 finding (sister session) does NOT replicate on swebench — and now there's a comment explaining why.

## Scope

- Docstring-only change in 2 files (`_build_tool` in each cube).
- **No** behavior change. No tests needed.
- **No** auto-fix marker — this is pure prose annotation, not a fix.

## Diff stat

```
 cubes/swebench-live-cube/src/swebench_live_cube/task.py     | 12 ++++++++++++
 cubes/swebench-verified-cube/src/swebench_verified_cube/task.py | 13 +++++++++++++
 2 files changed, 25 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)