### PR TITLE
feat(genny): fold a benchmark hint prompt into the system message

### DIFF
--- a/src/cube_harness/agents/genny.py
+++ b/src/cube_harness/agents/genny.py
@@ -235,6 +235,11 @@ class GennyConfig(AgentConfig):
     # the goal — not as a separate hint section.
     task_clarification: dict[str, str] = Field(default_factory=dict)
 
+    # Benchmark-wide orientation prompt, folded into the system message. Sourced at experiment
+    # design time from the benchmark (see BenchmarkConfig.load_benchmark_clarifications). Generic
+    # by design — a generalist agent should remain competitive without it.
+    benchmark_hint_prompt: str | None = None
+
     # Observation format for tool results (role="tool" messages).
     # "raw"        = send content unchanged (default).
     # "output_tag" = wrap content in <output>...</output>, matching mini-swe-agent format.
@@ -433,6 +438,8 @@ class Genny(Agent):
         enabling Anthropic's longest-prefix cache matching.
         """
         system_content = self.config.system_prompt
+        if self.config.benchmark_hint_prompt:
+            system_content += f"\n\n{self.config.benchmark_hint_prompt}"
         if self._compacted_summary:
             system_content += f"\n\n## Summary of earlier work\n{self._compacted_summary}"
         messages: list[dict | Message] = [{"role": "system", "content": system_content}]

--- a/tests/test_genny.py
+++ b/tests/test_genny.py
@@ -569,6 +569,25 @@ class TestHintResolution:
         assert "Task Hint" not in contents
         assert "Additional task details" not in contents
 
+    def test_benchmark_hint_folded_into_system_message(self) -> None:
+        config = GennyConfig(
+            llm_config=_llm_config(),
+            benchmark_hint_prompt="Submit your final answer with final_step.",
+        )
+        agent = Genny(config=config, action_schemas=[], task_id="t1")
+        agent.goal = [{"role": "user", "content": "do the task"}]
+        messages = agent._build_base_prompt()
+        system = next(m for m in messages if isinstance(m, dict) and m.get("role") == "system")
+        assert "Submit your final answer with final_step." in system["content"]
+
+    def test_no_benchmark_hint_leaves_system_message_unchanged(self) -> None:
+        config = GennyConfig(llm_config=_llm_config())
+        agent = Genny(config=config, action_schemas=[], task_id="t1")
+        agent.goal = [{"role": "user", "content": "do the task"}]
+        messages = agent._build_base_prompt()
+        system = next(m for m in messages if isinstance(m, dict) and m.get("role") == "system")
+        assert system["content"] == config.system_prompt
+
     def test_make_wires_task_id(self) -> None:
         config = GennyConfig(llm_config=_llm_config(), task_hints={"t1": "my hint"})
         agent = config.make(task_id="t1")


### PR DESCRIPTION
## What

Adds `GennyConfig.benchmark_hint_prompt` — a benchmark-wide orientation prompt folded into Genny's **system message** (stays in the cached prefix, identical across the run).

## Design

Benchmark-derived prompt context (`benchmark_hint_prompt` + the existing `task_clarification` dict) is **resolved at experiment-design time** and passed into the `agent_config`. The benchmark only *stores* these for organization; it never acts on them. This keeps all prompt content in agent-land — nothing on `EpisodeConfig`/`TaskConfig`, no protocol change.

The companion piece — a `BenchmarkConfig.load_benchmark_clarifications()` loader that reads a per-benchmark sidecar (`benchmark_hint` string + `task_clarification` dict) so recipes can wire `GennyConfig(benchmark_hint_prompt=..., task_clarification=...)` — lands in a separate cube-standard PR.

## Tests

`tests/test_genny.py`: hint folded into the system message; absent hint leaves the system message unchanged. Full genny suite green (98 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)