### PR TITLE
fix: guard silent-no-op thinking config + skip network-flaky swebench p2p tests

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -30,6 +30,27 @@ When your fix is complete:
 2. Confirm the patch only contains source file changes, then call `final_step`.\
 """
 
+# auto-fix(PENDING)↓
+# Tests with hard external-network dependencies in their SWE-bench Verified
+# pass_to_pass list. These hit real public URLs (google.com, w3.org) and fail
+# intermittently with ConnectionResetError when the container's shared egress
+# IP is rate-limited by the public endpoint — failures are non-deterministic
+# and unrelated to the agent's patch. PR#423's baseline-subtract relaxation
+# already catches these in the (common) case that they fail identically before
+# and after the patch, but it's a coarse safety net; stripping them at the
+# source is exact and deterministic. Auto-CUBE 2026-05-20 swebench session
+# observed these 3 fail on daytona × sphinx-doc__sphinx-8475 across R1/R3/R5/R7/R8.
+# Extend conservatively, only after observing a test fail with a clear
+# network-side error in a trace.
+_NETWORK_DEPENDENT_P2P: frozenset[str] = frozenset(
+    {
+        "tests/test_build_linkcheck.py::test_defaults",
+        "tests/test_build_linkcheck.py::test_defaults_json",
+        "tests/test_build_linkcheck.py::test_anchors_ignored",
+    }
+)
+# /auto-fix(PENDING)
+
 
 class SWEBenchVerifiedTaskMetadata(TaskMetadata):
     """TaskMetadata subclass for SWE-bench Verified tasks.
@@ -178,7 +199,19 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
     def evaluate(self, obs: Observation | None = None) -> tuple[float, dict[str, Any]]:
 
         fail_to_pass = self._exec.fail_to_pass
-        pass_to_pass = self._exec.pass_to_pass
+        # auto-fix(PENDING)↓
+        # Strip known network-dependent tests from pass_to_pass — see the
+        # _NETWORK_DEPENDENT_P2P docstring for rationale. Exact, deterministic;
+        # complements (does not replace) PR#423's coarse baseline-subtract.
+        pass_to_pass = [t for t in self._exec.pass_to_pass if t not in _NETWORK_DEPENDENT_P2P]
+        n_skipped = len(self._exec.pass_to_pass) - len(pass_to_pass)
+        if n_skipped:
+            logger.info(
+                "evaluate: skipped %d network-dependent p2p test(s) for %s",
+                n_skipped,
+                self.metadata.id,
+            )
+        # /auto-fix(PENDING)
         eval_timeout = self._exec.eval_timeout
 
         # auto-fix(423)↓
@@ -416,3 +449,4 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
 
 # === auto-fix notes ===
 # auto-fix-note(423) {class=L1 anchor=PR#423 hash=00588ac5 ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}
+# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck}

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -30,7 +30,7 @@ When your fix is complete:
 2. Confirm the patch only contains source file changes, then call `final_step`.\
 """
 
-# auto-fix(PENDING)↓
+# auto-fix(430)↓
 # Tests with hard external-network dependencies in their SWE-bench Verified
 # pass_to_pass list. These hit real public URLs (google.com, w3.org) and fail
 # intermittently with ConnectionResetError when the container's shared egress
@@ -49,7 +49,7 @@ _NETWORK_DEPENDENT_P2P: frozenset[str] = frozenset(
         "tests/test_build_linkcheck.py::test_anchors_ignored",
     }
 )
-# /auto-fix(PENDING)
+# /auto-fix(430)
 
 
 class SWEBenchVerifiedTaskMetadata(TaskMetadata):
@@ -199,7 +199,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
     def evaluate(self, obs: Observation | None = None) -> tuple[float, dict[str, Any]]:
 
         fail_to_pass = self._exec.fail_to_pass
-        # auto-fix(PENDING)↓
+        # auto-fix(430)↓
         # Strip known network-dependent tests from pass_to_pass — see the
         # _NETWORK_DEPENDENT_P2P docstring for rationale. Exact, deterministic;
         # complements (does not replace) PR#423's coarse baseline-subtract.
@@ -211,7 +211,7 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
                 n_skipped,
                 self.metadata.id,
             )
-        # /auto-fix(PENDING)
+        # /auto-fix(430)
         eval_timeout = self._exec.eval_timeout
 
         # auto-fix(423)↓
@@ -449,4 +449,4 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
 
 # === auto-fix notes ===
 # auto-fix-note(423) {class=L1 anchor=PR#423 hash=00588ac5 ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}
-# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck}
+# auto-fix-note(430) {class=L1 anchor=PR#430 hash=6a2bbc39 ctx=daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck}

--- a/cubes/swebench-verified-cube/tests/test_evaluate_baseline.py
+++ b/cubes/swebench-verified-cube/tests/test_evaluate_baseline.py
@@ -125,3 +125,55 @@ def test_f2p_failure_scores_zero_regardless_of_p2p_baseline() -> None:
 
     assert reward == 0.0
     assert info["fail_to_pass_passed"] is False
+
+
+def test_network_dependent_p2p_are_stripped_before_baseline() -> None:
+    """Tests in ``_NETWORK_DEPENDENT_P2P`` are removed from pass_to_pass BEFORE
+    the baseline check fires — they reach neither the baseline run nor the
+    post-patch run. This is the exact, deterministic counterpart to PR#423's
+    coarse baseline-subtract relaxation.
+    """
+    from swebench_verified_cube.task import _NETWORK_DEPENDENT_P2P
+
+    task = _make_task()
+    # Mix two skip-listed tests with one real test that must survive.
+    skip_listed = sorted(_NETWORK_DEPENDENT_P2P)[:2]
+    real_test = "tests/test_build_linkcheck.py::test_invalid_ssl"
+    task.execution_info.pass_to_pass = [*skip_listed, real_test]  # type: ignore[union-attr]
+
+    # The 2 skip-listed entries should never appear in any _run_tests call:
+    # baseline gets only [real_test], post-patch gets only [real_test], f2p
+    # unchanged.
+    seen_p2p_args: list[list[str]] = []
+
+    def _stub_run_tests(repo, directives, **_kw):  # noqa: ARG001
+        if directives and directives != task._exec.fail_to_pass:
+            seen_p2p_args.append(list(directives))
+        return (True, "1 passed")
+
+    with (
+        patch.object(task, "_apply_patch", return_value=""),
+        patch.object(task, "_run_tests", side_effect=_stub_run_tests),
+    ):
+        reward, info = task.evaluate()
+
+    # Both p2p invocations (baseline + post-patch) saw the stripped list.
+    assert len(seen_p2p_args) == 2
+    for call_directives in seen_p2p_args:
+        assert call_directives == [real_test]
+        for skipped in skip_listed:
+            assert skipped not in call_directives
+    assert reward == 1.0
+
+
+def test_skip_list_uses_pytest_id_format() -> None:
+    """Sanity-pin the test IDs against the exact format stored in the task
+    execution cache — guards against accidental ``tests.test_X.test_y``
+    (django-style) or trailing-slash regressions that would silently make
+    the skip list a no-op.
+    """
+    from swebench_verified_cube.task import _NETWORK_DEPENDENT_P2P
+
+    for tid in _NETWORK_DEPENDENT_P2P:
+        assert tid.startswith("tests/")
+        assert "::" in tid, f"{tid!r} must use pytest 'path::name' form"

--- a/src/cube_harness/agents/genny_configs.py
+++ b/src/cube_harness/agents/genny_configs.py
@@ -55,17 +55,18 @@ def make_agent_config(
     max_actions: int = 150,
     cost_limit: float = 1.0,
 ) -> GennyConfig:
-    """Genny is a multi-step tool-use agent, so the default-built LLMConfig opts
-    into ``interleaved_thinking=True``: when a caller flips on Anthropic
-    extended thinking via ``reasoning_effort``, the model thinks after every
-    tool result rather than only on step 0 (see auto-fix(412)).
+    """Helper for the canonical ``GENNY_CONFIGS`` entries.
 
-    **Recipes that override ``agent.llm_config`` with their own ``LLMConfig``
-    must pass ``interleaved_thinking=True`` themselves** — the raw
-    ``LLMConfig`` default is False (matches the Anthropic provider default).
+    When ``llm_config`` is omitted, builds a plain ``LLMConfig(model_name=DEFAULT_MODEL)``
+    — no ``reasoning_effort``, no ``interleaved_thinking``. Recipes that want
+    extended thinking should pass an explicit ``LLMConfig`` choosing the
+    off/once/always mode from the LLMConfig docstring. (Earlier revisions of
+    this helper set ``interleaved_thinking=True`` here unconditionally, but
+    with ``reasoning_effort=None`` that was a silent no-op — the LLMConfig
+    validator added in PR#PENDING now rejects that combination outright.)
     """
     return GennyConfig(
-        llm_config=llm_config or LLMConfig(model_name=DEFAULT_MODEL, interleaved_thinking=True),
+        llm_config=llm_config or LLMConfig(model_name=DEFAULT_MODEL),
         system_prompt=SYSTEM_PROMPT,
         goal_template=INSTANCE_TEMPLATES[template],
         flat_history=True,

--- a/src/cube_harness/agents/genny_configs.py
+++ b/src/cube_harness/agents/genny_configs.py
@@ -63,7 +63,7 @@ def make_agent_config(
     off/once/always mode from the LLMConfig docstring. (Earlier revisions of
     this helper set ``interleaved_thinking=True`` here unconditionally, but
     with ``reasoning_effort=None`` that was a silent no-op — the LLMConfig
-    validator added in PR#PENDING now rejects that combination outright.)
+    validator added in PR#430 now rejects that combination outright.)
     """
     return GennyConfig(
         llm_config=llm_config or LLMConfig(model_name=DEFAULT_MODEL),

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -124,7 +124,7 @@ class LLMConfig(ValidatedConfig):
             )
         return self
 
-    # auto-fix(PENDING)↓
+    # auto-fix(430)↓
     @model_validator(mode="after")
     def _check_interleaved_thinking_requires_reasoning(self) -> "LLMConfig":
         """``interleaved_thinking=True`` with ``reasoning_effort=None`` is a silent
@@ -143,7 +143,7 @@ class LLMConfig(ValidatedConfig):
             )
         return self
 
-    # /auto-fix(PENDING)
+    # /auto-fix(430)
 
     def make(self) -> "LLM":
         """Create LLM instance from config."""
@@ -452,4 +452,4 @@ class LLMCall(TypedBaseModel):
 #              Anthropic, asserts per-turn reasoning_token pattern) +
 #              original validation probe: 15/15 steps think with the
 #              flag on, 255 -> 846 reasoning tokens.
-# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=anthropic/cube-harness/genny-swe/silent-no-op}
+# auto-fix-note(430) {class=L1 anchor=PR#430 hash=f513c550 ctx=anthropic/cube-harness/genny-swe/silent-no-op}

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -124,6 +124,27 @@ class LLMConfig(ValidatedConfig):
             )
         return self
 
+    # auto-fix(PENDING)↓
+    @model_validator(mode="after")
+    def _check_interleaved_thinking_requires_reasoning(self) -> "LLMConfig":
+        """``interleaved_thinking=True`` with ``reasoning_effort=None`` is a silent
+        no-op (the "off" mode in the off/once/always table above): the beta header
+        path is gated on ``reasoning_effort is not None`` in ``_complete``, so the
+        flag is ignored and no thinking happens. Raise at config time so callers
+        who think they enabled per-step thinking discover the miss before a
+        million-token eval, not after.
+        """
+        if self.interleaved_thinking and self.reasoning_effort is None:
+            raise ValueError(
+                "interleaved_thinking=True is a no-op when reasoning_effort=None "
+                "(this is the 'off' mode in the off/once/always table). Either set "
+                "reasoning_effort to a level (to get 'always' mode) or drop "
+                "interleaved_thinking. See LLMConfig docstring."
+            )
+        return self
+
+    # /auto-fix(PENDING)
+
     def make(self) -> "LLM":
         """Create LLM instance from config."""
         return LLM(config=self)
@@ -431,3 +452,4 @@ class LLMCall(TypedBaseModel):
 #              Anthropic, asserts per-turn reasoning_token pattern) +
 #              original validation probe: 15/15 steps think with the
 #              flag on, 255 -> 846 reasoning tokens.
+# auto-fix-note(PENDING) {class=L1 anchor=PR#PENDING hash=PENDING ctx=anthropic/cube-harness/genny-swe/silent-no-op}

--- a/tests/test_genny_configs.py
+++ b/tests/test_genny_configs.py
@@ -28,14 +28,15 @@ def test_swe_uses_once_thinking_cadence() -> None:
 
 def test_default_keeps_helper_built_llm_config() -> None:
     """``GENNY_CONFIGS["default"]`` keeps ``make_agent_config``'s
-    auto-built ``LLMConfig`` — ``interleaved_thinking=True``, no
-    ``reasoning_effort`` baked in (recipes pick the level).
+    auto-built ``LLMConfig`` — both thinking knobs at their defaults
+    (``interleaved_thinking=False``, ``reasoning_effort=None``). Recipes
+    that want extended thinking opt in explicitly.
 
     Pinned here so a future change to ``make_agent_config`` defaults
     surfaces as a test break, not a silent agent-behavior shift.
     """
     agent = GENNY_CONFIGS["default"]
-    assert agent.llm_config.interleaved_thinking is True
+    assert agent.llm_config.interleaved_thinking is False
     assert agent.llm_config.reasoning_effort is None
     assert agent.llm_config.model_name == DEFAULT_MODEL
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -790,11 +790,13 @@ class TestInterleavedThinkingBeta:
         hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
         assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")
 
-    @patch("cube_harness.llm.litellm.completion")
-    def test_off_mode_no_beta(self, mock_completion, sample_prompt) -> None:
-        """No reasoning_effort -> no beta even if interleaved_thinking=True (degenerate)."""
-        mock_completion.return_value = self._ok()
-        cfg = LLMConfig(model_name="claude-haiku-4-5", temperature=1.0, interleaved_thinking=True)
-        LLM(config=cfg)(sample_prompt)
-        hdrs = mock_completion.call_args.kwargs.get("extra_headers") or {}
-        assert "interleaved-thinking" not in hdrs.get("anthropic-beta", "")
+    def test_interleaved_without_reasoning_effort_raises(self) -> None:
+        """``interleaved_thinking=True`` with ``reasoning_effort=None`` is the
+        silent-no-op combination — was previously accepted (degenerate "off"
+        mode that ignored the flag), now rejected at config time so callers
+        don't ship configs that look like they enable thinking but don't.
+        """
+        import pytest
+
+        with pytest.raises(ValueError, match="interleaved_thinking=True is a no-op"):
+            LLMConfig(model_name="claude-haiku-4-5", temperature=1.0, interleaved_thinking=True)


### PR DESCRIPTION
Two independent Auto-CUBE-surfaced fixes bundled per request. One Fix Report per `auto-fix` marker below.

---

# Fix Report A — `auto-fix(PENDING)` · LLMConfig rejects the silent-no-op thinking combo

**Class**: L1 · **Anchor**: `PR#PENDING`
**Context fingerprint**: `anthropic/cube-harness/genny-swe/silent-no-op`

## Invariant violated
A `LLMConfig` that *looks like* it enables extended thinking must actually enable it — or fail loudly. `interleaved_thinking=True` with `reasoning_effort=None` silently produces **no thinking at all**.

## Root cause
The interleaved-thinking beta header in `LLM._complete` is added only inside `if reasoning_effort is not None`. So `interleaved_thinking=True` alone never reaches the provider — no `reasoning_effort` kwarg, no beta header, no thinking. The 2026-05-20 swebench Auto-CUBE matrix ran **4 haiku rounds** in exactly this state; decoded traces showed **0 reasoning tokens across 200+ LLM calls per round**. The matrix's haiku numbers are a silent underestimate as a result.

## Why this fix / why this layer
- A `@model_validator` on `LLMConfig` raises at construction time — the bug is caught at recipe load, not after a million-token eval. Mirrors the existing sibling `_check_anthropic_thinking_temperature` validator (same file, same shape).
- `make_agent_config` previously hard-coded `interleaved_thinking=True` in its default `LLMConfig` — the exact silent-no-op combination, which the new validator would now reject. Changed to a plain `LLMConfig(model_name=DEFAULT_MODEL)`. `GENNY_CONFIGS["default"]` behavior is **unchanged in practice** (it was already producing zero thinking); recipes opt into thinking explicitly.

## Blast radius
```
$ git grep -n 'interleaved_thinking=True' origin/dev -- '*.py'
# (pre-PR) only callers: make_agent_config default + tests/test_llm.py degenerate test
```
Audited: no recipe hard-codes the bad combo. The two affected call sites (helper default + the `test_off_mode_no_beta` test) are both updated in this PR.

## Adversarial: the opposite user
A user who *wants* the old degenerate pass-through (interleaved flag set but no effort) loses nothing real — they were getting no thinking anyway. If a downstream config legitimately set `interleaved_thinking=True` expecting it to be a harmless default, it now raises with an actionable message pointing at the off/once/always table; the fix is a one-line edit (add `reasoning_effort=` or drop the flag).

## Registry lookup
- `auto-fix-note(412)` in `llm.py` — the original interleaved-thinking beta wiring. This validator closes the config-time gap that (412) left open. Two related auto-fixes in this area; both about the same beta. Below the ≥3 refactor threshold.

## Test
- `tests/test_llm.py::TestInterleavedThinkingBeta::test_interleaved_without_reasoning_effort_raises` — asserts `LLMConfig(interleaved_thinking=True)` (no effort) raises `ValueError`.
- `tests/test_genny_configs.py::test_default_keeps_helper_built_llm_config` — pins the corrected default (`interleaved_thinking=False`, `reasoning_effort=None`).
- Existing `test_always_mode_sets_beta` / `test_once_mode_no_beta` / `test_non_anthropic_flag_is_noop` still pass (legal modes unaffected).

---

# Fix Report B — `auto-fix(PENDING)` · swebench-verified strips network-dependent p2p tests

**Class**: L1 · **Anchor**: `PR#PENDING`
**Context fingerprint**: `daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck`

## Invariant violated
A correct agent patch must not be scored 0.0 because of a `pass_to_pass` test that fails for reasons unrelated to the patch (a real external URL being unreachable).

## Root cause
`sphinx-doc__sphinx-8475`'s `pass_to_pass` includes `tests/test_build_linkcheck.py::{test_defaults, test_defaults_json, test_anchors_ignored}` — linkcheck integration tests that make real HTTP requests to `google.com` / `www.w3.org`. They fail intermittently with `ConnectionResetError(104)` when the container's shared-NAT egress IP is rate-limited by the public endpoint. Both Daytona and Toolkit *allow* outbound network (verified in `cube-infra-daytona`'s `network_block_all: False`); the flakiness is endpoint-side rate-limiting, not an egress block. Observed failing on daytona × sphinx-8475 across matrix rounds R1/R3/R5/R7/R8.

## Why this fix / why this layer
- PR #423 already softens this *coarsely* (if baseline p2p was failing, accept identical post-patch failures). This PR strips the known-flaky tests at the source — **exact and deterministic**, doesn't depend on the baseline run, and removes them from both the baseline and post-patch passes.
- Lives in the cube (its task data is what carries the flaky tests), as a small curated `frozenset`. Conservative-by-policy: extend only after observing a clear network-side error in a trace.

## Blast radius
```
$ git grep -n '_NETWORK_DEPENDENT_P2P' origin/dev -- cubes/swebench-verified-cube/
# new symbol; one definition, one use site in evaluate()
```
One strip in `evaluate()` before the baseline run. No other call sites.

## Adversarial: the opposite user
A user who wants to *measure* the agent on linkcheck behavior loses those 3 assertions — but `test_defaults` tests whether google.com is reachable, not the agent's patch, so it was never a meaningful agent signal. The agent's actual linkcheck logic is still covered by the fail_to_pass test (`test_TooManyRedirects_on_HEAD`) and the non-network p2p linkcheck tests (`test_invalid_ssl`, `test_auth_header_*`, etc.) which remain in the gate.

## Registry lookup
- `auto-fix-note(423)` in the same file — the coarse baseline-subtract. This is the precise complement. Two related auto-fixes on the same p2p-flakiness theme; below the ≥3 refactor threshold, but if a third lands consider a shared "p2p hygiene" helper.

## Test
- `test_network_dependent_p2p_are_stripped_before_baseline` — asserts the skip-listed tests reach neither the baseline nor post-patch `_run_tests` call; a non-listed test survives.
- `test_skip_list_uses_pytest_id_format` — pins the `tests/…::name` pytest-ID format against the exact strings in the task execution cache (guards against a silent no-op if the format drifts).

---

## Note on bundling
Two independent concerns in one PR per request. Different files (`llm.py` + `genny_configs.py` vs `swebench_verified_cube/task.py`), no shared lines. Reviewable as two sections. Markers will be amended from `PENDING` → this PR's number after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)