### PR TITLE
fix(genny): pin swe config to "once" thinking (reasoning_effort=medium, interleaved=False)

### DIFF
--- a/src/cube_harness/agents/genny_configs.py
+++ b/src/cube_harness/agents/genny_configs.py
@@ -78,6 +78,20 @@ def make_agent_config(
 GENNY_CONFIGS: ConfigRegistry[GennyConfig] = ConfigRegistry(
     {
         "default": make_agent_config(),
-        "swe": make_agent_config(template="workflow"),
+        # swe: SWE-bench-style debugging rewards deliberation at turn start
+        # over re-thinking after every tool call. Use the "once" cadence
+        # (``reasoning_effort="medium"`` + ``interleaved_thinking=False``)
+        # instead of the helper's "always" cadence — Auto-CUBE matrix
+        # 2026-05-20 found no measurable accuracy gain from per-step
+        # thinking on the 4-step Reproduce → Explore → Fix → Verify
+        # workflow, and "once" is ~2× faster wall-clock per episode.
+        "swe": make_agent_config(
+            llm_config=LLMConfig(
+                model_name=DEFAULT_MODEL,
+                reasoning_effort="medium",
+                interleaved_thinking=False,
+            ),
+            template="workflow",
+        ),
     }
 )

--- a/tests/test_genny_configs.py
+++ b/tests/test_genny_configs.py
@@ -1,0 +1,51 @@
+"""Pin the public shape of GENNY_CONFIGS entries.
+
+This is the only file in the suite that pins the *defaults* of canonical
+Genny configs — if these change, downstream recipes silently get a
+different agent. Surface the change here so reviewers see it.
+"""
+
+from __future__ import annotations
+
+from cube_harness.agents.genny_configs import DEFAULT_MODEL, GENNY_CONFIGS
+
+
+def test_swe_uses_once_thinking_cadence() -> None:
+    """``GENNY_CONFIGS["swe"]`` runs in the "once" thinking cadence:
+    ``reasoning_effort="medium"`` + ``interleaved_thinking=False``.
+
+    This is the cadence the Auto-CUBE matrix (2026-05-20 swebench session)
+    converged on for swe-bench-style tasks. Per-step thinking via the
+    Anthropic interleaved-thinking beta gave no measurable accuracy gain
+    on the 4-step Reproduce → Explore → Fix → Verify workflow and roughly
+    doubled wall-clock per episode.
+    """
+    agent = GENNY_CONFIGS["swe"]
+    assert agent.llm_config.reasoning_effort == "medium"
+    assert agent.llm_config.interleaved_thinking is False
+    assert agent.llm_config.model_name == DEFAULT_MODEL
+
+
+def test_default_keeps_helper_built_llm_config() -> None:
+    """``GENNY_CONFIGS["default"]`` keeps ``make_agent_config``'s
+    auto-built ``LLMConfig`` — ``interleaved_thinking=True``, no
+    ``reasoning_effort`` baked in (recipes pick the level).
+
+    Pinned here so a future change to ``make_agent_config`` defaults
+    surfaces as a test break, not a silent agent-behavior shift.
+    """
+    agent = GENNY_CONFIGS["default"]
+    assert agent.llm_config.interleaved_thinking is True
+    assert agent.llm_config.reasoning_effort is None
+    assert agent.llm_config.model_name == DEFAULT_MODEL
+
+
+def test_each_lookup_returns_a_fresh_copy() -> None:
+    """``ConfigRegistry`` returns deep copies — mutating one shouldn't
+    affect the registry or a second lookup. This is the property recipes
+    rely on when they reassign ``agent.llm_config = ...``.
+    """
+    a = GENNY_CONFIGS["swe"]
+    a.llm_config.reasoning_effort = "high"
+    b = GENNY_CONFIGS["swe"]
+    assert b.llm_config.reasoning_effort == "medium"


### PR DESCRIPTION
## Why

`GENNY_CONFIGS["swe"]` inherited the helper-built `LLMConfig`:

```python
LLMConfig(model_name=DEFAULT_MODEL, interleaved_thinking=True)
```

With `reasoning_effort` left unset (default `None`), the `interleaved_thinking=True` flag is **a silent no-op** — the wrapper at [`llm.py:287-302`](src/cube_harness/llm.py#L287-L302) gates the `interleaved-thinking-2025-05-14` beta header inside `if reasoning_effort is not None`. So the request goes out without the kwarg and without the header, and the model runs in "off" mode.

The Auto-CUBE 2026-05-20 swebench session decoded its own traces and verified this empirically: all 4 haiku × swe rounds (R1, R2, R5, R6) had **0 thinking blocks and 0 reasoning tokens** across 200+ LLM calls per round.

## What

Pin `swe` to the **"once" cadence** (`reasoning_effort="medium"` + `interleaved_thinking=False`) — the second row in the [LLMConfig docstring's off/once/always table](src/cube_harness/llm.py#L97-L105). Two reasons:

1. **Defensive.** "Once" actually engages thinking — no exposure to the silent-no-op pitfall above. If the helper default ever changes, swe stays correct.
2. **Cheaper.** SWE-bench-style 4-step Reproduce → Explore → Fix → Verify already has a turn-start plan; re-thinking after every tool result (the "always" cadence) added latency without measurable accuracy gain on the matrix and roughly doubled wall-clock per episode.

`default` keeps the helper-built config (unchanged) because it targets generic 3-step tasks where per-step thinking is more often worth the latency. The helper's own silent-no-op risk is a separate follow-up (a `LLMConfig` `@model_validator` rejecting `interleaved_thinking=True` with `reasoning_effort=None`).

## Tests

New `tests/test_genny_configs.py` (3 tests, all passing):
- `test_swe_uses_once_thinking_cadence` — pins swe's `reasoning_effort="medium"` + `interleaved_thinking=False`.
- `test_default_keeps_helper_built_llm_config` — pins default's `interleaved_thinking=True` + `reasoning_effort=None`, so a future helper-default shift surfaces as a test break.
- `test_each_lookup_returns_a_fresh_copy` — pins the `ConfigRegistry` deep-copy property that recipes rely on.

## Diff

```
 src/cube_harness/agents/genny_configs.py | 17 +++++++++++++-
 tests/test_genny_configs.py              | 50 ++++++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 1 deletion(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)