### PR TITLE
docs(openspec): guide proposals to be concise

### DIFF
--- a/.claude/commands/update-openspec.md
+++ b/.claude/commands/update-openspec.md
@@ -36,12 +36,15 @@ Focus on layers relevant to the current change, or all layers for a full audit.
 
 ## Decision rule
 
-**Minor drift** (1–3 spec lines, no contract change): edit the spec directly.
+**Default: edit the spec directly** and describe the change in the PR. Additive,
+backward-compatible drift (a new method, a new optional field, a corrected invariant)
+needs no proposal folder — just keep the living spec accurate.
 
-**Substantive drift** (new capability, breaking change, or multiple invariants affected):
-create `openspec/changes/<name>/` with `proposal.md` + `deltas.md` (ADDED / MODIFIED / REMOVED
-sections in target-state language) before editing the spec. This signals to the team that
-a real contract change is in flight.
+**Open a `changes/<name>/` folder only for breaking or multi-invariant contract
+changes** — a changed/removed signature, a new required field, behavior the team needs
+to see before code lands. It carries `proposal.md` + `deltas.md` (ADDED / MODIFIED /
+REMOVED, target-state language). Keep the proposal proportional to the change and
+skimmable — see the proposal-writing guidance in `openspec/README.md`.
 
 ## Output
 

--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -37,11 +37,11 @@ This constitution is reviewed against actual code patterns. Anything listed here
 
 **Process**:
 1. Create a folder in `openspec/changes/<short-name>/`.
-2. Write `proposal.md` (rationale, scope, alternatives considered).
-3. Write `deltas.md` with ADDED / MODIFIED / REMOVED requirements against the affected spec.
-4. Optional: `design.md` for deeper design notes, `tasks.md` for implementation breakdown.
-5. Post to the team channel, tag relevant owners, async review, decision.
-6. On merge: apply deltas to `openspec/specs/`, move the folder to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+2. Write `proposal.md` (problem, change, alternatives) and `deltas.md` (ADDED / MODIFIED / REMOVED requirements against the affected spec). Keep both concise and skimmable — favor schemas/signatures over prose, show each thing once; see the proposal-writing guidance in `openspec/README.md`.
+3. Post to the team channel, tag relevant owners, async review, decision.
+4. On merge: apply deltas to `openspec/specs/`, move the folder to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Additive, backward-compatible changes (a new method, a new optional field) skip this — just keep the living spec accurate and describe the change in the PR.
 
 Cross-repo changes (cube-standard ↔ cube-harness) require a proposal in the **upstream** repo first. cube-harness is a consumer of cube-standard's contracts.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ default is `debug`, invoked as `/auto-cube` or `/auto-cube-debug`).
 1. **Find the relevant spec** — which layer? Start there.
 2. **Check "Invariants" and "Gotchas"** — these are the traps.
 3. **Check `openspec/changes/`** — someone may already be proposing your change.
-4. **For substantive contract changes**, write a delta spec
-   (`openspec/changes/<name>/deltas.md` with ADDED / MODIFIED / REMOVED sections)
-   before coding. Archive to `openspec/changes/archive/YYYY-MM-DD-<name>/` when done.
+4. **For breaking or multi-invariant contract changes**, open `openspec/changes/<name>/`
+   (`proposal.md` + `deltas.md`, ADDED / MODIFIED / REMOVED) before coding; additive changes
+   just edit the spec. Keep proposals concise — see [openspec/README.md](openspec/README.md).
+   Archive to `openspec/changes/archive/YYYY-MM-DD-<name>/` when done.
 5. **Constitution alignment:** every change is reviewed against the
    [constitution](.claude/rules/constitution.md) and [review rules](.claude/rules/review-rules.md).
 


### PR DESCRIPTION
## What

Mirrors cube-standard #200 (merged) — the proposal-conciseness guidance applied to cube-harness's three instruction surfaces. Docs-only.

- **`.claude/commands/update-openspec.md`** — loosen the decision rule: additive, backward-compatible drift edits the spec directly; reserve the `changes/` folder for breaking or multi-invariant contract changes.
- **`.claude/rules/constitution.md`** (RFC process) — drop the optional `design.md`/`tasks.md` (the bloat enabler), fold proposal+deltas into one concise step pointing at the proposal-writing guidance, and carve out additive changes.
- **`AGENTS.md`** (workflow step) — same scope bias + concise-proposal pointer.

## Why

Change proposals were ballooning to 500–700 lines while the canonical README claimed "one-page". The bloat is prose and redundancy, not structure — schemas/signatures/code blocks stay; the same thing shown three ways, version changelogs, and exhaustive test matrices go. Canonical guidance lives in cube-standard's `openspec/README.md` § "Writing a proposal" (this repo's README forwards there).

## Note

The constitution edit doesn't change any review rule (TC-001 still requires an RFC for breaking changes), so `/update-constitution` wasn't needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
