### PR TITLE
refactor(metadata): normalize ContainerConfig _type to cube.resource (depends on cube-standard #201)

### DIFF
--- a/cubes/swebench-live-cube/scripts/create_task_metadata.py
+++ b/cubes/swebench-live-cube/scripts/create_task_metadata.py
@@ -32,7 +32,7 @@ from typing import Any
 # Make the package importable when executed from the cube root without venv activation.
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from cube.container import ContainerConfig
+from cube.resource import ContainerConfig
 from datasets import load_dataset
 
 from swebench_live_cube.benchmark import (

--- a/cubes/swebench-live-cube/src/swebench_live_cube/task_metadata.json
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/task_metadata.json
@@ -11,7 +11,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "c66868215665ec107b16a7a6a0b4bd52eaaaec16",
@@ -35,7 +35,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "52955ba4d867d2f4c78de8e2bf3c1df1f945a1d6",
@@ -59,7 +59,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "4664a0baa2993efb2b0265d41f376dd5c902c6c8",
@@ -82,7 +82,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "78e9fa96152d186ec7086d741f5f8ddaba1315e8",
@@ -106,7 +106,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "52fe657ef65e4bf808ea4667b130bc177385a773",
@@ -129,7 +129,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "10a008fac10e2eb7dd343c128cbf2e0f971fa993",
@@ -153,7 +153,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a896807eac70aa5723f0bba07ede9302f35f3fac",
@@ -177,7 +177,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "cd707961898e7012159b7205dabc4a2824eb3a68",
@@ -201,7 +201,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "ee6271f76b681e64a97f02e28af4c514e1006a41",
@@ -224,7 +224,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "c51103a068db018bad1152f78141d6c7360c29ff",
@@ -248,7 +248,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "5edca97a2ef091d969fcd550aa436bb7fedad71a",
@@ -271,7 +271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "8552c7a7f3dcca4ecb3ca4e3e61b7629a6b3a18c",
@@ -295,7 +295,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "81c69513b447656f0ba03a7ef6debfa505e0c22a",
@@ -318,7 +318,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "2f87363410f3c904e107e85ca10b9f84902db93f",
@@ -342,7 +342,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "e61f56950d624f5fa540a1c8d4e3baedd2889bd0",
@@ -366,7 +366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "1b6146bde5f0fb7d4cd02d69ea1ea1637ae209ae",
@@ -389,7 +389,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "cbca63dc7739720eab856f48b32f9e782438be7a",
@@ -413,7 +413,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "9e3f4521db37f3216e1b256f6227ed852f54b879",
@@ -437,7 +437,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "66cadb2402a3611ae014225ffdf4e10cd580528c",
@@ -460,7 +460,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "f73de91a10c4c02bbd6b3238fd2c2184ec4786af",
@@ -483,7 +483,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "9491f93de9ebc15bc71a3f502f11f7fac9d78818",
@@ -507,7 +507,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "4456e267ebecdbc27f7c7ddc174b1997355a496e",
@@ -530,7 +530,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "c25bef3ab28d721ace050b01ba5ab7b3a34d60fb",
@@ -554,7 +554,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "d8b331412a89cbeaf07cc94fa5b55b9e5b6bf626",
@@ -577,7 +577,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "70c71ebfe2f08ab54a5c21bc3d44c3479a362b27",
@@ -601,7 +601,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "689a0e64012d1e576ebd99e786a254bc537582c6",
@@ -625,7 +625,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "09161fc9181bf94aa3bbc5509c663d736a9553dc",
@@ -649,7 +649,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "fd7538f0e23a49ec34b636484de2d1b4b690c7fb",
@@ -673,7 +673,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "e1a17d5af24185b8bc1952c8c46af130fce90794",
@@ -696,7 +696,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "b16d6b4ce0796020a0ad5ee1c56453fde6079f2b",
@@ -719,7 +719,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "8ebf1ca548854919398c38d9f15912ad01f3b18a",
@@ -742,7 +742,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "bb070a7d912866805fad67482b1a029908e0eab4",
@@ -765,7 +765,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "369a3d0751b20cdb19abf7547b8b98e8cbd6dec9",
@@ -789,7 +789,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "9316764e90aea8d193cd8f03b0caccdf02af3ba0",
@@ -813,7 +813,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "3d49941484ef4dbceb155be0aedb09e49b896cd6",
@@ -836,7 +836,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "e8097167e0f70e887cc7aa8b9eaeabacbff6ed6a",
@@ -860,7 +860,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "334e69fbb40e27ff55929976a4413ffd60c13d30",
@@ -883,7 +883,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "5ec27a365963afd3f8910434ab21ddbb7463adc6",
@@ -906,7 +906,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "ab9faf9471035f29c1cc83bbe77b4b9e7220af6c",
@@ -930,7 +930,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "a55db38c061522a2b6397516df1eeedf2e8b4dc5",
@@ -953,7 +953,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "466c671cbe5c4f23747b8684665cebefdf6d8fdf",
@@ -976,7 +976,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "cb6db062ffcecc0928358d26c9c094da8aa0efaa",
@@ -1000,7 +1000,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "5b268db34d9f989cab67ecb340379a0ba9ec0da6",
@@ -1024,7 +1024,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "c6d3252cb87af839c8fd1e82bc14339b466e2002",
@@ -1048,7 +1048,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "e20de7e292e57e798036ad22b38b2fb94dc33856",
@@ -1072,7 +1072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "816d219c04b2bdb7de81081fa14eac63000dac30",
@@ -1095,7 +1095,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "816d219c04b2bdb7de81081fa14eac63000dac30",
@@ -1119,7 +1119,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "6fd4873a367d20624105967c5be0d451f72f946d",
@@ -1143,7 +1143,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "fdfc2fb5ea7df6664c35b7d8188caa4551f3be5d",
@@ -1166,7 +1166,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "8a58abe5e751af5b72e219e1bf3a90bb54e13b12",
@@ -1190,7 +1190,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "ea3ab628b456c0d8d401f37b568c90628a39e33a",
@@ -1213,7 +1213,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "036016004c5a2805b977b268af39313d6e7d5700",
@@ -1237,7 +1237,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "6fd4873a367d20624105967c5be0d451f72f946d",
@@ -1261,7 +1261,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "f01096fef402485092c7132dfd042cc8f467ed09",
@@ -1285,7 +1285,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "18f03b7b281a779915b4038164fff473930dd032",
@@ -1308,7 +1308,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "efe911f61a8d9ccd258b1c24bb9094fdce5d177d",
@@ -1332,7 +1332,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "efe911f61a8d9ccd258b1c24bb9094fdce5d177d",
@@ -1356,7 +1356,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "1c892c20334185294fa06ee5bf7a91ec843bbaa7",
@@ -1379,7 +1379,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "cbf10b9dc7670c71d019ae9df81a8702fd191462",
@@ -1403,7 +1403,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "0005c85fccccb491930f064ea8d064e87ce7ee79",
@@ -1427,7 +1427,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "f17bd4bfcab07d10a35a7e9c47920dbc43623e5b",
@@ -1450,7 +1450,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "a32250cc2886c177fc852dfc069022e653178011",
@@ -1474,7 +1474,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "920a65634cd89d47f2a561e17b99c2a5233cfa39",
@@ -1497,7 +1497,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "3c580fc0cd831043b5e1d8d9c0af60e67966136c",
@@ -1521,7 +1521,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "f1b98cf1241e5d31eff6deefa1419507221d0c2f",
@@ -1545,7 +1545,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f5d6598ab0363234d42436ed83a18ef96d78f6fa",
@@ -1569,7 +1569,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "8093c685c87d9666e7e7dd3bdb35f7a4ca29f12f",
@@ -1593,7 +1593,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "78fea5f8d7bf6ca55796e82ed341e7fd291878f0",
@@ -1617,7 +1617,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "b51f852b097f416d9c60198a838ce3d5f396ea19",
@@ -1640,7 +1640,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "ea15b184c008f06f3205884e85dd4fb2269158e8",
@@ -1663,7 +1663,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "f366e9cc11d9f8196454356af8d4bd40f0d1d6f1",
@@ -1686,7 +1686,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "43d79d3a2428122bf0284ce7f23fb3773a048a9f",
@@ -1710,7 +1710,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "5146610eff1e7400d425c7e8b8efbb3fafee98bd",
@@ -1734,7 +1734,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "374d5f5c3a5dff429c14d9dce2e709ac52527f3e",
@@ -1758,7 +1758,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "cc700f91ddfc511002d7468d335b43271dc7974a",
@@ -1782,7 +1782,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "4240ef8fc783c0c1598085b596783ace9ccaee03",
@@ -1805,7 +1805,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "eeb12087fb278a67f263fb9f3cc495959112ef8c",
@@ -1828,7 +1828,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "1c6e5902db227517e452cfd55fe977c5f9c3fb0a",
@@ -1852,7 +1852,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "0910a7b10ee32005239dd8ca3d392afc0cf02ffc",
@@ -1875,7 +1875,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "24021be4f3e968c11fc46d2e175c0fa0a0c17bd4",
@@ -1898,7 +1898,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "71715c88c21a186043c4da7f015bbc9ebdb94bb8",
@@ -1921,7 +1921,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "5a3b04540efe1559fe807f99b6305222bbe294bc",
@@ -1945,7 +1945,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "01b90b5dcdb472345e4508846e6f949544388d58",
@@ -1969,7 +1969,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "31d403612ebfc36fea0e9e017e42595f9dac60e6",
@@ -1993,7 +1993,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "2f800173a5e4cedfe99a6d6ad367057bfcc96d2b",
@@ -2016,7 +2016,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "df3f505f90faf20d2d1023c18627808166666cac",
@@ -2039,7 +2039,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "fb1e5cad591a020e237bf7c695049afc1c4c39a7",
@@ -2063,7 +2063,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jarun/buku",
     "base_commit": "e757c8e5490673f7a682a481699cf6276036111c",
@@ -2087,7 +2087,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "aa59dacddcafc531915dc983e3da6e8937558f9e",
@@ -2110,7 +2110,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "b7eeccb603b119c14b8d1d0efd6b5edc723d690c",
@@ -2134,7 +2134,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "db82a83eb4a3f2ec8f2489e1a01f8ad94deaecd1",
@@ -2157,7 +2157,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "2dbc249b7d5def49aecaf8ab23d147e15ca6c63e",
@@ -2180,7 +2180,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "832ebf0f1cec31d294b12a67b6a7e199ed22882e",
@@ -2203,7 +2203,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "bb020520aab4bcee770bfb74d5206bd9a4667f89",
@@ -2226,7 +2226,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "7b4a708ad6e4cb0119102041bd86f98015bc4900",
@@ -2250,7 +2250,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "cb0301fd9e55bc5bb4eb50ae3800a9a5d0168145",
@@ -2273,7 +2273,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "3d0ff15aaa0c7e5165aecc4f33bdb3171f04d7b0",
@@ -2297,7 +2297,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "6376c63deba1abab6ac0087a77897f599c0e807a",
@@ -2321,7 +2321,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "216d3acf9a0047a258ac2f3a0645f2dc9a04c630",
@@ -2344,7 +2344,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "28739c763000afc908ebc64eba717b7d01784de1",
@@ -2368,7 +2368,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "bb539d8e89fa7601e69fb9dbf849b051c61a3a31",
@@ -2392,7 +2392,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "d44da7516ef72d9ce9e0e214facabe13b901681e",
@@ -2416,7 +2416,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "4240ef8fc783c0c1598085b596783ace9ccaee03",
@@ -2440,7 +2440,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "ea84d9d5f0bd2859f3281e4dac812ae05d33f466",
@@ -2464,7 +2464,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "ff9e871af1ee6ff55267342e1f6f3889ab55278b",
@@ -2488,7 +2488,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "25b5930c6e6a1a44670ebc77d34f0cd7d441f623",
@@ -2511,7 +2511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "313277af993cebfbae49d385327fc7f45e32f737",
@@ -2535,7 +2535,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/starlette",
     "base_commit": "8d0cff820f89b5d5b19677246293513a9d1c952c",
@@ -2559,7 +2559,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "88d3f040e158703ae0c6499bb3b217a1e4c455a4",
@@ -2583,7 +2583,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "cf66b46cf9fdbb050a6e29438ca226757359af7d",
@@ -2606,7 +2606,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "f91754b01cb9f32b83aeaa80b74ed10b5dfccb6a",
@@ -2629,7 +2629,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "2c4310d9ff4136416bbfe7e255a3d7ab610ccac7",
@@ -2652,7 +2652,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "216d3acf9a0047a258ac2f3a0645f2dc9a04c630",
@@ -2675,7 +2675,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "13380e100200db3a04cb43be968d6962d51d0a28",
@@ -2699,7 +2699,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "3fddc56942846220b39945559f4b5e695873bb43",
@@ -2723,7 +2723,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "b9946b236d49e43335935d2bb0e3c4b38b997757",
@@ -2747,7 +2747,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "ffa7db56eaa8ee4b349613eedff476ab311c809d",
@@ -2771,7 +2771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "080878be865ea63857ab67be1db6cd8f1bb9e503",
@@ -2795,7 +2795,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "c22bab6233f89efa9a091c5d736e7c7b58199970",
@@ -2819,7 +2819,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "537e9da59e7df337fa39897d0b583ce0c12d3ed9",
@@ -2843,7 +2843,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f31647f3ef2feaabc91b2875d540ae48d2a4a4c8",
@@ -2867,7 +2867,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "cf84d9a6410dec07f57916905c9f54bf00d22b2e",
@@ -2892,7 +2892,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "f24cae348e5fb32a5de7d3b383e0adea13131d24",
@@ -2916,7 +2916,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1e42a99a1d6225f320a4938fcd7a778a88a8b410",
@@ -2941,7 +2941,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "bec73109d60c08f0e27d407858f8048b2d5c354c",
@@ -2965,7 +2965,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "5e3cfecdeab4182e4a405e94fb2d78f7b70eb16a",
@@ -2990,7 +2990,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "yt-dlp/yt-dlp",
     "base_commit": "983c58fb7a809d827b5821d493819da954f2c00b",
@@ -3014,7 +3014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "bf52423a81254009e9be6ca1b89a3f4c6e49ed49",
@@ -3038,7 +3038,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "38eb89e5a9ac3b61ca71834a3e92af7dd51e03f5",
@@ -3062,7 +3062,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "16ceaba5f7126ca86e5b50b669975c926b9f8f55",
@@ -3087,7 +3087,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "06fdf2885d70149803dbc47324ae8c951b7e58b3",
@@ -3112,7 +3112,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "c5b738681ef0c2541344aff1063e5f85720b3c1f",
@@ -3136,7 +3136,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "03f1205629ad17f123a190040361babc41c18afc",
@@ -3160,7 +3160,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "23a98cc5c543fd2456a189d794ff135008e50bf6",
@@ -3185,7 +3185,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "4107cc489eba9c25a1ddbfd1314be4a3a80de197",
@@ -3208,7 +3208,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "ad3b3354e4e57bc0ac4d8cd9b7748adb1d2034ed",
@@ -3232,7 +3232,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "f919d0d0d512a755f0f85af540ed75f73140a685",
@@ -3257,7 +3257,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "07652d4a4133e825aeeb09973398575b25713c82",
@@ -3281,7 +3281,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "8f6e45ba63941316b630e4c94ee2063395aa2b63",
@@ -3305,7 +3305,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "03c8c46c3b9524b0ddcca44a9f0d1596f5079be0",
@@ -3328,7 +3328,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0d7df0385cfa566a29c2ba73188224fb15d93889",
@@ -3352,7 +3352,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "7e514f46eb078a46051a2f0f9139a8340beb16b5",
@@ -3376,7 +3376,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8e463fb9af11adc21906049c369a023a30e67d1f",
@@ -3400,7 +3400,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a5672f0746161e808e2ea187f17322433bd0baab",
@@ -3424,7 +3424,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "132223fa20cfc684574a12c24e1d1715f9329be6",
@@ -3448,7 +3448,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "f1c8633a7d765f07b94e0a6097b3f0c7912b955f",
@@ -3472,7 +3472,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "9a952fef5fa8399cb82cb726860814e21816f16d",
@@ -3497,7 +3497,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "2e0c41f66ee7a9fddbc517a3ca75a2ce0cf2efd1",
@@ -3521,7 +3521,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "3eab2b6e7d8dab972b9e5714a845777d664e7ecb",
@@ -3544,7 +3544,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "02545e95585fa222f9e83b83161e6af4065fd6f7",
@@ -3567,7 +3567,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "1cc1eb5856cb05675e242a617dba8c047eb77dbb",
@@ -3592,7 +3592,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "41be3a05797a7827fb4e27d7c1edda4a22a6036a",
@@ -3615,7 +3615,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "3eab2b6e7d8dab972b9e5714a845777d664e7ecb",
@@ -3638,7 +3638,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "74847b145d63e7038752db93efd5ef5d4f9bd75e",
@@ -3663,7 +3663,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "4dc65a32312a3e37168a2f65c419046e4fea341e",
@@ -3688,7 +3688,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "dbb98b4a40d1679800f7f85d0dad59ef60b5b790",
@@ -3711,7 +3711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "2e0c41f66ee7a9fddbc517a3ca75a2ce0cf2efd1",
@@ -3736,7 +3736,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "bcf450d0eb712309fa22fd23073ddfba51d575e8",
@@ -3761,7 +3761,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "c07eb2a6a04e0694d27e6b5e256cc219ac68af0c",
@@ -3785,7 +3785,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "e8a8bfe42f8f96747b0d9f432aaed907ebcf1c10",
@@ -3810,7 +3810,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "6af80da35a7c96059c534ee38be9123bcfc7f50f",
@@ -3835,7 +3835,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kubernetes-client/python",
     "base_commit": "4da83df8f0c0b97554e2f8a130218ca3b1396062",
@@ -3860,7 +3860,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5714a1872bc0b867089b4b5e412f762c84d18ce2",
@@ -3883,7 +3883,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "f8900ead0d9381a7652568768b065324f929734e",
@@ -3907,7 +3907,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "yt-dlp/yt-dlp",
     "base_commit": "a6783a3b9905e547f6c1d4df9d7c7999feda8afa",
@@ -3932,7 +3932,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pallets/flask",
     "base_commit": "62c56e08c43f5eb174d15dd050591cfba9aed548",
@@ -3956,7 +3956,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "15a5ac03c45f6888a5a3b6acc72a72da27495567",
@@ -3980,7 +3980,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "a30b177e0c7f022f3ea63323dbd427401b371d92",
@@ -4004,7 +4004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "acb40b0713c30466dcbab73e6b98d1add8e5dd98",
@@ -4028,7 +4028,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "afdcdd4acc3fd00420a656b1c106d9a8bb85ad29",
@@ -4053,7 +4053,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "ef383c4edef8b2e13f40bfd28e9d149386577ff3",
@@ -4077,7 +4077,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "4b113ab852b31df67db5f830833111e1159f4a51",
@@ -4102,7 +4102,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "fa10dcf11add0afd3b4b22af29f8d504e7ef8a0a",
@@ -4127,7 +4127,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "76c134c5a20c443b01fb023c514487e713c784ab",
@@ -4151,7 +4151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7728bc9722a12c758b4cc2f39cf656a0497e5583",
@@ -4176,7 +4176,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "5a9ff0beb17090a64bc886bed6265c583ba8e32d",
@@ -4201,7 +4201,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "11076b8fc78bb61707c271953783198f4b6a04f1",
@@ -4225,7 +4225,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "ca74c8e81ce48b0f7b838492cab8634b9f1d33b7",
@@ -4249,7 +4249,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "5f5e76e2c0ba47e644b11e8e2177ffff606f76af",
@@ -4273,7 +4273,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "0f8ff5c2e890d3fe03cfc86e9024024a1f3cfce8",
@@ -4298,7 +4298,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "e1faa38e9024eadebc9274041887276164c215fd",
@@ -4322,7 +4322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "33763ade9bed7e20f0bc4fee4b207596abee5375",
@@ -4346,7 +4346,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "9d83f3fb144cf8034fb5d1e9de4cc26d89814686",
@@ -4371,7 +4371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "d0fcb3c49700a43fd04f9030becbb59640f0ebdf",
@@ -4396,7 +4396,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "2b7ef0dccc94540b259d62b02d8e7acb466ed4ed",
@@ -4421,7 +4421,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pallets/flask",
     "base_commit": "10bdf61a0f751f3cb000f8f8ac5ac5b4bb535677",
@@ -4445,7 +4445,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "ee0f19b696c60064c58cdc08b3265aef56d49ff8",
@@ -4469,7 +4469,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "b96d3e05238c615d87bd9042b057e4b08d030313",
@@ -4494,7 +4494,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "b325a4bb87ffaa994a289826621941e9673db284",
@@ -4518,7 +4518,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "fddc08caff79db6f3d7981a31fca73214359e861",
@@ -4542,7 +4542,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "37f44eda5555ffed3b4c581925650fb939e55b94",
@@ -4566,7 +4566,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "d810d5aac00cf9a4215f601247d08f6f7904bcfe",
@@ -4590,7 +4590,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "68cb5b320653ad64c68ff48a4bb4ba449a01d3a6",
@@ -4614,7 +4614,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "c36338c171cef52cdce7cd445795ee362435f6ea",
@@ -4638,7 +4638,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "8573f951eb782596f91148753305c5bf0ade3ae6",
@@ -4663,7 +4663,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "a8225996abf3e8c4706324fbdde2908e4dd777df",
@@ -4688,7 +4688,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "4897d0d15d4403de00d19c570d60178541c7c582",
@@ -4712,7 +4712,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "fddcd4556c01bf7add84a265ee79a41be06647c7",
@@ -4735,7 +4735,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "aa4920ec0935511b0f3d8f57040b70c00996e0c4",
@@ -4759,7 +4759,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "6edfdbf6ae90b0153309e3bf066aa3b2d16494a7",
@@ -4784,7 +4784,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "05cb9f88f7b03e5fedba15de9d083e3059abd6e4",
@@ -4808,7 +4808,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "922712c2f7136fba9b6e7c077bc8d19053230ec3",
@@ -4833,7 +4833,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "dbb926408d96258e30f8139aeed7e1ce3ec20167",
@@ -4858,7 +4858,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "690c55f736bbb285ef9e2a7e9f1634fdc53a5542",
@@ -4882,7 +4882,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "873f33ed40bb38407a87abba6cd2a65f35eb6286",
@@ -4906,7 +4906,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "3bf74038405bd9f489395eb3c3ae2cbd4911a1c5",
@@ -4931,7 +4931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "6765af055555c60f2170352e3f2d809a101d351a",
@@ -4956,7 +4956,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "7741985fd08414d35f7aa75ec9e6ce65eee3b522",
@@ -4981,7 +4981,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "6d083eb39b802592c5faba5a91c4782f7d831f8c",
@@ -5006,7 +5006,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "58dc21c83ff28a683cbbf5cede11a916a2ff77e6",
@@ -5030,7 +5030,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "19192ef6a075bab14d6af4a73c295711a7db9b0e",
@@ -5055,7 +5055,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "a94c1682b275bbf755342c0164d2ac0c379c0c16",
@@ -5080,7 +5080,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "3da5bac8c4743c59940e857d5d7a0552604d3fa9",
@@ -5105,7 +5105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "f3c3546925897243edb4e3ba42210c5262ce74cf",
@@ -5130,7 +5130,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "8afed74aacfee0b2094b7f138ccbb69146b793e7",
@@ -5153,7 +5153,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "4d0945c238e96551a06a7a8382e5792cb95afa2a",
@@ -5177,7 +5177,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "3bc10dd90fc8d621103f1962eb6dc1ab137b8217",
@@ -5200,7 +5200,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "eec68e40db9e2de2a592cdd6956443b2534bb37f",
@@ -5224,7 +5224,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "1597013645bfcd31207d31b969193b458ce85626",
@@ -5249,7 +5249,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "77d5e6394a88ead151c9469494749f95f06b24bf",
@@ -5274,7 +5274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0e3017f6c55d239b64c2a6cccc6920f83968f9ad",
@@ -5297,7 +5297,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "7ad7cfd0588e6ee67bdfc0f1bc2e43dd4503e44d",
@@ -5322,7 +5322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "f2bd4bc25b24587aef40f486087412b9da8f1d94",
@@ -5347,7 +5347,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "3c6f9a5a55b79563e32c766a1b5409e1d20b3601",
@@ -5370,7 +5370,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "2520c51aaf4c0a4af965026ae3a3fd5b03930288",
@@ -5394,7 +5394,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "30ecbc1fe4ffe2dd3690071f891352e15419b874",
@@ -5419,7 +5419,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "73efd383c3712153a868a882a8353ef8169aabdc",
@@ -5443,7 +5443,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "e9a03c5c8ebe4f7176ee12f48ad4cc8161f492b6",
@@ -5468,7 +5468,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "ffcce608bbfe07dba658f9951ceeb5da78073472",
@@ -5493,7 +5493,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "cd5bd0b4bdca67c52b0e448931d00986eecc8a3a",
@@ -5518,7 +5518,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8454bc9a7146e2b648090e866d09054589070599",
@@ -5543,7 +5543,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "ed2c941a8ee3dafb884746d03bcdc0cae57fd8a0",
@@ -5566,7 +5566,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "4afe174b5c9865d1fcba2bed83b68eee5c298e6c",
@@ -5590,7 +5590,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "14b242f66d3c8f0e3f27b05f948ae9005052e8c0",
@@ -5613,7 +5613,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "28f69ba98708393deb0f35501940f40b0f081504",
@@ -5637,7 +5637,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "d7befc67ad35d4aca37e6b36ba62950e71068efb",
@@ -5661,7 +5661,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "a898beaed7126f07b3a0ae21df8b291d512f798f",
@@ -5685,7 +5685,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "arviz-devs/arviz",
     "base_commit": "1d8c0102e1277ae3fe8a62d3ca47a84ba222bdb6",
@@ -5709,7 +5709,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "e40fe0229a5550c6eb6668974d40593a9e787f3c",
@@ -5734,7 +5734,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "yt-dlp/yt-dlp",
     "base_commit": "d298693b1b266d198e8eeecb90ea17c4a031268f",
@@ -5759,7 +5759,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "base_commit": "1913351ea8c2bdabe5638ae0ef44fc5a49a3090d",
@@ -5782,7 +5782,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "2bcdafc67824a60d65bce8bea65d019061c4e360",
@@ -5805,7 +5805,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "ccb62f766a03e3e3bee8a7439d056936d0fd7f3a",
@@ -5829,7 +5829,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "dd2f203090af6f570b0c5158661d718607758c96",
@@ -5853,7 +5853,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/starlette",
     "base_commit": "f13d354e18141cea9041ffad603d98197d880a73",
@@ -5878,7 +5878,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "d532def93ed25a3831aef588627bd855a71af336",
@@ -5902,7 +5902,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "ba32c7e8e263675431b49d6eae71e7fa3945d286",
@@ -5927,7 +5927,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "700563cda182416a6c99af4bcaa96077c2412465",
@@ -5952,7 +5952,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "e4b0f8cb640439ac8d49ee2072a0d8147f7623f2",
@@ -5977,7 +5977,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "6caa903b7bdb6db5b1c83523edbbfc2c8204002a",
@@ -6001,7 +6001,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "5ff3740063c1ac57f17ecd697bcd06cc1de4e75c",
@@ -6025,7 +6025,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pwr-Solaar/Solaar",
     "base_commit": "382e0b6797af1dd7a3ec05365d23fe95f974c8c8",
@@ -6049,7 +6049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "9cfda1c5d13bf0d4abe9296811d685089bedc2c6",
@@ -6072,7 +6072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "cb2283feaea643b822267526336ce20e67fb983e",
@@ -6096,7 +6096,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/datasets",
     "base_commit": "6457be66e2ef88411281eddc4e7698866a3977f1",
@@ -6119,7 +6119,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "df49afcdbeacfce25256376dc95841ab41f05424",
@@ -6143,7 +6143,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "93c4c8d2827bad02e48234799f159f196acb2282",
@@ -6166,7 +6166,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "1812899d04b535e2099ea0f9b8814ff3b266d9a9",
@@ -6190,7 +6190,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "6e2b7af3e0334a944e2dbb8159c553cfaa0cbe05",
@@ -6214,7 +6214,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "fb8dbba89cfc8d8a54d4c34c60b38fd504c4906e",
@@ -6239,7 +6239,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "cyclotruc/gitingest",
     "base_commit": "96bc3958a3b3409e009c80d7ac89a97c4c9520fa",
@@ -6263,7 +6263,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "3ae39419c050c54df37dfb79107cd93c3598e116",
@@ -6286,7 +6286,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "olofk/fusesoc",
     "base_commit": "d3aa7910a1e3e20c7b3489811aa649fc9ff80c19",
@@ -6309,7 +6309,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "f37fb16c2459807e0b392dc3306c373e5f68cc4f",
@@ -6334,7 +6334,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "427d7c56abe33a300f211680edd22b90c6981ef7",
@@ -6357,7 +6357,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "62c80e679c5a17eb08e1a836a2a8ad3f75697fdb",
@@ -6380,7 +6380,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "6e33a336c6be430b231d7d5d99cdadc94ed6b906",
@@ -6404,7 +6404,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "0def44efc13ac98ecef691daf217a31f6c459812",
@@ -6428,7 +6428,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "0def44efc13ac98ecef691daf217a31f6c459812",
@@ -6452,7 +6452,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "4f73b192f8bcab8077ef7adac7063b23c237f630",
@@ -6475,7 +6475,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "80b817e9d563d48a4a29c00e8c361b8b5000a60d",
@@ -6499,7 +6499,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "arviz-devs/arviz",
     "base_commit": "3205b82bb4d6097c31f7334d7ac51a6de37002d0",
@@ -6522,7 +6522,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0d174849026b389e3b32b3e64914231389550893",
@@ -6546,7 +6546,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "deeae4510eae72dc85ad2a9982f01165dad707d8",
@@ -6569,7 +6569,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "ec7dc8aea29b51f08c4671a6d2fc2c800c29091f",
@@ -6593,7 +6593,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "cyclotruc/gitingest",
     "base_commit": "8137ce10649526820efe752ff81eefabbea8ee23",
@@ -6617,7 +6617,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beancount/beancount",
     "base_commit": "a0e6f445fbf0d101602a4b6d886d6320971587b6",
@@ -6642,7 +6642,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "26b80778f52246214efe72b777d548f85d810198",
@@ -6666,7 +6666,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "e345cbdfba9c656b01ef4e116822ad03ffe9d804",
@@ -6690,7 +6690,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "5e7c7b4d53ce320a4de201c31c4fdd153ab207bc",
@@ -6715,7 +6715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "a4ec1e5be3fb553b45af5f38f134f7be26d3a274",
@@ -6738,7 +6738,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "eb95f5b9472f8d75888d0ffcecba32e17a882423",
@@ -6761,7 +6761,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "5d9282d0ef73a24976e4977f6d6dfe143bdf779a",
@@ -6785,7 +6785,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "icloud-photos-downloader/icloud_photos_downloader",
     "base_commit": "337ea77aefb5c1189681a2971c037caeeec43f51",
@@ -6810,7 +6810,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "icloud-photos-downloader/icloud_photos_downloader",
     "base_commit": "f8987b1933554af5489c2088b1066244abb270b4",
@@ -6833,7 +6833,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "e18155fa106cf64d7b39dcc6506b60fd82703b10",
@@ -6858,7 +6858,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "0ff045263f69802e32d7e5a69ac5c16142f7a96e",
@@ -6882,7 +6882,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "d680bf4719933756a41cced3a4f17620e0be9381",
@@ -6907,7 +6907,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "6fb23c1ab7f149ed1bec81eef6959e09526b2058",
@@ -6931,7 +6931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "bd08d6485daad3a8eba8d22ca0c185c6653acf2c",
@@ -6955,7 +6955,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "4ccb048d10390bafbefc23215322c803c71438be",
@@ -6980,7 +6980,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "609412d8544217247ddf2f72f988da1b38ef01bc",
@@ -7005,7 +7005,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "46cb2d078adebb0830d054052c1a489e699583b0",
@@ -7028,7 +7028,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "f39bf4d2585746fce3ba39decba62693c82f194e",
@@ -7052,7 +7052,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "da39d8262b1b4a3d88c3bf934c047deca354b01e",
@@ -7076,7 +7076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "019a6661f4b4ae6bffcfe015387e90d8b0190c8b",
@@ -7101,7 +7101,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "71bd7319fe324f7b7ff14b8210420843bf06d7d2",
@@ -7125,7 +7125,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "29f3a5ca0bd366d5bffebfcfba6181af322041b3",
@@ -7149,7 +7149,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "a833900d537ec15b50ef2288891ebfc2fa693f22",
@@ -7172,7 +7172,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "95dfc70468fad48fc4647317b8aa91ce4f3cc43b",
@@ -7196,7 +7196,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "637e037d668db7aebe61ae04261ebfc5cb7f32c5",
@@ -7219,7 +7219,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "e28f1714bc81d180a128a7b17794c586cb8fafb1",
@@ -7242,7 +7242,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapy-plugins/scrapy-splash",
     "base_commit": "538f4d1df62f0169c3371c3ac5d46ee190de7906",
@@ -7267,7 +7267,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "ac7cc07f8f6c7ffb8860d9b799c4b85aaacf11ae",
@@ -7291,7 +7291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "b2598faec18d147a491ff4ec1e9d0fd138e0342e",
@@ -7315,7 +7315,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "9c8da1faa55adc79c7403f99daeac89b75c17794",
@@ -7338,7 +7338,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "2c3257d4ea1bae113a0b2338e2b7763189287206",
@@ -7362,7 +7362,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "a70bfc26c0ff90f8feb2001fc6cadf53658aba3f",
@@ -7386,7 +7386,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a589da356d6bd75e059505b2a91e9e044148ac50",
@@ -7409,7 +7409,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "99d5cc98b19d4e1d70a0fd81d68d1f5f453a48d9",
@@ -7432,7 +7432,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "4f45637ac45ab8f75794e6dbde069ba371d2bc02",
@@ -7455,7 +7455,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "80b817e9d563d48a4a29c00e8c361b8b5000a60d",
@@ -7480,7 +7480,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "638ea0dffad99cb2c28a64888bb2f528a3e4f31c",
@@ -7503,7 +7503,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "adae52da073f306f94183aec3b92b4333fead930",
@@ -7528,7 +7528,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "a060edf190c8820adb8428678fb923f184aa42a4",
@@ -7552,7 +7552,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "059cad9c1c0b684ec095634992468eca18bbd395",
@@ -7575,7 +7575,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "5c274fa0c3a5f5e85c7e71a0e53b9ea5b3428bf8",
@@ -7599,7 +7599,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "5e7c7b4d53ce320a4de201c31c4fdd153ab207bc",
@@ -7622,7 +7622,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "2d5f4a68bbf4689103db596576f719f6237f3d77",
@@ -7646,7 +7646,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "b11303adb9771346f79f5ca7bab0f3a6f733a6eb",
@@ -7670,7 +7670,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "8b0f288ae10065b5f40673d904f2204c5a3ec770",
@@ -7695,7 +7695,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "c5a300a4357d40d202f92dd08894ea520f2ade3f",
@@ -7720,7 +7720,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "12a8747ec98617fa1989ce069f174b3587005cdf",
@@ -7744,7 +7744,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "465a3d2247f6f4deaa702989688de9caeae5c585",
@@ -7769,7 +7769,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "c4b3dcbaf9f9a5d0895374981a9d222e6be094e2",
@@ -7792,7 +7792,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wireservice/csvkit",
     "base_commit": "bd6095d39bcd27ec227a8e802ff5329535df9a07",
@@ -7817,7 +7817,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "328e4197df16fbcfe2ac4a779c687a2ff7e1557e",
@@ -7841,7 +7841,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "5e7c7b4d53ce320a4de201c31c4fdd153ab207bc",
@@ -7865,7 +7865,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "105e6312f8ce3414ba0bebf88ad6e35b3953df38",
@@ -7890,7 +7890,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "9d83ecd0aee6ae60318e67b50d903b1368a7635f",
@@ -7914,7 +7914,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "3f99fe70fa35cf0d5821e2c2f7e8b02d8925cce2",
@@ -7938,7 +7938,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "c582a94ce4c21d1099790b0ea4f785a8769be654",
@@ -7961,7 +7961,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "4eb62f05f8a6207ba0df279823f53893af3c7f86",
@@ -7985,7 +7985,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "985690cc60169e3abcdca9a4707bdb7e8ae27cd0",
@@ -8009,7 +8009,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "bc1669b2f7ab42015426a49c1692851bf0897d24",
@@ -8032,7 +8032,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "e310e2029102b5d63a679a2b64501c045aa86336",
@@ -8057,7 +8057,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "meta-llama/llama-stack",
     "base_commit": "c91e3552a3d2644a9068250594d88764b1cbeaf9",
@@ -8081,7 +8081,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0017c296b27770cbf8dfbfc6422bb37f13970b62",
@@ -8105,7 +8105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "e17479bd0701e8fc0b26981339540599dc224d11",
@@ -8129,7 +8129,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "78608135d9dd2d14a569253c80c5a959cf32bff7",
@@ -8153,7 +8153,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "d602a4a33ed33d5c9dd02d7e0777055674dd549f",
@@ -8177,7 +8177,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "74eddd6af20566771ae4551a21e389e9ec188e66",
@@ -8201,7 +8201,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "98a7201ee6ce5decb81df58151249516d397d484",
@@ -8225,7 +8225,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "a44f38b40a61c5b91e6de68d20d27ed01d3ccb56",
@@ -8250,7 +8250,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "5a3f7c2b018695c9290d92dfc2384ee7a2cb61c3",
@@ -8275,7 +8275,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "9d61bdce52ddc916abcb9f932410102be17b354e",
@@ -8298,7 +8298,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "de3d0a23e816d54717a7542a9a1a1f2eb7a7eaec",
@@ -8322,7 +8322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jazzband/tablib",
     "base_commit": "70775bc922602ae535e0b2e525f6926030334ab8",
@@ -8346,7 +8346,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "abb81878fd114f309297b35e1d392bee0d196fbf",
@@ -8370,7 +8370,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "0d5af5c3f258ccc41715ae8fb9650908a95a06fc",
@@ -8395,7 +8395,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "0caf09628011f9790d6e8df62fe92c485c7382ae",
@@ -8419,7 +8419,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "icloud-photos-downloader/icloud_photos_downloader",
     "base_commit": "b69c9a125d9202828ef7aa679d51a4b5365f10ba",
@@ -8443,7 +8443,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "8b0f288ae10065b5f40673d904f2204c5a3ec770",
@@ -8467,7 +8467,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "2edac1defc9ba641a91cd96dd2d06ab5419faf62",
@@ -8491,7 +8491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "30f85103cd5efdc8359353e536730809ef020fec",
@@ -8515,7 +8515,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "amoffat/sh",
     "base_commit": "11f55d5db6df0ce8571268a1e6c1179d88a1e9ed",
@@ -8538,7 +8538,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wireservice/csvkit",
     "base_commit": "d9ee9118884accc3cde5f3fd4dbf055d95446ff8",
@@ -8563,7 +8563,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a21c0cf650d1a31577d794b1faee5dcde005d45e",
@@ -8586,7 +8586,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "d17bb0631ce13b00a68319f31425ddf5a57719eb",
@@ -8610,7 +8610,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "2fffc620651d6d22c3279a1a6aac302146b97036",
@@ -8634,7 +8634,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "969d991ef41dd2be55d7d98609a447733fac1bac",
@@ -8658,7 +8658,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "fd830c8f2c31c940dc4d425f1bd366eba36dbd85",
@@ -8682,7 +8682,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "db4f23771abb41e598ad65041c997d72d6268dd9",
@@ -8707,7 +8707,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "db4f23771abb41e598ad65041c997d72d6268dd9",
@@ -8730,7 +8730,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "a7a68157aefdeaa2e58b99980e3f3b6abdae2884",
@@ -8754,7 +8754,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "86f29e137a10bb6ed140c1a8c05c3099987b13c5",
@@ -8777,7 +8777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "0b7a88a967ce8d02284dd4c7e47889ccc0bbcbf0",
@@ -8801,7 +8801,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "e520a5e531faa5961a260fd38db476008a86d718",
@@ -8825,7 +8825,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0e490157fd1423eb1b1034ba048c3b15a1ec3026",
@@ -8848,7 +8848,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0e490157fd1423eb1b1034ba048c3b15a1ec3026",
@@ -8872,7 +8872,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "03b74eaa4b60a5a713e03cb22a5d863bc041750d",
@@ -8895,7 +8895,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "38b63ac1d9c1c24e609be63c3e1fe91a1d814f94",
@@ -8919,7 +8919,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "10ff1e76e9d3b818332596166691fef93a6ed976",
@@ -8942,7 +8942,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "f6799ab8e60d7fcd4b02d52d5903f08c24957faf",
@@ -8966,7 +8966,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "1c02efb55247860b1dc92aa0c5cd5c69b8b8e59d",
@@ -8990,7 +8990,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "ed041973514db89e77ee78b13dd805ac0b358588",
@@ -9014,7 +9014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "theOehrly/Fast-F1",
     "base_commit": "1482a077ece15e1d5a1a719faeda36d7906a6bb8",
@@ -9038,7 +9038,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "ef0c97cb34d753aa831fe9f4e71df399d90d746b",
@@ -9061,7 +9061,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "20197135f56dcd886248e671058933c14cdf5f78",
@@ -9085,7 +9085,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "theOehrly/Fast-F1",
     "base_commit": "0526f59fe9788183078067e774e2f12afcaca731",
@@ -9109,7 +9109,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "830e7497c3a23cfd3354665ec6c77cec0e8105b3",
@@ -9134,7 +9134,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "9da6696a45c0141715cd95030c861c3e9f3f40cf",
@@ -9158,7 +9158,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "a6a4b0a85d70677937f7fd83c23185384d4f7827",
@@ -9183,7 +9183,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c4fafd9b04a6d0988a23ecda626c2473891ef7e5",
@@ -9208,7 +9208,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "fb462618190e87b4f0dec0bb677bcdea40b448a7",
@@ -9231,7 +9231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "70be08ef1eea9cbd49d787ac0fe3d1fc85a1bf86",
@@ -9256,7 +9256,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "70d0bf779fb0876e34540e9df37c3f4559006aec",
@@ -9279,7 +9279,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "e9e3048afae1705a4c3f80e4ca56dcc0c6df998e",
@@ -9304,7 +9304,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "92935966250922b21f688947593da7d1d15b4efc",
@@ -9329,7 +9329,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ad8ff14bdd6b80ed9fd1c619b479f8a5c0838bab",
@@ -9353,7 +9353,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "e6278b452a0d2b4080068ee61d99d613d5273f37",
@@ -9378,7 +9378,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "564d09acbf2c8ef6500a3864f1fa1d38b3c5cdd5",
@@ -9403,7 +9403,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "03f148d7e3c80a9354b5ccf30423a321b85979a9",
@@ -9427,7 +9427,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "ee9427a5d0f8618082592ed0e967e7c60747293c",
@@ -9451,7 +9451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "7b02177e9bf01dc0c7734cb7af9021c952426d56",
@@ -9476,7 +9476,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "9905e9fa171c808a78f0006c83fc3c2c51a6f90f",
@@ -9499,7 +9499,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2498cd430fa3448c11109978f7a967e4aa032c5a",
@@ -9522,7 +9522,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "19943b775d40c018e844f2cb1728442f58112a3b",
@@ -9546,7 +9546,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "home-assistant/supervisor",
     "base_commit": "34752466d55ff6748509aa47a4576a767db11c60",
@@ -9570,7 +9570,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "651367020b0ad6243677e8c280758208889b74db",
@@ -9595,7 +9595,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "c32f1a8f09923b8a22641755fd9e43aba35368be",
@@ -9619,7 +9619,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "978324813ce6a4a39156c549436b89eb22944038",
@@ -9643,7 +9643,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "512c8bee6cd237a8e56ab5527ee2876d8070c0d6",
@@ -9666,7 +9666,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Flexget/Flexget",
     "base_commit": "05c34fe1d7028d6a81e94e4dce99bfc62efd1e91",
@@ -9691,7 +9691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "5ed4d33f7da60a7780a5693c677bcb82249a92f5",
@@ -9715,7 +9715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f31a78f057c05c20482965cbdf21a79a9db04c45",
@@ -9738,7 +9738,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f31a78f057c05c20482965cbdf21a79a9db04c45",
@@ -9763,7 +9763,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "769629fb23c19a7629ee8b1ae97940665d6d57bf",
@@ -9787,7 +9787,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "bb539d8e89fa7601e69fb9dbf849b051c61a3a31",
@@ -9811,7 +9811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "9585ee54932bc135a05a6617d039d4f994daa7a3",
@@ -9835,7 +9835,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0bf508f3474e5f4b4a5ace8a1412bc450fb0bae0",
@@ -9860,7 +9860,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "7351d0cf7087d759dd24b06190cb759ec3381da6",
@@ -9885,7 +9885,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "9fbfa9676f661a1a523a4fa841f440dc10fc0fa7",
@@ -9908,7 +9908,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "d865f5f0f2b7862afb96a4bf3dabdd0d464e5da9",
@@ -9932,7 +9932,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "c887ecbc753763ff4232041cc84c9c6a44d20fd4",
@@ -9955,7 +9955,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "bdec8890372ed4af29075dee22e4dfc8a9f0807f",
@@ -9978,7 +9978,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "1cec93e695a09ddcff3dcb69192e72746a079cd4",
@@ -10002,7 +10002,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "yt-dlp/yt-dlp",
     "base_commit": "2ee3a0aff9be2be3bea60640d3d8a0febaf0acb6",
@@ -10026,7 +10026,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "a3e5bef359ae1d5359fe8649aba9f12f8e3fd5c8",
@@ -10050,7 +10050,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "yt-dlp/yt-dlp",
     "base_commit": "9d5e6de2e7a47226d1f72c713ad45c88ba01db68",
@@ -10075,7 +10075,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "a9dc9acc2dd1bab761b45e48c8d63aa108811a82",
@@ -10099,7 +10099,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "1b24ad91323c8444e398b75ed40ad54cf678ea0d",
@@ -10123,7 +10123,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "1863011580c054a6bffa6b94bd0d876df393da35",
@@ -10147,7 +10147,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1fb10da677ee052a5f38df2298ba6192d51ea212",
@@ -10170,7 +10170,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytransitions/transitions",
     "base_commit": "4d8d103b52e3eaad6dc8e82c829fb98319782406",
@@ -10194,7 +10194,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "0e2c4e41ffdc4c35132840d97135664843c9fe2a",
@@ -10218,7 +10218,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "bfbd0b56d7abf639101fb79ed684642ac41d3277",
@@ -10241,7 +10241,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "31270c14e30901ae5b178f72c67a83efe070768c",
@@ -10266,7 +10266,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "73b91d5803c44e6f12bec495651be802615b3826",
@@ -10290,7 +10290,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "f99fa5f23c039e8e8434871b0e39e9e889d4a03b",
@@ -10313,7 +10313,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hiyouga/LLaMA-Factory",
     "base_commit": "f54733460427cf2b126b8b8737fdd732c0e19d9c",
@@ -10338,7 +10338,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "14761c910fa995c458333d8780a5797c0aab6308",
@@ -10362,7 +10362,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qubvel-org/segmentation_models.pytorch",
     "base_commit": "44505fd39785e42756a3e67fd47afae18f5f54f5",
@@ -10385,7 +10385,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1f112d48a2829dd8f274275bb1a5cc0a11379f62",
@@ -10410,7 +10410,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "e483ec6f5627b4b9e47319443d5c813c801fd0c7",
@@ -10434,7 +10434,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/ansible-lint",
     "base_commit": "3fe9fb5cc3d9b2ffa5226b662f07319ae52480f5",
@@ -10457,7 +10457,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "lss233/kirara-ai",
     "base_commit": "01f95895fcbe6a330b5b7b82c5769afa080abb05",
@@ -10481,7 +10481,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "8ebd9c60208fbd3c61ffd56d852db1a3f1d962e7",
@@ -10504,7 +10504,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "1a6f645e25685f267cbce6d23eebd920e5675dec",
@@ -10527,7 +10527,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "8356e82c294104e8c4608f45f2f631cc41ddca67",
@@ -10551,7 +10551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "6afcaf60bde184258b79d3bba8eb35046a87a073",
@@ -10574,7 +10574,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "84aea68d90ff5f8e65af33fd004e7b84424bc712",
@@ -10597,7 +10597,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "3274d6a65d8a6e911ef3fd7d180e34c41c132bec",
@@ -10621,7 +10621,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-poetry/poetry",
     "base_commit": "afbdfe9be21efe15107ca448a529b8fc40d6511e",
@@ -10644,7 +10644,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "da772724fcc09b340185a8c5b45e77c5b3ff1069",
@@ -10668,7 +10668,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c516d3fe48e7ca469ca94a293f12df56f7964fe3",
@@ -10692,7 +10692,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "cf04446a5a38af7940aaa83410a5863214b4d542",
@@ -10716,7 +10716,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "025c796756241ba9bed8c979e72930afa712b299",
@@ -10739,7 +10739,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "dd954e3cf2fbb119530ca2e6885b784bad9bace9",
@@ -10763,7 +10763,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "a46469423c40edab3b2321d00ed371b7f30c8f50",
@@ -10786,7 +10786,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "25e9127db9004c9c49ca46bdf5297682fac71fbb",
@@ -10809,7 +10809,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "8bf41a8510352e6a1f5d474801f9a6a73c888379",
@@ -10832,7 +10832,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Azure/azure-sdk-for-python",
     "base_commit": "e37eeb245abfebbd397653b88b04179c527ffded",
@@ -10855,7 +10855,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "21e91cd132964b9eb44442e6c6765c8fa22c2128",
@@ -10878,7 +10878,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "827585b134d730550820f307fb31a555d758c58c",
@@ -10901,7 +10901,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jarun/buku",
     "base_commit": "6af253a9b9f59e82d56ac2e40c157f58010f269e",
@@ -10924,7 +10924,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "8928c785301526674cb949d38b583d02a499b0a4",
@@ -10947,7 +10947,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "662f184ce70c296019fad360c38a937031b2dd53",
@@ -10970,7 +10970,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "185e1c79c9f15ac90226282e44f75699c38428fc",
@@ -10993,7 +10993,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Aider-AI/aider",
     "base_commit": "270e84287a8c3f9e0062e6b04434a4f3d3784d67",
@@ -11017,7 +11017,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "4db86d8821dd9f371ff6d0cc00e080a6683bfa90",
@@ -11040,7 +11040,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "126515a81f2e981894095dc9e76c4634f85dc2ca",
@@ -11064,7 +11064,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "cdc53cae78d080d67ecaa184ff16a83dba13a010",
@@ -11087,7 +11087,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "d1b18028b2fb5b5a7132558cc581f59c568271ee",
@@ -11110,7 +11110,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "20d36a2ab8a21eeff2f360f73b14b99d5e397762",
@@ -11134,7 +11134,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/datasets",
     "base_commit": "491d8082e2f062a1cf4734c2b88940a496f9892e",
@@ -11157,7 +11157,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "apify/crawlee-python",
     "base_commit": "cc98f83ce5d46c9b53db744f313d9c9b8c836c68",
@@ -11180,7 +11180,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "dc7d71bd1a2d143f10fa8fe91d31292bdf8f5113",
@@ -11203,7 +11203,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "6941081bdedabb2ba275b17a82a2d137d373ca47",
@@ -11226,7 +11226,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "114b4568ba869d878a2830f543158fb902e43c59",
@@ -11249,7 +11249,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "b10976aed676cd65e633de58627b1d353d5b4e62",
@@ -11272,7 +11272,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "1b0684bd6cc1272f4ddcb6d93f987228d6e492b7",
@@ -11296,7 +11296,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "0f7736e6f2ea3910b4b0e6086fd77404f66db1a2",
@@ -11319,7 +11319,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-poetry/poetry",
     "base_commit": "8e5426df948cf7dc3be2721fb858c8424ea5f5d7",
@@ -11342,7 +11342,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "b8aad0d032315f0d6317f7cf570bb65083f0c973",
@@ -11366,7 +11366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "quantumlib/Cirq",
     "base_commit": "5112418cf892512511bb20a37ddbbca36cb85bda",
@@ -11390,7 +11390,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "9166f3ab18737d0813e6cf7e04a5e3d4ba22606b",
@@ -11413,7 +11413,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/pipenv",
     "base_commit": "1cf036a08541801d6e24fb46dd6d3f592f9e40a6",
@@ -11437,7 +11437,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "8f22fd255efc5710e4fd1853f12c34abf893abe6",
@@ -11460,7 +11460,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/Radicale",
     "base_commit": "600c82d9773a4f171dc4088790d9e0b260cddf8e",
@@ -11484,7 +11484,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "76b2bd31d32a1231320f8151d94f99e77ac8dc5b",
@@ -11508,7 +11508,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "cfa62cd1ec824bdb4f422d09af5c7fff7a98687a",
@@ -11531,7 +11531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "44cb5d48c16e857bcf95a5a9bfd449e6953a6973",
@@ -11554,7 +11554,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "4fa8ea313b82c649088d73f304ec44ce3e347f20",
@@ -11578,7 +11578,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "342c86dd97b8b75a077007586c8bd91abe962bfe",
@@ -11602,7 +11602,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "b82af5b826553b5d35864c924af3b368a235fd6d",
@@ -11626,7 +11626,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "b62957b992ec1da37c42ad37e8ed23fc51644b3e",
@@ -11650,7 +11650,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "7df8db451dbbaf4e96adfd8289b6e84e64b5a5b2",
@@ -11673,7 +11673,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "d8e868beb4ec60bceb2897477e8983fe10ad3b94",
@@ -11697,7 +11697,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fsspec/filesystem_spec",
     "base_commit": "0d5d47ed2a8ca829ab1e7fa9ffb614951728cad1",
@@ -11721,7 +11721,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "feature-engine/feature_engine",
     "base_commit": "05649adde554963c8112f04f1dd3ffa920010777",
@@ -11744,7 +11744,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyca/cryptography",
     "base_commit": "b7760e223f12ca38c419bb6def4544ee1d92034e",
@@ -11768,7 +11768,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "facelessuser/pymdown-extensions",
     "base_commit": "f655468301b9372c1619a40c2f4b08e4d936b5d7",
@@ -11791,7 +11791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "apify/crawlee-python",
     "base_commit": "aeb06dc9679ae317ff072c4280f8f47d69f7afbf",
@@ -11814,7 +11814,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "cc77dcc4de32cb58c8bdff4cf3bae3fa6458b685",
@@ -11838,7 +11838,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "2dc71971a2ace203fc9250efbbd21aa13960caae",
@@ -11862,7 +11862,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "cf876705e4dbe54473cb0870406dc786e8966f66",
@@ -11886,7 +11886,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "347403429a12a28bfd5ecc01f3054109ce94dabe",
@@ -11910,7 +11910,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Pyomo/pyomo",
     "base_commit": "175353ce8fac5b38728007b0d7f5e1c1335dddf3",
@@ -11934,7 +11934,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "248dccbdd341941b988b622c51c26d1b9af66876",
@@ -11958,7 +11958,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapinghub/dateparser",
     "base_commit": "f65936408e24ede5a4e3c05f624323bfc474c585",
@@ -11981,7 +11981,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "92dfb19a220cdb78d47d2220414fc91c4007d8d0",
@@ -12003,7 +12003,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "aad62f61c9192789f4ac5087fba00fc2329b7e82",
@@ -12026,7 +12026,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "13380e100200db3a04cb43be968d6962d51d0a28",
@@ -12048,7 +12048,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "4edefe3e56d1656298c3f9a767da2e5292551432",
@@ -12071,7 +12071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "9618fc6322745834dd098cadecf8e05a0917d498",
@@ -12094,7 +12094,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "8fa06240e0a957e6778a207bf5b54615147f97ae",
@@ -12117,7 +12117,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "6e835e2729c24fac40e2f908c33bed9be5f6042d",
@@ -12140,7 +12140,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "81756c366400a4c7d2c3934b5ff1a359206f241a",
@@ -12163,7 +12163,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "511354a8382ee40d08322117c81bdd452131ff6f",
@@ -12185,7 +12185,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "fb37edc8f114a2a2e68bdbba16013bd51b3e50ec",
@@ -12208,7 +12208,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "069bc4dcd9e7d6795efd042dbc64d145e8a785d3",
@@ -12231,7 +12231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "1c496e9b3a772c0ac65ee7099e8292ec2a3d01e6",
@@ -12254,7 +12254,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "e077e2fccdb69a3bc8bfe979b320783568f6ffab",
@@ -12276,7 +12276,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "67e59aca1632e0f2311c3418541360f51a306ba9",
@@ -12299,7 +12299,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "3275dfd082df245956f8999caa595999b5beb7f7",
@@ -12321,7 +12321,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "235bf97906db7bb3dca3fcc646b3895982c95810",
@@ -12345,7 +12345,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "df5533f7d2d7bbe5092ddbbfb213c561fd263a64",
@@ -12368,7 +12368,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "cb106f045c751d7bfd2ce8f80b4056189073d809",
@@ -12390,7 +12390,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "a243d91e43b4c43fe8d184b541b608b6ddd80f71",
@@ -12413,7 +12413,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "ca9519bf182650cd464d6825de451471b3243627",
@@ -12436,7 +12436,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "bba7b1a0d6cbee94b04f70514228fca9c1d165ae",
@@ -12458,7 +12458,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "021af1fedb3c6cff0e42cba9eed140eea7f819e3",
@@ -12481,7 +12481,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "e5ef54c86cf10dd6f09b6eccea55fb3cc3038e3b",
@@ -12503,7 +12503,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "e04dfaab53c54b83096222993b914dc62e483156",
@@ -12527,7 +12527,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "4adcc8f46fe9c5f919c9d942e1e1a0cf7d342cc2",
@@ -12550,7 +12550,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "84bf6818cacc1d01ca0f12ec376eb7a54f6675bc",
@@ -12573,7 +12573,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "250fa19baf01aa2289afe44b07225f785cf536c5",
@@ -12595,7 +12595,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "6534e00304d14defda4b88a54f3a1fb2019e862c",
@@ -12617,7 +12617,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "178a1e653440a3adac822bc4d4c62f50c88b9ddb",
@@ -12640,7 +12640,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "22b88e7d3866ca5410bb2ecfd3081486d0566dc5",
@@ -12664,7 +12664,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "659a32fd5b54c45152714385740f520b5e9d68a0",
@@ -12687,7 +12687,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "122103f7bebe0414113b35b7a00563f1dc307de4",
@@ -12710,7 +12710,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "3dfb0e43eb1eafd09b959ae22607af3d5c7814e6",
@@ -12732,7 +12732,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "8aeba3ec6ad5a36c6f57c32d6ede59c2ecc68151",
@@ -12755,7 +12755,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "80528432efa97e809e5dd646010e1deba3f21fff",
@@ -12777,7 +12777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "81c2f579d50057d51351c259796e07958efdd9d1",
@@ -12800,7 +12800,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "7ede0929dc39858a2801f8b6b2711db0d4fa5bfe",
@@ -12823,7 +12823,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "27d0b28d066dff159e2567a87d02acd35c35c778",
@@ -12846,7 +12846,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "84089bcc57adb3ab0937e91ae8ec7f53f2131b25",
@@ -12870,7 +12870,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "5fd46c82f46ea601730f839994b3350e45cb9444",
@@ -12892,7 +12892,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "d5a83722de3473ce367c2209f9145c59797d48fd",
@@ -12915,7 +12915,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "eeca2239384508506766faf1a541528ef688b290",
@@ -12938,7 +12938,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "9eb72c8242f683978255a04f198a4765ec5809d7",
@@ -12960,7 +12960,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "1536a2aa652b50fe4447a96dadadec8312698a4c",
@@ -12984,7 +12984,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "eadb214ef45a059d43e102942cc0d59046019a33",
@@ -13006,7 +13006,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "71ea887ade58f57cbc5b37f311188bfb7cda8ca5",
@@ -13030,7 +13030,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "base_commit": "382fc2c0c6c0ef0874bc65bc1175f97c073e5086",
@@ -13053,7 +13053,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "7186962a1607332682dc1dad4e2b0d7c97825b84",
@@ -13076,7 +13076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "16b80885ade5c31dcf27fedd35959164e9ce417c",
@@ -13099,7 +13099,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "953035a5262763a26696e490b5aa35086b3e2311",
@@ -13122,7 +13122,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "ff0497cc042332313afd3d2e9ba8f949c3857896",
@@ -13145,7 +13145,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "50716d42e814051dc66a59002f704d8ca029360b",
@@ -13167,7 +13167,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "84c5f4f528d01e275e1af89b4199eebf667e2235",
@@ -13190,7 +13190,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "596d5ba420dd2865d576db2c5f860d9d77db8054",
@@ -13213,7 +13213,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "f57dd52100aafc4640891493ba43ad527433232f",
@@ -13236,7 +13236,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "911f3523ab94472bd9a1f8ecbd2493437058daee",
@@ -13260,7 +13260,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "c5887932a552c859376a53fb4dbe39f2ab17ba20",
@@ -13283,7 +13283,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "9391c2a9b386cbbbe27d18206790a40c27503348",
@@ -13307,7 +13307,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "FreeOpcUa/opcua-asyncio",
     "base_commit": "c7d4354afb809a07f07fb6b2648cdccb5fefc910",
@@ -13330,7 +13330,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "719b3462b58bd5c4fc12d93cb978f824bc7a610b",
@@ -13353,7 +13353,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "2958e0a8e61b01523b6232486683e21e22c85465",
@@ -13376,7 +13376,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "be982f2f304487fe634e507f2d1341225fd5019d",
@@ -13399,7 +13399,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ea83c9f6bea2c3103f7a37850e0bb3735d677780",
@@ -13421,7 +13421,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "05af9c3439b05c8e730a3185fc84e2b45cda22b3",
@@ -13444,7 +13444,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "7405482fdf3eba989ceb27e6ea71968e356d0b33",
@@ -13467,7 +13467,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "85400a0430f4f5fb93936ceca2124c0e7968cca6",
@@ -13490,7 +13490,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "c2a5e743c6d239ce45a2e992b1a56954788fc976",
@@ -13512,7 +13512,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "6938c21ff7afb407f6696dbd31ee1c02fb5c64e0",
@@ -13535,7 +13535,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "cc83b59e6937ea742c80b023d1e7e5d0afeff23f",
@@ -13558,7 +13558,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "cfc75bb08ba07aac21cedd7d946fcb3bcaf4cdef",
@@ -13581,7 +13581,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "514f975298b940fca1a39917ff35aa12b149a1e7",
@@ -13604,7 +13604,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "8acefefc4238b9d32cda2e8670ba53e212837c7c",
@@ -13626,7 +13626,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "e7beb8bc5c647d15fef9b5a2a9136b6a605d35db",
@@ -13649,7 +13649,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7f9ac83e35d3fc087e4bdf86260181de8f55e18d",
@@ -13671,7 +13671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "fe06909e32669470c190484cdc202fc46b09879f",
@@ -13695,7 +13695,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "d07d1920bc4882ea024bec592032eb118d5abc31",
@@ -13718,7 +13718,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "11cd6f885a0c1980c6b094dba1f5cb5b321021c3",
@@ -13740,7 +13740,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "a243d91e43b4c43fe8d184b541b608b6ddd80f71",
@@ -13763,7 +13763,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "efcca8deaf720b2652e2d3d8876ab5187808abb8",
@@ -13785,7 +13785,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "33879e284c7987c81cce11b3ea06fd99533c395d",
@@ -13808,7 +13808,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "4ee8677e9461e753e6d1d4afe5c5a5d48a1910db",
@@ -13830,7 +13830,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "fecc37d8b99b8fa20c9e925660fa25c3157c206c",
@@ -13854,7 +13854,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c15ccfcd0aaf343e2feae6fd065dda12225e4824",
@@ -13877,7 +13877,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "87a7a1a62bca244ae755a4593a9029d633bf2e96",
@@ -13900,7 +13900,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "e1979b933e5b247792c298d2bccb29014aea27d5",
@@ -13923,7 +13923,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "7521eb1dc6ac89fcf1763bee879d1207a87ddefa",
@@ -13946,7 +13946,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "29d10d1a6c58d02a4f9629ececddac6280c340cd",
@@ -13968,7 +13968,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "faaf98858135cd8279caede18906d4b36a4b78a9",
@@ -13991,7 +13991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "3678ee1976d6a33af17462ddd0be2a8921077c8e",
@@ -14014,7 +14014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "bdb4006f2ac24003b003e5975586c299bbf61b5d",
@@ -14037,7 +14037,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "b8247ffb1a26289039d8e5c00e4d55c061d0c373",
@@ -14060,7 +14060,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "b1548d0aa4f89cf7e808b34ba4203b32f0fc67d1",
@@ -14082,7 +14082,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "6af299ac2396b0d29d7976c861765022f6df8ee9",
@@ -14105,7 +14105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beancount/beancount",
     "base_commit": "8c99bf0c8b254275d23058d4cd703c98c373f67e",
@@ -14128,7 +14128,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "656814c69f9e2f1cf1f53cfac994ad41f7476baf",
@@ -14151,7 +14151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "62d93a0907aff76063d8b0b3efedeb8c2f14f082",
@@ -14174,7 +14174,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "3c72e2a83b468bb0d18e958c7e160fbb324b146e",
@@ -14197,7 +14197,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "f90b506a9ff2b202fbec707be776cfa590519a14",
@@ -14219,7 +14219,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "c887ecbc753763ff4232041cc84c9c6a44d20fd4",
@@ -14243,7 +14243,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "3bd2bea54d3c30e6d2a4f1613b8d0ce5070710e2",
@@ -14265,7 +14265,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "39782e75e7c04efabd785e86b0ad33bc5eeea51c",
@@ -14287,7 +14287,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "3c9fee783d2228276fa9a8b021396db08f0693d4",
@@ -14310,7 +14310,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "5d78ec26c9bdc6e23c9fa217936d15fa16c5b8f3",
@@ -14333,7 +14333,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "ad5d29d92fec1592ee8a8597df46ea09b9260f8a",
@@ -14355,7 +14355,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "amoffat/sh",
     "base_commit": "b658ce261b56c02cb8635416d310ca8f30f4dc90",
@@ -14378,7 +14378,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "facebookresearch/hydra",
     "base_commit": "0ede84058e57a40260a93ae4f9abe08a572b23e0",
@@ -14401,7 +14401,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "b4d790dd57b324c20ea9031b4769ba4d75ecd691",
@@ -14424,7 +14424,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "f43d0eb4714de529a45dd9161e7774d070699bad",
@@ -14447,7 +14447,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "863184dfaa9c89b3f272da3042e5e9beaac200f3",
@@ -14470,7 +14470,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "4244af2c297c2aa3a666ef09b604f31c624d4d52",
@@ -14493,7 +14493,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "50fb4a9dbb905af5a9b95b957ab942511c0fff9b",
@@ -14516,7 +14516,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "55bbdb8da2fe0d46412dbcbfcf3d8787980027c0",
@@ -14538,7 +14538,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "1eafae0edb78a16b0ed8e531c85ca70498a76a20",
@@ -14562,7 +14562,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "06a474b5e7d6a26994db18f97cf9058246cd24bd",
@@ -14585,7 +14585,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "8c7e07e5b5f4fd3d41369ddc2c33bf4a1391d5c5",
@@ -14607,7 +14607,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "955432c552d6da7250a76c4f623b33b5d4e6c215",
@@ -14630,7 +14630,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "590d86ebf451fadff95215d4357d22769be39249",
@@ -14652,7 +14652,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "105823765d607dc32e153fc69495c9aa10eedb0b",
@@ -14674,7 +14674,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "5aedd8e94beafaf95df5379b5035dca60e3faff7",
@@ -14698,7 +14698,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "25e8f49b7ea1fe8ecad16bff3c4242a715f98ccb",
@@ -14720,7 +14720,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "c303ee29b5f39420947d6748baccf2999a529309",
@@ -14743,7 +14743,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ced34f108b5bbae07a71a0c1e2ebd37fe8cf3ca1",
@@ -14765,7 +14765,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "4a1fc064a7899872ee845df6a8810bb51a6845ac",
@@ -14787,7 +14787,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "modelcontextprotocol/python-sdk",
     "base_commit": "08042c3307bdd0d4a66b0dd3200f38222f447b1e",
@@ -14810,7 +14810,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "942fcf4e5578da3f3ce22501b17fbceb5ea9c350",
@@ -14833,7 +14833,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "59029095e86eacd402083fca7c308b06889f6301",
@@ -14855,7 +14855,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5300bd67702e4fb8196cdf032bfcb47aa57e6ec1",
@@ -14878,7 +14878,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "74c7f9a598c4e32b3f551f75ed965f446d786ab1",
@@ -14900,7 +14900,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wireservice/csvkit",
     "base_commit": "d00ea20b965548299f4724c6ef9f9a6bdb33e02d",
@@ -14923,7 +14923,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "98d68db7f3a7d6eec4dc463a24839af542fb70cc",
@@ -14945,7 +14945,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "1454013b8b615ce75d30d38b7710e3fccca16263",
@@ -14967,7 +14967,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanford-crfm/helm",
     "base_commit": "46dacf07fbef04ca21e9b4c66e5d576b10a158b4",
@@ -14991,7 +14991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "6d886dc0fa8e0fa1d011e9332f609cee526c9bbd",
@@ -15014,7 +15014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "52a028251c5afdd5ba586e74efb14f5c74b4490f",
@@ -15037,7 +15037,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "82a14627fddbd0b2d802fbc574fa3b1ef010a801",
@@ -15060,7 +15060,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "5e9f7c22ad630400ee062c0b3675b2243e742844",
@@ -15083,7 +15083,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "3289b0dd509d1c870917aff6f878ab56dd10d790",
@@ -15106,7 +15106,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "bcaffa137e5724259c4bf96a658fe3a11191b25e",
@@ -15128,7 +15128,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d8db468afbac9410d0ba5209ac9c4a58224c3864",
@@ -15151,7 +15151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "656fe6dc6edc9d4a079b9e44330dd2a943aad77b",
@@ -15173,7 +15173,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "4052a10fdfd34d08ae72ef078b6cc43b95b1c723",
@@ -15196,7 +15196,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "286e53b067f39281aaca9c5b55439b1520032620",
@@ -15219,7 +15219,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "172976df7a88b331ad5fc49824d286e69128c6ef",
@@ -15241,7 +15241,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "938c8b6aa95a32568063f5e7cf005f8b478c3f61",
@@ -15264,7 +15264,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f6fceb1b568bf08f8244cf123b71cf32af8bec33",
@@ -15287,7 +15287,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "054f23363fd50efedaf54ee7fb0333824b0de41f",
@@ -15310,7 +15310,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "11237883edfd33e9c41abdb869b449160bc1dbbf",
@@ -15334,7 +15334,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f75d15a17c95d3c62a4c27fd100e7e75cf9a7ca5",
@@ -15356,7 +15356,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "2aab2813f44275683c70631ebc2a2a96dd748a6c",
@@ -15379,7 +15379,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "47a5f750c18864f66b7fb2cd297bc50f2d74e4e3",
@@ -15402,7 +15402,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "2c09a8617476090aa634ac5e28e60c8d89247cb1",
@@ -15424,7 +15424,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "8387f4a491b03963c6ddf10d94feaeb044c8385a",
@@ -15447,7 +15447,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d4e7b3e1edda188c13f7c404e064cb3a98d58965",
@@ -15470,7 +15470,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "73ea5949bbb8e99bacd16d1cada2a444861a9cfa",
@@ -15494,7 +15494,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "fed9e57a0033dee6c18ce9da40dcd49e1211f876",
@@ -15517,7 +15517,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "d07fdc994015772a9fa0dc1a12d1391b5765916c",
@@ -15539,7 +15539,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "cd75cbd7e0a0ee1bd644e1a1e0b69e909bf455fb",
@@ -15562,7 +15562,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "ae4ff3065a62d6c8ac33df6b7fdbdab1e87a5ad5",
@@ -15584,7 +15584,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "f5067c16757f4cd800ae3ba0ac25ff79d2e41a7f",
@@ -15607,7 +15607,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "f69c998d3eb61e06ba3f4a33ac7049008bc4d22c",
@@ -15629,7 +15629,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "0b9a25a63142b2bcee8249c69595377678b2ad0d",
@@ -15652,7 +15652,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "fd6a69d78e7ab2de2d0392d55af2942bb69e6ab6",
@@ -15675,7 +15675,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "50a617b1b6545a662160916c757b3598a9ecc61b",
@@ -15697,7 +15697,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "882a174e48a4dfd22d4fab4b2e3b74f091b3f98e",
@@ -15720,7 +15720,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "81bd39a575bbce3ab83e71d998eda5cce65a6c87",
@@ -15742,7 +15742,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "beaf31382d3d58e4d956d3a82bafee462d31e4ed",
@@ -15764,7 +15764,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "380d2e21c08df30034372cd31f445f3da1f48cef",
@@ -15787,7 +15787,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "c0ecd70e6ff9e92ee686671c7e0f152ab643f25e",
@@ -15809,7 +15809,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "25470edb2c7e1acee84ba9c6eaaf5117c5c7f6a7",
@@ -15832,7 +15832,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "6fc6f1ea3a9ffb0067de8bdf1d8ffc0d2052744d",
@@ -15855,7 +15855,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "b30486317d835cc70f272983d5981bcfc6aa4cd7",
@@ -15878,7 +15878,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "cd07cbf413c5f55006308856660ee1208285c83b",
@@ -15901,7 +15901,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "base_commit": "e8fa8dd31c365cb5b52f8bdf1966e13cbf66e9ec",
@@ -15924,7 +15924,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "c944440469ccdc5cd79c825da46536997429850b",
@@ -15947,7 +15947,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "9ace6bf63dcda53ca2a6600cb7057790a4114023",
@@ -15969,7 +15969,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "082f13f37861da2b205fb042dd34cc7826cfadbb",
@@ -15991,7 +15991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "66f0a49b759fe0a88ac115f25528e087199d9de5",
@@ -16014,7 +16014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "739bc4d59cc0ea9bc0d9d5bfb0c805c77780f197",
@@ -16036,7 +16036,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "b6e585f80ace1896e6bd3c31d827a1991ed2c664",
@@ -16058,7 +16058,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "bb82883cb4abf5171e82ae4c025c012f5218b6a7",
@@ -16081,7 +16081,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "818c9fadd9cb1748f2b5545e8ef5f141526ec14e",
@@ -16103,7 +16103,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "bf6b68ff886d7b23eae37042139b0e1f654f06b4",
@@ -16126,7 +16126,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "a1b0cb24d51cfd4ab3760c86e432416f5bb6f7b3",
@@ -16148,7 +16148,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "d5c3da9efaa4bbd1d24fa768752df3da343b1d33",
@@ -16172,7 +16172,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "2e0c41f66ee7a9fddbc517a3ca75a2ce0cf2efd1",
@@ -16194,7 +16194,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "89886b861bb3241fe09ac52b76992e32682cdc09",
@@ -16217,7 +16217,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "c2aebd81f144d9c28dec06b447371f540935c1a5",
@@ -16240,7 +16240,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "d5d7ce369aef035712cf73446f9085a32105846f",
@@ -16263,7 +16263,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "f1972e0a5499d836a02f591bb06101fc2f48d75b",
@@ -16285,7 +16285,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "1c131dfffe2d359eda93f7d4cc6d920fbe76efe4",
@@ -16308,7 +16308,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "ed4fe4ed11a980f1be61b253743270ecf9173f14",
@@ -16331,7 +16331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "67de0369c711c7e3440c5b956a4b090820747abd",
@@ -16353,7 +16353,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "1eecaa38e8cf07a013a6bf00ea7378c9b23ba65e",
@@ -16376,7 +16376,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "7681902839b3f3192dae888e6dae38489bccf50e",
@@ -16398,7 +16398,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c037052581a1caef3287332635ca73bcd3bb07ea",
@@ -16421,7 +16421,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "90a7ac5738b2ce64dae7bc399f9f0f788f9e7a17",
@@ -16444,7 +16444,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "b3d862106d1d22f891ec4bb1bacc9d092b42fcfe",
@@ -16467,7 +16467,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "bc082b56eef8c29a062b241d44e10e4302975ae8",
@@ -16489,7 +16489,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "a4a6c7d9e904de88feaeeb509879f431b64681ac",
@@ -16512,7 +16512,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "9782e80c58fb4e403cc48d64a2369f9748a7e5e1",
@@ -16535,7 +16535,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "45eb54e4afffb0d6ba0746ca6f207d994133d293",
@@ -16557,7 +16557,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "a6995c377d65ce850c2d744ad42a2a79f6d511b3",
@@ -16579,7 +16579,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "26acf8ae894fb54ad9ef6836757ef4406d4bffae",
@@ -16601,7 +16601,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "92493e36a5bb8efe4653db5295a48841cc92ff4d",
@@ -16623,7 +16623,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "c446ec4cdf1f5227fb36bd68b2db9e63db94ad6a",
@@ -16646,7 +16646,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "6477a028855a336453c96c92b1c69072ec80f777",
@@ -16669,7 +16669,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "e0fbf32abaf1eb51db27c2b0995a7b3e9cdc3ed0",
@@ -16691,7 +16691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "c65f3a1d60d9c41ab3e60a0a7d1309b6111b1047",
@@ -16715,7 +16715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "1c29bff9981ada322a6ef4f93169c00f261418e5",
@@ -16737,7 +16737,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "ce213775b6be0a50d6b2f5ba4362c04b79a2b7cc",
@@ -16759,7 +16759,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "4051e2cae2d3bd09e1029b45b63888d32a593b93",
@@ -16782,7 +16782,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "104780004fc4af39cc6d85ca88a65220176e0ff3",
@@ -16805,7 +16805,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "efca179db885d4ed34d08c5f050c57dc07330e7e",
@@ -16827,7 +16827,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "4ce0f99cfb5b08bf770a935c59936a6353e3d27d",
@@ -16850,7 +16850,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "25bfb1a07c091b56b0380abb5a43c206dd29c07b",
@@ -16872,7 +16872,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "59b23d379cfa8378490675021d20bf51dbee652d",
@@ -16895,7 +16895,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "5d23f145efbe5b4ab44ceda5d29e16eecba288ff",
@@ -16918,7 +16918,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "447a2c35e6290d6723b97f264ebca86ef0f28539",
@@ -16941,7 +16941,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1940c9fe9444d15a507c422338ef64d6e67ab169",
@@ -16963,7 +16963,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "71e7c35662a4b2ba8543194cc132616065dfc56a",
@@ -16986,7 +16986,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "b0782f87c49ae280fb63d328c3c4d46b56c96ea4",
@@ -17009,7 +17009,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "ac589ca13b2dccaa96526ec000a7778d297b24ff",
@@ -17031,7 +17031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "f0bae912201bbd265a3485ccf4f490be2fc675c7",
@@ -17053,7 +17053,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "9a834e069fd04cffadbb2d2e3ccc70342a872252",
@@ -17076,7 +17076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "37ee5dc8e7a628a92320a1b1944884f75563d659",
@@ -17098,7 +17098,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "767012b66a61ff350f8bd021e338bd504c3e222b",
@@ -17121,7 +17121,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "1eecaa38e8cf07a013a6bf00ea7378c9b23ba65e",
@@ -17144,7 +17144,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "fd4e896ee9b632e9bd85e4abb5d5250ed4b5ea67",
@@ -17166,7 +17166,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "f205f541ed1497a0c83433e0206e6bce10a2530d",
@@ -17189,7 +17189,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "3873fad83c32be7a054cbcd4845f17c6dc748516",
@@ -17211,7 +17211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "04ee04150ac6ce41393c4e8e0d04030f3c5e2596",
@@ -17233,7 +17233,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "fc9bdeb657997081baf316d1703b120b3b0d683f",
@@ -17255,7 +17255,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "8d04e530da24b5e5c8c11af29829714eeea47db2",
@@ -17277,7 +17277,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "0a6c09e252ecbee6f5184c1e1e13075527c1b3f0",
@@ -17299,7 +17299,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "78748d36fd1fe9a71c3d42a7a88e0b63edd1c3d7",
@@ -17322,7 +17322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d1f6e8a9bd85b238b99936c3da0f488d10183b40",
@@ -17345,7 +17345,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "59bcd3895b2723f9c360709afd5dff3fe539e0e4",
@@ -17367,7 +17367,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "7041f11fb00d85ecc7ba8951beca6726868ad50e",
@@ -17390,7 +17390,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "5e43be7a7a924f8161181a49e93053aa4a80f54d",
@@ -17412,7 +17412,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "d5ae46bc93f83914c90aefdcf4183bb65b096e18",
@@ -17435,7 +17435,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "ae484c946c1c1f37982484908c55feb4322786ff",
@@ -17458,7 +17458,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "19d3f39e757ee3488b7e5f581aa970de432a3019",
@@ -17481,7 +17481,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "03f148d7e3c80a9354b5ccf30423a321b85979a9",
@@ -17503,7 +17503,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e9e4bb13e821470f28411742f1de179a796bc005",
@@ -17527,7 +17527,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "freqtrade/freqtrade",
     "base_commit": "9ec46496f0efa57a6c8e0c6ced5fc7a506966625",
@@ -17550,7 +17550,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "5d5e6c8f0e9cc6f37c73fc3b5967f8d4f3acaa22",
@@ -17573,7 +17573,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "aa400169cbcb1ef512bf843241e233132e2e8671",
@@ -17596,7 +17596,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "10442e52aed3d937b252293d556ed1d0afa8b622",
@@ -17619,7 +17619,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "113680d93cf1fee56ee26b436a889f2152e7aac6",
@@ -17641,7 +17641,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "98d68db7f3a7d6eec4dc463a24839af542fb70cc",
@@ -17663,7 +17663,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jpadilla/pyjwt",
     "base_commit": "7b4bc844b9d4c38a8dbba1e727f963611124dd5b",
@@ -17685,7 +17685,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "0e825c25972c4d2bae0b9910aae90e4d4ebac213",
@@ -17708,7 +17708,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "52a41eaefb06cae7cacce096713534690ecd347b",
@@ -17731,7 +17731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "c919739fe6b2cdd46887dda90dcc50cb22996fe5",
@@ -17754,7 +17754,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "d7ed89dc00fff6b98d036a8519979fd6e9dd823b",
@@ -17776,7 +17776,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "27b1ae7f8dfeedcc817ca8506b5835c468ebc658",
@@ -17799,7 +17799,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "fac5d8f740952485ce2c094e2826ed358fbe90fd",
@@ -17822,7 +17822,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "a48cd4c6a872b6565bc58030b74585812f327f36",
@@ -17845,7 +17845,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2035d2848ea3ba4dd2533a602d9a2f88487f942e",
@@ -17868,7 +17868,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "171f10ca1c2a73ea41a06e4c6ecf4de1f53523e7",
@@ -17891,7 +17891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "camel-ai/camel",
     "base_commit": "e4e26df768f282333fe54fda0967ceb592928aa1",
@@ -17913,7 +17913,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "309f2c9c8959222e59d537b447c087a65c8b8998",
@@ -17936,7 +17936,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "a93828a94f105909f9398c00d2cddf4ac43197ac",
@@ -17959,7 +17959,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "3e18251f2d5d542a5f9ef538b894764c95caad16",
@@ -17982,7 +17982,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "9bd2a2051758c97299a8a11895b8b060a0f340ac",
@@ -18004,7 +18004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "969d09dcafd3669753e30060ccca7e5fd4c356cd",
@@ -18027,7 +18027,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "4c6c65e7c94b87b50f26ad7f35ac26ed26a54cee",
@@ -18050,7 +18050,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "ed17e00da9b8119c0a01290ebcace64bc0120b84",
@@ -18072,7 +18072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "d3892d52902fc49103a8ee44c16f60b495a6b636",
@@ -18095,7 +18095,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "2343a8d3870e4ae1be04287687868d8a5216f80c",
@@ -18118,7 +18118,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "slackapi/bolt-python",
     "base_commit": "4c237fe47f017d2d6b6d66b639fad83d91be2f0e",
@@ -18140,7 +18140,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "8e66c9b3c75282c8439ace67c2c4559311b51a27",
@@ -18162,7 +18162,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "6bdc74f9be39d550c551b1b4268252f4d4a74ee2",
@@ -18184,7 +18184,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "39961a597e6af4d2084903b4420590de588c139f",
@@ -18206,7 +18206,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "b9bee24047f21f9b86a76682ab43d047e3f76f07",
@@ -18228,7 +18228,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "1f914c5143250c1113089868f30eed67697dc40d",
@@ -18251,7 +18251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "dba212f7e335b931561d0a71152703226af85d8d",
@@ -18275,7 +18275,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "362a393c799ed2d9d36dcccd457d4533ff5a2855",
@@ -18298,7 +18298,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "f0d8e2ef5e8b5887d5d5aac5a547a8b573e80309",
@@ -18321,7 +18321,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "6d655330afe90a1277bcfbe3b5861b7552634f75",
@@ -18343,7 +18343,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hiyouga/LLaMA-Factory",
     "base_commit": "7e0cdb1a76c1ac6b69de86d4ba40e9395f883cdb",
@@ -18366,7 +18366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "6471521a5c161aba98c4d323dc457db0f2b80b9c",
@@ -18388,7 +18388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "cc0f0bcc2261cceef0ec61ef3f018177c6f0fb5a",
@@ -18410,7 +18410,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "6bde3618237cdae312e4e7fb006690be2a3ee0f6",
@@ -18433,7 +18433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "theOehrly/Fast-F1",
     "base_commit": "954dcf0c8cf979edf2fcfb5e26c0b07c5bd30b91",
@@ -18456,7 +18456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "e9c3ef8d0de3080ca59f7f8dbabf9b52983adc7d",
@@ -18479,7 +18479,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "83aa3e41bf9d4de308e306521e0cb3f688952942",
@@ -18502,7 +18502,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7f3f09945f8972f1fb37da38fa325dab11a52390",
@@ -18524,7 +18524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "825353df37c99928894e902559f6ec4cb429570d",
@@ -18547,7 +18547,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "5fadd7ee36edffa135774ab81731e083916fce84",
@@ -18569,7 +18569,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "f1c9fc50f0a7e186bab4587b28d019a909a7e97f",
@@ -18592,7 +18592,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "12f923325a1794bab26c82dbfef2c47d44f054f8",
@@ -18614,7 +18614,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "881cd4e38d31663ae67bdae227ec1ccdfd5e2c77",
@@ -18636,7 +18636,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "97a4a719623b5bf652c8fb5377c6fff3aa1a9cea",
@@ -18658,7 +18658,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "bbb5fff3806a290c4bfe63a4a530c884d43bf46e",
@@ -18680,7 +18680,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "32718f18e917edad561dd1058c1479894b0191f7",
@@ -18702,7 +18702,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "825353df37c99928894e902559f6ec4cb429570d",
@@ -18725,7 +18725,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "dfcb68114157b49eb4bbbf56190a7518237ea2ed",
@@ -18749,7 +18749,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "arviz-devs/arviz",
     "base_commit": "0fc11178e3802de9e2e6557ce455cced9a22974f",
@@ -18773,7 +18773,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "ced6ec369d3016dad69ef6f8a9ef41a484b3bdfb",
@@ -18796,7 +18796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "30f803b2e9b5e237c5c31df57f657ae69bec240d",
@@ -18819,7 +18819,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "0572f7871823bdef3ceceaf41dedd0a6bd100995",
@@ -18842,7 +18842,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "55cf8c70214be559268719f0f1049f98c6c6731a",
@@ -18865,7 +18865,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e25b357d6eab29fcb64ee04340f2d0d479ea09bf",
@@ -18889,7 +18889,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "8c8e26dab401121e9fccc8e8e8958609ccb045f5",
@@ -18912,7 +18912,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "178d0dbde6167b0f1a83c9faabf1bf33ba0087d8",
@@ -18934,7 +18934,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "olofk/fusesoc",
     "base_commit": "ea427d4d1c4ff2ce7768b1e97956aaad09a7f9f0",
@@ -18957,7 +18957,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "ed39a193ba383ea966b4b8bda000d4828d0be7aa",
@@ -18980,7 +18980,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "b2ef949cceb01c53d231a4da9cbfbaa12cea981d",
@@ -19003,7 +19003,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "e50476895fc7b7f6578be30b40a1226b6957dcb2",
@@ -19025,7 +19025,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "16933a1aa41c9d1854dfd4309940b73b3ee008cf",
@@ -19048,7 +19048,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "68e0368c680decbc7c9e1da57b56b3a8212b3ec2",
@@ -19070,7 +19070,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "9504700777fd067cc2bb73c66b62ce8f06955970",
@@ -19093,7 +19093,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "570f66ac15df27bd3f15b64f0013fbfe17d4cdc1",
@@ -19116,7 +19116,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "f00f27143e52dfda31457be57be7e930ad6fcee3",
@@ -19138,7 +19138,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a3d2fbcefe1cbdff55efb085d7c177c3d1e32dc8",
@@ -19161,7 +19161,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "608aa01d8b540dbfe93e664768b8927a1b50d063",
@@ -19184,7 +19184,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "969e5f55d603ea86b3f0832e23a69e0c58621d3e",
@@ -19207,7 +19207,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "75723b7720952ac0a4c7d3e277b6714ba55ded18",
@@ -19229,7 +19229,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "0387b25bc9fedcae81e7de01579a7ef052fec32f",
@@ -19251,7 +19251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c8918e43bac8e4af2ff1e57271222d415b81fdd8",
@@ -19274,7 +19274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "06297af6798f26b38717773aab5752a1158aa04c",
@@ -19296,7 +19296,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "c68072270c5cd888f945d6812b0fffdd823a698c",
@@ -19320,7 +19320,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "3cfd03fb6fd2176b90ad14223408f3c4ec803cb6",
@@ -19344,7 +19344,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "7a29fcbc65c7625bae96f9ec5e45315144e86043",
@@ -19366,7 +19366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "7e34a320c4504e69b47499cc72a022559ada0b3a",
@@ -19388,7 +19388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "3cb44431288dd143bed6ba67e9b13afc2cde1aa9",
@@ -19411,7 +19411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "328b8dcaa5a5d69827a62c1062fdcaec91b3125e",
@@ -19434,7 +19434,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "15a5ac03c45f6888a5a3b6acc72a72da27495567",
@@ -19456,7 +19456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "2f383bce25876b0d2b11f17b6a2265aaa4983dbb",
@@ -19478,7 +19478,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "c9a993cec536c67978cc34771d8627dfa4ceb260",
@@ -19501,7 +19501,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "78b50f12d6df56e54ed3e4b736f16c79345d0aff",
@@ -19525,7 +19525,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "74c7f9a598c4e32b3f551f75ed965f446d786ab1",
@@ -19547,7 +19547,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "e94224931feddf9e12bb25452bf0d0c21da8a7e0",
@@ -19571,7 +19571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "32b87be55f7b7e55179d0c288c97e5e33d139689",
@@ -19593,7 +19593,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "2418e007cea84452fc256a8d56d6125660b5aff2",
@@ -19615,7 +19615,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "591cffeb14e2d92747f1f49639fcbbe1ed4a80a9",
@@ -19638,7 +19638,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "36a84276a20d418105ee973b5960ea79f7635018",
@@ -19660,7 +19660,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "dfb0ae3747e5cfaf362edaab835ef68642a7e97d",
@@ -19683,7 +19683,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "edd958fff61a640cf02c7640b717e78f10322b8b",
@@ -19706,7 +19706,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "8a542e22a0c32d7122c4735004ca51bc072ef313",
@@ -19729,7 +19729,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "2cb0520b6685617685eda7d6548812659ae586f4",
@@ -19751,7 +19751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kubernetes-client/python",
     "base_commit": "a5c337329410c2132e2dea31a69e2a942111a1ec",
@@ -19773,7 +19773,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "9af6c7e442580c1df4763e6170ed36918d16eddd",
@@ -19796,7 +19796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "d6459fc18259a45d9f16c3c6d72921758419ceae",
@@ -19819,7 +19819,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "1a03526e2dda9818424c400530163464a2e74b9b",
@@ -19842,7 +19842,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "365c950ea98a55ef34e55c653fcb6a62665ac4e8",
@@ -19865,7 +19865,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "f1acb4f7c969b69a441da0c043fe5bbe6dbc3748",
@@ -19888,7 +19888,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "27087e0b6d61de4507328e2d29a1801dfb67fa78",
@@ -19910,7 +19910,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "feast-dev/feast",
     "base_commit": "48a4285b3a91bd6e490d6562591de612b96a5e02",
@@ -19934,7 +19934,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "ef25765c8d7aa8e70fa36a01dacad50326948ed1",
@@ -19957,7 +19957,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "e9b9ea568e169aea13ae2d03c0eb92ee241f47a1",
@@ -19980,7 +19980,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7ea2b7bcee377f4ae7baccc8126730d25e5fbc83",
@@ -20004,7 +20004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "b485f5a9e1a2caf3af5e2bafa07390fe7609c3f8",
@@ -20026,7 +20026,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "360cd12f3580764d8258daa22e485060f075d139",
@@ -20049,7 +20049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "46d006470b78de90c051f566e3fd9f69a5444907",
@@ -20071,7 +20071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "adb97e848ca88f0b9abc5b1c5085f548847e3f8f",
@@ -20094,7 +20094,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "accaf6dc528db25a420e8d76de5d8839854b8dad",
@@ -20116,7 +20116,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "89f21c28c2a2f37fd5ebace65d3f63a5497d8ae6",
@@ -20138,7 +20138,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "b9d7a983594f94e2d98833da66f339dc8f6695eb",
@@ -20161,7 +20161,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "ca74c76dca41a456280df8d05903c36736bc762f",
@@ -20183,7 +20183,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "8bb736111aab2e8e831cdd8b2c88a6e881335a28",
@@ -20206,7 +20206,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5300bd67702e4fb8196cdf032bfcb47aa57e6ec1",
@@ -20228,7 +20228,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "37c53dd099c25646e10b20f50741535136e9494d",
@@ -20250,7 +20250,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "da6e2415983cc0eadacfa49eb43161a6c2be6d36",
@@ -20272,7 +20272,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "fb462618190e87b4f0dec0bb677bcdea40b448a7",
@@ -20296,7 +20296,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "1b2053b3580891f0ca43c3d99b8709664efbd3e2",
@@ -20318,7 +20318,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "4c356306273153d5dc26fc5772b106b4f750095f",
@@ -20341,7 +20341,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "b28352fb28f0e892d4d93b2e5d787739a4118885",
@@ -20363,7 +20363,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "52a028251c5afdd5ba586e74efb14f5c74b4490f",
@@ -20385,7 +20385,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "58bb1bcc518fe7ee295d28903e0d57f346b4b74f",
@@ -20407,7 +20407,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "39d5b39113859f52923ae1c7998e9c9cef40274b",
@@ -20430,7 +20430,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "1f431a81d0e58265071237e5a5bc2d5c8ff0445c",
@@ -20452,7 +20452,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "ea016314b0fa7442137701bf6be9be01d0d88c35",
@@ -20475,7 +20475,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "71715c88c21a186043c4da7f015bbc9ebdb94bb8",
@@ -20498,7 +20498,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "feast-dev/feast",
     "base_commit": "e88f1e39778300fb443f1db230fe9589b74d9ed6",
@@ -20521,7 +20521,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "4038f7bdfdad05697510a3f9657bd4fdc7c12d4b",
@@ -20544,7 +20544,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "e8654e11da3634bba866c5ad7781da76f2b77d65",
@@ -20567,7 +20567,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Delgan/loguru",
     "base_commit": "7748b6cde69880101a5cfb5dcc653ad7cf23402d",
@@ -20589,7 +20589,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "ee56bb0edaac43d5b7113b2a9d00ed9723ae83b2",
@@ -20611,7 +20611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "e470e62395762e52f5bf72347f40657711de04ec",
@@ -20633,7 +20633,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "28d57468c36f224bc6e50dc7922f128498f3b58c",
@@ -20657,7 +20657,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5673e336aa6ec4f89e61259e7aa6e8dddf61bbe0",
@@ -20680,7 +20680,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c233c627e72c15288290a0f55d9f5832051c1c61",
@@ -20703,7 +20703,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "08ff1edaba02bd6af95c545f4312dd039fb80bb9",
@@ -20725,7 +20725,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "71e4015e2271964ca9d2353adfa85928f4241d11",
@@ -20748,7 +20748,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "78b6bdc04f89dafe4d157855a9023826cab8a0fd",
@@ -20771,7 +20771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "c7aa7e3800498c8d1b7664a4073fee6c6c238956",
@@ -20793,7 +20793,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "4acc78b8aec4f145e7e72c931accfa7e12e5cd4d",
@@ -20816,7 +20816,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "df705d4fc719ab617705197248804d689ad74767",
@@ -20839,7 +20839,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "9cb34242c89a20c67f9eae438d7c0a018346d6fb",
@@ -20862,7 +20862,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "906177329bcc54f6946af361fcd3d0e334e6ce5f",
@@ -20886,7 +20886,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "96ef6635e4306c2a5e2aa1b6c4aadb3e4f31c37e",
@@ -20909,7 +20909,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "3eb7226b6e519c691aa31760cac2c8237ab95991",
@@ -20932,7 +20932,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "cf728496e4ffb9b9f9aaa4c3518d9f8898d2b4d9",
@@ -20955,7 +20955,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "6de20475d3f58e83903899b7d1a26cc317449556",
@@ -20977,7 +20977,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "e1a17d5af24185b8bc1952c8c46af130fce90794",
@@ -21000,7 +21000,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e1063a152b8a969383f35c122a8b26eca58a0820",
@@ -21023,7 +21023,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2e3f51782056b6665560f9af6166e30d7c2801ab",
@@ -21046,7 +21046,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "30ecbc1fe4ffe2dd3690071f891352e15419b874",
@@ -21070,7 +21070,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "cc1b2f7ec575848f3a6bff7c7acef32e4b68994f",
@@ -21092,7 +21092,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "57cd5eb22af1590eaf771a9e5f0d60f6bec2354d",
@@ -21114,7 +21114,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "19c9598355b8243038bdeb1253d219e0371f71af",
@@ -21137,7 +21137,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "822c9d07699aa090fb8d37cb94247ea0d085125b",
@@ -21159,7 +21159,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "be859d54cb1470c9e2a55589ebb99e90329bc444",
@@ -21182,7 +21182,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "20fe88dd572e1aeec53f7725b620263e7b11ed2d",
@@ -21205,7 +21205,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "bada70fbe79f61ea98dc735d630d61a082cd7474",
@@ -21228,7 +21228,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "home-assistant/supervisor",
     "base_commit": "fcb3e2eb55f1929b09392d05ec54a72999d758d1",
@@ -21251,7 +21251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "70d5d4a1085412a382efcaabe1cebac7687c5ff4",
@@ -21274,7 +21274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "2276f624cf0ab85a43df17fb3f21058ca08d1123",
@@ -21297,7 +21297,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "012151132e612475fc1a1298fc8aea5fbb6264fe",
@@ -21320,7 +21320,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "6a562dbc931c2b764d797b83e60a10aea07d0290",
@@ -21343,7 +21343,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "27ed574b63fdaf9a0c118c924d4875569758f0de",
@@ -21365,7 +21365,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5d6acdf486d0b7ca0065ea5eef9573f2c24b07b3",
@@ -21388,7 +21388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "a1822e2091b900bfcf5cf2ef62191255d8da1b71",
@@ -21411,7 +21411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "27944170a3e451dbaca219921896363c990c6cc9",
@@ -21433,7 +21433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "2ccae70089a883f8eb057f4a736281b6f361a99d",
@@ -21456,7 +21456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "c0716dd34483b302a9c290d4e61b96a7ee941567",
@@ -21479,7 +21479,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "d0aae9bd6e3615e8d1023ca3c5c5aca1992d8a87",
@@ -21501,7 +21501,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "3d9be79618e80095826882637f13ecf96af88639",
@@ -21524,7 +21524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "6a776e672fb69cc4ee42df9039066200f1baf24e",
@@ -21546,7 +21546,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "c83de6ae90d43280df63baa729d50d06826b3462",
@@ -21568,7 +21568,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "38188da5d8a3f5b0038934f29d67b8a03e0f3531",
@@ -21590,7 +21590,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2cf7c3258abd0614f85f683c1564efcb91181410",
@@ -21613,7 +21613,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "b5b5e10df55f0d153053f5e6fcb419dac89cd42d",
@@ -21636,7 +21636,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "136f67ce862c4dbe5955501978687b1d736de02c",
@@ -21659,7 +21659,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "80a6c1f3300f360b318acfde1fdd1bb2e49942d4",
@@ -21682,7 +21682,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "36ff520aba444d75a9bcb34e1a12661ecece9ebf",
@@ -21705,7 +21705,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "faa419b7af433c75253374c3d319ba5ffc3139cd",
@@ -21727,7 +21727,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "fcea36bc8ec703fda9eb52674ff2be7b6b3130b4",
@@ -21749,7 +21749,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "780c3ab8536db878ebcc65abd0ec90483005c658",
@@ -21771,7 +21771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "2ac4efacfef5182aaef3e26a4f1e066ab228dfdd",
@@ -21794,7 +21794,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "634c608f129d15a307557800deaba954f8a30a3e",
@@ -21816,7 +21816,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "4368d7eafb3033d56431284b64e1bcc7404a4311",
@@ -21839,7 +21839,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "a1822e2091b900bfcf5cf2ef62191255d8da1b71",
@@ -21861,7 +21861,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "48e9c81fd60708be4c67bca8e1a7ade1e4b0bfec",
@@ -21884,7 +21884,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "1493543559f9a56366052b74003cccf06900fe27",
@@ -21908,7 +21908,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "3cc4d44df0d9d2cc0766c9a36ddc9cc0f20e9f3d",
@@ -21931,7 +21931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "d3b1ef1fe653f4ad9d8a91db87ba1be7b8bde977",
@@ -21954,7 +21954,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/starlette",
     "base_commit": "c78c9aac17a4d68e0647252310044502f1b7da71",
@@ -21977,7 +21977,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "06297af6798f26b38717773aab5752a1158aa04c",
@@ -22000,7 +22000,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "2723052176c2e1e5cc192061121423ad6685c954",
@@ -22023,7 +22023,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "d8e988105fdff8c452e3cc73f7790db0b0b64c9d",
@@ -22046,7 +22046,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8dd89075a1c57df407e2255ee34720a60d5172c4",
@@ -22068,7 +22068,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "7067d744c68a4358697336cb906a05cc4f9729b9",
@@ -22091,7 +22091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "5910b4adc9b2688155abb8d2290e5cf56833eb0b",
@@ -22114,7 +22114,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "6828f347136482f6d36fc7a481e21a57825872d5",
@@ -22136,7 +22136,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "756ee925302c61ebf43b5ed958c05577ea7ff3dd",
@@ -22159,7 +22159,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "7b0ad9795df5f9a49a585b6c2368a476c286c217",
@@ -22181,7 +22181,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "5d3779ffe2709fbdb5bff1b4f0d33ef2c8c617d9",
@@ -22205,7 +22205,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "9f0b928f03bc7a92412b1b93d1ff36f578e30bba",
@@ -22227,7 +22227,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f0425378dde7d897df39f90e6757688f21a1085e",
@@ -22250,7 +22250,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "7cbc79d2a61cab1e663714724454fbb432d70fec",
@@ -22272,7 +22272,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "641e3def2c8f915f741937ddfc7ff28ca86a6370",
@@ -22295,7 +22295,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "a45c278027de3541de85e3a0ac87328ac923e82a",
@@ -22317,7 +22317,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "937bfcc6385ab88384d13fd7aca325386ad31b97",
@@ -22340,7 +22340,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "9f8dcbd6a9d37d56a14b747b83d97d6b8527a2ab",
@@ -22363,7 +22363,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "f6cf6a0e77dd504cfc35dd499dd8694b0b80b4ae",
@@ -22385,7 +22385,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "ddf2b88dfa506fb43a73cc9f64dc7377a679c0b3",
@@ -22408,7 +22408,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f46bf1485100919ffac5fa13e89a612ae52d4ca5",
@@ -22430,7 +22430,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "fba9ee50ae314c4fc05f419fcea096e0f8295452",
@@ -22453,7 +22453,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "42ceb787344ce4d94716f2bdab8bd0b6723c36f0",
@@ -22476,7 +22476,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "380bba1d0b4f3665afdb164ad784dd234ccb8de3",
@@ -22498,7 +22498,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "dec777485fa3bfc32e4b544193d5ff1d271518bf",
@@ -22521,7 +22521,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "b25d2e8b2dd373f8e7888098c63bd4a273f87730",
@@ -22544,7 +22544,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "fbcac7611bf9a16750678f93483d3dbe0e261a0a",
@@ -22567,7 +22567,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "df29ff3da695fdbc42ccdd6b487703650e99f67f",
@@ -22589,7 +22589,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "67f237c1dece2fd3c56b25c925dabedc3b6e40be",
@@ -22612,7 +22612,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "503d275ade85e04efed787ec421bdc55a5a77abf",
@@ -22635,7 +22635,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "345b26ff9c839e682c4706d29b3da2d8970ae7c1",
@@ -22657,7 +22657,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "bfe5f893f4f2bd7e8256fd229cbfefb27c2dddc1",
@@ -22680,7 +22680,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7728bc9722a12c758b4cc2f39cf656a0497e5583",
@@ -22704,7 +22704,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "20b4f177fd815ab65f1bf700335856d0281dae15",
@@ -22727,7 +22727,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "ef407dbdc4b2d827a4509572904d6a6c539064e4",
@@ -22750,7 +22750,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "f9ea1a013c29e24001dc6cb7b10d9f740545fe58",
@@ -22774,7 +22774,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "936c9f58d733ec352db7afa6099131f11a327115",
@@ -22796,7 +22796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "67702e092723a829e70f483e68f86c08213543f6",
@@ -22819,7 +22819,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f5e61338ba370772f5d941ded4c84deabe177226",
@@ -22842,7 +22842,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "97d8e6d81433a5077fcd622ec16d40e587e937f1",
@@ -22865,7 +22865,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "2acfd4db274a27da66f5e51316bafd1a941a8de7",
@@ -22888,7 +22888,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0852fea517c1f4b00c4cc290d333544f91e9663a",
@@ -22911,7 +22911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "aaecc9376d0662aeca5d3bd7c9d9fa36d6398478",
@@ -22933,7 +22933,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "24acebd733c5bea49bcef3d404f4907d4dffd300",
@@ -22955,7 +22955,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "75ddaffe4a2f4af6f83e840be9f456aa22a0104e",
@@ -22978,7 +22978,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "theOehrly/Fast-F1",
     "base_commit": "17cb24aa35cbdea03a7fb739132f5693cd4171fb",
@@ -23001,7 +23001,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "8512040f7ca4a96b2ee79fc563d567efe62784e6",
@@ -23024,7 +23024,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "903cd93a43163bd69c84fbdfc33ff8f25e2fdeeb",
@@ -23046,7 +23046,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "2d2d94b1a67e0f1cff7bcd9d2bf4f603c936d027",
@@ -23069,7 +23069,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "022947a2a587483ac897f403f52a1e0a50f53667",
@@ -23092,7 +23092,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d99c7149ff64c2dd98b5d9752f5308f8ffd70474",
@@ -23115,7 +23115,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "dfb7186eed9253fff9958877bb3fe1e5e0ffcf32",
@@ -23138,7 +23138,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "5ce771e19b9aed17401f5865011ebec59105f5a6",
@@ -23161,7 +23161,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "fe6389f9b1bcad62b5b3620fa73507febc703607",
@@ -23183,7 +23183,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "d7066e7457f782d26e9c1f74450d062310c97fe0",
@@ -23207,7 +23207,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "icloud-photos-downloader/icloud_photos_downloader",
     "base_commit": "6e9c6c69996a39d0e7f77c9fd4f9b160b4b8bcdd",
@@ -23229,7 +23229,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "3b782cbecf3073ae96ea33e202e4e2a4f15e3a4d",
@@ -23251,7 +23251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "cyclotruc/gitingest",
     "base_commit": "2125765025c65fdd2aec89856bdc095dfb0fc826",
@@ -23274,7 +23274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "240e525ae2a82486a59fbb85e4664ace234ff554",
@@ -23297,7 +23297,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "cd8281b686bf7c441fcbbbc1e36763e30d7f0327",
@@ -23319,7 +23319,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "6322c4dc4afe0c91160cbdfb069119ca815a60a1",
@@ -23342,7 +23342,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "5822ff21dc327ab4404c9557f6f61e4da56fabf8",
@@ -23366,7 +23366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "f39bf4d2585746fce3ba39decba62693c82f194e",
@@ -23389,7 +23389,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2a794ba11d5e65d25383c185a4a40849577178bb",
@@ -23412,7 +23412,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "0687c851e14cf187bb213128c4f23feecd0105ac",
@@ -23434,7 +23434,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "707bfbd6695958853610bdaf10886f8c6b88e149",
@@ -23457,7 +23457,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "32718f18e917edad561dd1058c1479894b0191f7",
@@ -23480,7 +23480,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "afe6c9f5abad14f1889b3ba791c3f808435844c1",
@@ -23502,7 +23502,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "5398229da51147b24458d661a8c9820967ec5b10",
@@ -23524,7 +23524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "384eb0faf82bfc514b644469ba042da341fefaf7",
@@ -23548,7 +23548,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "af3e6670efd11b3eef6a47aef68eb644213db056",
@@ -23571,7 +23571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "33ead654e84511fb409218407852d7d146d16763",
@@ -23594,7 +23594,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "16ed6ef200b83eb25c7fe19b4b83c9fc502daf71",
@@ -23617,7 +23617,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "b8b8b5d5c64aa97108b957c9cfa9f4f0f4629153",
@@ -23640,7 +23640,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "6d3e6a924253f2a033823d2b835450f0d904230a",
@@ -23663,7 +23663,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c4fafd9b04a6d0988a23ecda626c2473891ef7e5",
@@ -23687,7 +23687,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "4e06b59b60ef375062d63de449d90abf53cb5aa1",
@@ -23710,7 +23710,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "209e6d5ff0f30f0be1774045de2491272bd2bdc2",
@@ -23733,7 +23733,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "51beb4825723c83947377738d9fd449aa2f7d746",
@@ -23757,7 +23757,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "38c820901beb553a0657dd768c6212891b0a5989",
@@ -23780,7 +23780,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0d09f6bc9d97bea13e2ddfae32295261d49fb8f6",
@@ -23803,7 +23803,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "9f4da5159a098256dfbccd2c926107953a6812e5",
@@ -23826,7 +23826,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "6acce7bd9cc864713f57e7fbdcda75bbff2de9c7",
@@ -23849,7 +23849,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "afc90f67ddb66508c43cfe474acfaa3ab427eb0a",
@@ -23873,7 +23873,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "801c9adb94b213fc5e8cacb0d9920a0ff7727c2e",
@@ -23896,7 +23896,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "0326b59c18e6ad926e183973083de9b94a52193c",
@@ -23918,7 +23918,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "364c8d8f13327fce6d1648ee5d28407c58f683ad",
@@ -23941,7 +23941,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d818b6edab232dc45929388e757bd4ac90e11bbd",
@@ -23964,7 +23964,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "042356899105694e1adaa0a9322c19fd3647973f",
@@ -23987,7 +23987,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "c062ec2f625f40a61cbc8ba5cf148b03d34a99fb",
@@ -24010,7 +24010,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "aa52f656c2ee45b01920ffbc5c8b250e5204c142",
@@ -24032,7 +24032,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapinghub/dateparser",
     "base_commit": "1d4b05875d2ee35987607f8e33efa4c8df74dfb2",
@@ -24055,7 +24055,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "9b4033284c1d4c40270be64c2eed3d85e1d4d454",
@@ -24077,7 +24077,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "8d7a58347ddce640b4871f6017936537a9f1088c",
@@ -24100,7 +24100,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "6a9bc4c051f0e4ee5e4ff48f08fd14230036dc46",
@@ -24122,7 +24122,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "8eff35713e7ed5ceb5c3a415c349fdcc5294a7b5",
@@ -24145,7 +24145,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "37ac3ef0888bbd9235d17cbc6d284856f5276b44",
@@ -24167,7 +24167,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "a05362c79a7dc22f633f60d12e95092a29824040",
@@ -24190,7 +24190,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "d4c348cc5ac556aa36f31e94e074a0375b7c94cf",
@@ -24213,7 +24213,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "ca231b189adc84caf8bb15f96162719848b765aa",
@@ -24235,7 +24235,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "586c0cd178f1d36692717dff0707078bb8f899ae",
@@ -24257,7 +24257,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "524c4400a59626e1b8f699a9742b0445dfadbdff",
@@ -24279,7 +24279,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "ed2c941a8ee3dafb884746d03bcdc0cae57fd8a0",
@@ -24301,7 +24301,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "14a44e14ba839348bdad140fa6a8ac1ecfcfe0ad",
@@ -24324,7 +24324,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "d810d5aac00cf9a4215f601247d08f6f7904bcfe",
@@ -24348,7 +24348,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "86c8cae40d9e47dde478d48caf8f27ab9a56fa7f",
@@ -24370,7 +24370,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "84858854ae2bc4a5b3b136e04b65b44fef26ebab",
@@ -24393,7 +24393,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "6888fde3eb896fa0a5578c2e8f4e7db0ad1687c3",
@@ -24416,7 +24416,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "9d231aeecdd69f4d06c75a702755fa70d8c2b5f6",
@@ -24439,7 +24439,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "9be662aacc994c7016e9c0724500c658589369f2",
@@ -24461,7 +24461,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn-contrib/category_encoders",
     "base_commit": "06e46db07ff15c362d7de5ad225bb0bffc245369",
@@ -24484,7 +24484,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e1063a152b8a969383f35c122a8b26eca58a0820",
@@ -24506,7 +24506,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "2958e0a8e61b01523b6232486683e21e22c85465",
@@ -24528,7 +24528,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "b297f85c356609d1024ff63798d02b8493a56f3a",
@@ -24551,7 +24551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "ebff1259a45dc7c45409ae439d36d7607afe86ee",
@@ -24575,7 +24575,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "f799b00c76f5a0af12dd43010e817d816459f4b2",
@@ -24597,7 +24597,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c67d1bf0e95a233c0872b528b41e8eef42a6c963",
@@ -24620,7 +24620,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "2f76db8f13e8465a6f01ff0786176a2ba46473f9",
@@ -24643,7 +24643,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "8e2bc9199f47ce98acfd7d91cf57f2589f41c252",
@@ -24666,7 +24666,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "b65d1ef58430e55b534b4bb59a55a0b0b24e33ff",
@@ -24689,7 +24689,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "cd1a30d75856a32d2a01912dad575fa8c88a1674",
@@ -24711,7 +24711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "0a7947567f400192f6099c47fa84e2bde36e531e",
@@ -24733,7 +24733,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "251fe08f8da8214dafdf094afd80c543b8e2e0fe",
@@ -24755,7 +24755,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "b2b771076c37e3a5ab3ab8e93a39b978ae832c15",
@@ -24777,7 +24777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/starlette",
     "base_commit": "c8a46925366361e40b65b117473db1342895b904",
@@ -24799,7 +24799,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a1d4c7c10fe06f8a938de8f1145b6470cd56e618",
@@ -24822,7 +24822,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "d0647edd0ab7fb7fb577491203645792c64137a4",
@@ -24844,7 +24844,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "17610ce2391172c5848dc1f9db377a0f9aa5c4ed",
@@ -24867,7 +24867,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2af24d076d33d7ca026d3db40a513e0df00676e9",
@@ -24889,7 +24889,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "bf0ebb8d09289a398f891964c53903f6a471d49d",
@@ -24912,7 +24912,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "e17ed74fe027eb84aaf72ce92c4b1bd8ebf8c049",
@@ -24936,7 +24936,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "eac7ab8263362d8cbcc273f08c788d8183d22ea9",
@@ -24959,7 +24959,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "99bd072ab6a76284a65a0150889a936bb64c83e7",
@@ -24981,7 +24981,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "75410e89cbbff6fb0f1603dc53eaebdc40bef058",
@@ -25003,7 +25003,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "b20f3ac29ad4c45bffddea2d732a159c945a4ba5",
@@ -25025,7 +25025,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "003e2cfb746dbc83370758c192edacebd761472b",
@@ -25049,7 +25049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "5616e145960775ab7673765b2c4c966928b8034e",
@@ -25072,7 +25072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "3ea128c962e056529f1550a67708d2580ac81bac",
@@ -25095,7 +25095,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "d4df9c09b2233888c97b25d28d6c548af5a20312",
@@ -25117,7 +25117,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "34c11fdf108395fcacbe2488655969fef5c7958c",
@@ -25141,7 +25141,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "f6799ab8e60d7fcd4b02d52d5903f08c24957faf",
@@ -25163,7 +25163,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "dc855b59608898d013e7bf5e9c2822b9635690a8",
@@ -25186,7 +25186,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7f0f1b2844b0892408bb5deefe04b78e60403a9f",
@@ -25208,7 +25208,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "94fdc994beacc482c720892e0e5e2a77968efcc4",
@@ -25230,7 +25230,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "b71a04b7d9c7a585e8706e480639cc777fd6f43e",
@@ -25252,7 +25252,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "e17d66e519d5dc5ac56dc687d5849d1e59fdcc24",
@@ -25275,7 +25275,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "adf0535a392100093ced71d096905d861c03ee23",
@@ -25298,7 +25298,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "c76e982e46c6e77a54a0fca4d4417eabb70cc85d",
@@ -25321,7 +25321,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "7ffbb0a7d7d89a5f6103106c7e40367361f84c0c",
@@ -25343,7 +25343,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "143b9202f3f2bb95738db3260b29827199273260",
@@ -25365,7 +25365,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "a36d2820d660229c70bd7c1ab22cc4d4f46cd307",
@@ -25387,7 +25387,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "d757bfac8a140832fcb7ebdf1bd502480d6a6911",
@@ -25410,7 +25410,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "4dde6fbaec5822dc23e5881d649cae1627e0f805",
@@ -25433,7 +25433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "fba5a6a65c37c2b9307c4d6c8ce3aacf7abb7c92",
@@ -25457,7 +25457,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f182e80685ec97b6a0b8b51d40be5782a69259b0",
@@ -25480,7 +25480,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "a9f6afd0152e30f32db69d35211fc05eceb9edfe",
@@ -25502,7 +25502,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "549021d2fcf26feac772731ae1e5607365be242b",
@@ -25525,7 +25525,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "ad07901d8cf6fb874262c6387bd24d9e5a284144",
@@ -25548,7 +25548,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "e6f2b0c72be421f3b324a55fca1dbc367405cce5",
@@ -25571,7 +25571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "a2e9a5252d2eab389bd19d359e6e7325a8232c79",
@@ -25593,7 +25593,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "524c4400a59626e1b8f699a9742b0445dfadbdff",
@@ -25615,7 +25615,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "39acdeef6424bf7e336ff71cf3a04540b92e2fcd",
@@ -25638,7 +25638,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "dd77f851494d24d19aecf0328c6913d121b8b51c",
@@ -25661,7 +25661,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "afb752765d88896c50d6cc529d653f63e0d3dd41",
@@ -25683,7 +25683,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "8b1ca959bd23d68848eed58f337cf3d25b00f9aa",
@@ -25706,7 +25706,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "101bc0d3943f6563851c9e25805085f86d74415b",
@@ -25728,7 +25728,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "40be4bc088710dcf80d6e26ba3c88f147dc40425",
@@ -25750,7 +25750,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "f4d45290e9feb0b80e27909275f028ff9b2470ce",
@@ -25774,7 +25774,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "397d9b013c6ab0d26b8c71cebd5cccd998d599ff",
@@ -25796,7 +25796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "13d4c3d91bf1ec7c1ebe36cf2b1f6874a319ef25",
@@ -25820,7 +25820,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "b83aef65e711e490403a1e37c4e818d7b6c098bc",
@@ -25842,7 +25842,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "c31fad7b695faad63108c39bd008da9681bd8183",
@@ -25866,7 +25866,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "ae2115c1456956fbc7073736b0999bf2d7342b2d",
@@ -25890,7 +25890,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0f1378756103b5e13a1b5a7e06e714e8a1f70559",
@@ -25913,7 +25913,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytransitions/transitions",
     "base_commit": "e3015425e295d39a4c5dec57604ece07a3cc4582",
@@ -25936,7 +25936,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "5e8f5b2c588b6ad537cec100b9d18409149608a3",
@@ -25958,7 +25958,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0597c50d8ca21c219f8187b8396954b8f74fbb16",
@@ -25981,7 +25981,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "1c60668f6bdd05dab619806e7b2dc25d3ed4ccbf",
@@ -26004,7 +26004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "6f78ab12df402b801628b4fa1b2071b0a7a01bb2",
@@ -26026,7 +26026,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "d8b5ebca42a32be615b938627a0601c2cb59e68f",
@@ -26049,7 +26049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "0fe2f1752ac67f9ce6d75bbe7a7fbe089b65ddff",
@@ -26072,7 +26072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "3c46b4120f503fff2644818411d1983f7be94e57",
@@ -26095,7 +26095,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "2d2d94b1a67e0f1cff7bcd9d2bf4f603c936d027",
@@ -26118,7 +26118,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "33dbc472444086e0db670758b30ed4a426a75244",
@@ -26140,7 +26140,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "b09806e0df8f01b9155017d3693764ae7beedcd5",
@@ -26163,7 +26163,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "a902244a6743eff627eaf485e01ae6ae0a9f24d5",
@@ -26186,7 +26186,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "19b13e2399b81c38ff6345896053b6e266c1b60e",
@@ -26209,7 +26209,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "9e92c7b95677b12b16199c0a8a1b6668833f51aa",
@@ -26231,7 +26231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "3c8be8ee40babf9bcbaae53b9f2ec518c6d76ca7",
@@ -26254,7 +26254,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "0810bd843cf8baf5e84a03ef588dbb339301c787",
@@ -26277,7 +26277,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "754f979dfad93a6270d947a001da2ebed59512c5",
@@ -26299,7 +26299,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "d53f97e984bfdd268aa92f8bf482ced0edda0110",
@@ -26322,7 +26322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a6bd8fbefb205ebdb67a76729b1d2324eb540271",
@@ -26346,7 +26346,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "8b6c82d8dd24953ab289ccf05f25d0c5f5b63475",
@@ -26368,7 +26368,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "b5d94f17b567fbc49a1c809e9fee6e19931b977f",
@@ -26391,7 +26391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "31a8b913004766234554b4de121d330939eb57d3",
@@ -26414,7 +26414,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "0616197b44ae95da03aad7e5ac3997b243bd735d",
@@ -26436,7 +26436,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "35f1a3106620b33371e420ec87969afeb65f86a8",
@@ -26459,7 +26459,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "b05394bb20722444648a33b4447156bcef202fd6",
@@ -26482,7 +26482,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "e0a1e8ce2fa10b9730dc9f6b3d4036f4e63947d9",
@@ -26506,7 +26506,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "d396db4588a8adf5ef5ca4e1268b23851cc89fdb",
@@ -26529,7 +26529,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "b09af642e6a345c021860148fd9946e1698ad545",
@@ -26552,7 +26552,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "12bb1dd23855454a0e18a67843fc88540cc2eaf8",
@@ -26575,7 +26575,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "ca8079bc64d1c5a736906442adac91f8e52c6dee",
@@ -26597,7 +26597,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c361744fa45be644670a8bf476d2bafccafe7f16",
@@ -26620,7 +26620,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "92d25a7066227d18f852eb49a397b46c11f0dc1a",
@@ -26642,7 +26642,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "664b45729aa6ac2d6ef9459d8c0ad04f50af847c",
@@ -26665,7 +26665,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e9f2b9b69e988ce88c5c756de3b53433b4b76ace",
@@ -26688,7 +26688,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "0fd212d11cf87a200eb2cfd5b0357d05fc7b3f32",
@@ -26710,7 +26710,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f08b9924712cf0c2f27b93cbb5206d56d0d824d8",
@@ -26732,7 +26732,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "7b4586ef2adc560b457731ae07be87e348a8769e",
@@ -26754,7 +26754,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "933579d3c4a585f236982d05d3a74921f9567415",
@@ -26777,7 +26777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "fa6be07ce86b3f8c5072a3d5ff355b4266baa32d",
@@ -26799,7 +26799,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "6609455defb68e2615126462f3ee8a5937dee54a",
@@ -26822,7 +26822,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "ddaa420aabc5708d2adbd14e2aca0ec5433a6fd0",
@@ -26844,7 +26844,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "c0071b825b5b1d97b9216acd7b67b47004375ef2",
@@ -26867,7 +26867,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "d8f84b0b81d569f011999533c4199df31bc65d85",
@@ -26890,7 +26890,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "9e99247da3d2f1e775789b5ce08add155f1e5b01",
@@ -26912,7 +26912,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "d61eb8c4c8c5a4645e937913d60200d6ffd85799",
@@ -26935,7 +26935,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "5d23f145efbe5b4ab44ceda5d29e16eecba288ff",
@@ -26958,7 +26958,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "ad6b49e09034166ba972bbd5d3c080495f3b23b1",
@@ -26980,7 +26980,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "cbd5be02c6694252263fc627a3078db8693a4f38",
@@ -27004,7 +27004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jazzband/tablib",
     "base_commit": "cd0ce712dec77368b2573b9043004ee03efefce1",
@@ -27026,7 +27026,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "957ce046df906fe062995b49d90c3b3f04d6c050",
@@ -27049,7 +27049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "0fd212d11cf87a200eb2cfd5b0357d05fc7b3f32",
@@ -27072,7 +27072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a7eeb0e6873fa7d4e85da6dc3e16662c42b66e73",
@@ -27094,7 +27094,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "50716d42e814051dc66a59002f704d8ca029360b",
@@ -27116,7 +27116,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "3d6a5fe55faadd4e3b242c65b2aed2fd76e1b9b9",
@@ -27140,7 +27140,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "cd026f5e1d849f047002d1c4978e5cb8e5a9f184",
@@ -27163,7 +27163,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "31ac633b18cd02528fac0038fa22ee5caa16b82f",
@@ -27185,7 +27185,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "6e3e4d1831a42d625754f3ec71bd0ded7d85be61",
@@ -27207,7 +27207,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "5da1db9fab76a2b6a3eff6e510bf76311875c8d2",
@@ -27230,7 +27230,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "94c21e65f177d8f15a8ab806167037d668c88571",
@@ -27252,7 +27252,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "5e6b12d12fa08abafbeb7570f47707fbedf69a45",
@@ -27274,7 +27274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "4c309554bd1c97d52ed74206d6604d3d72dabf7e",
@@ -27296,7 +27296,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "6236b919309ae02702ee15b2b6bde71cc64ad4ad",
@@ -27319,7 +27319,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "fd17607434b8037aa6d19a73bcd1659f1f74c709",
@@ -27341,7 +27341,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "1353b11f343f06da7e8739369668de86d4875f23",
@@ -27364,7 +27364,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "8663dbcb974bacc1e03d9f5158f62d7a98e398eb",
@@ -27388,7 +27388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "84ebc7d34510720858db4916103b41dcd7f28730",
@@ -27411,7 +27411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "52f2435b4217a35886f9bfa5140f8f6e7e0a7409",
@@ -27434,7 +27434,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "d7d1bba818ef36b2475b5d73cad6394841710211",
@@ -27456,7 +27456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "b0a36ecb1f7178aefd6c1c8ed86c53e56baa86c8",
@@ -27479,7 +27479,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "f35e5d6a840e1aeadefa92e87fd331c4798a0022",
@@ -27502,7 +27502,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "419b66158881af9da5b9b4d8f84b77f7a9c46105",
@@ -27525,7 +27525,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "57a0070dfdf79dee4198523b060e57b70b75835e",
@@ -27547,7 +27547,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "fa16860f58439735ddc4d2225876496545cb8e4e",
@@ -27569,7 +27569,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "d28a9ee0ea28b2356b24a0d0e0ed70c0141d41cc",
@@ -27591,7 +27591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/open-r1",
     "base_commit": "9915e06f1e2e5cdf580b706110734e2a24146a4d",
@@ -27614,7 +27614,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "66f0a49b759fe0a88ac115f25528e087199d9de5",
@@ -27636,7 +27636,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "6a84a5d408ee2fff112223e8ead94ef6ebfe9c2d",
@@ -27660,7 +27660,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "53431a424fdf624a95de5b14540cfb3b5a5e6eb0",
@@ -27683,7 +27683,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "f0ee037fae05cf4b69b26bae632f9297e81272ca",
@@ -27706,7 +27706,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "d5bdabdd80fdb5e9866d48676ac2eabf5ceae620",
@@ -27728,7 +27728,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "a8c989673d0ea0cd099ede136efa117eaeb7ae1d",
@@ -27750,7 +27750,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "df4eb5237f88a9fc9571a5605744b93cebd23df4",
@@ -27772,7 +27772,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "16017609ea2765c4651dbc13b4743578363b641a",
@@ -27794,7 +27794,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "1039c73553789228c60ab7fc4b446f2640be7ead",
@@ -27817,7 +27817,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "f054192156f5a9d577ac5356e1ad8b5c75a574e3",
@@ -27839,7 +27839,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "88191e74bf72345924ed703c65edb9fdf6bd8edd",
@@ -27861,7 +27861,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "2a1053c5ca995c30d52f60ae575f8bb2ef92b0d2",
@@ -27885,7 +27885,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "abc9038580a8b6318cd693b5d6b1af2b4138c404",
@@ -27908,7 +27908,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c361744fa45be644670a8bf476d2bafccafe7f16",
@@ -27931,7 +27931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "76090ea59d3d9cca8f9995cbb6f1558b63e3a1ba",
@@ -27954,7 +27954,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "53280bd3ec188b7be3cba8834b4f000bc7fbbe91",
@@ -27976,7 +27976,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "7d52cfd1cc1d133f9fe777909db242d31daa78a3",
@@ -27999,7 +27999,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "02683b8c3736b87f7af6ab86d4e1f56932309b0e",
@@ -28021,7 +28021,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "33b36ee82f39827ea7bd611d14104def888a768c",
@@ -28044,7 +28044,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "8acc982527cefbffae5bbc46c9b1221a2b66c723",
@@ -28066,7 +28066,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "528b0b69d2b66c4c7b99a5f13c314001b0bd91fa",
@@ -28089,7 +28089,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2c22ae5a2e9ae968148948dd416faa051c3964e3",
@@ -28112,7 +28112,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "9a30ca7da1aeffe0c21b81fc7722eb1aed1512da",
@@ -28135,7 +28135,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "780c3ab8536db878ebcc65abd0ec90483005c658",
@@ -28157,7 +28157,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "e131065d746a94b093bdef24713a0eb28c3158d8",
@@ -28180,7 +28180,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "000938414f46aeaff20256e63d84c96612ae014d",
@@ -28203,7 +28203,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "ab30b0cfb12a1822b572cdff69a1633c21730031",
@@ -28226,7 +28226,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "a88c59072e24749b586a5fe38f29090782778a2d",
@@ -28249,7 +28249,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "cf3655968b8b12cc0ecd28fb324e63fb94d5e7e2",
@@ -28271,7 +28271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "b0b0fb6d1d4f67ab32980c4fac017211aab25d1f",
@@ -28294,7 +28294,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "dd592cdd7c6059f80fa7362b7f6fc7e79fc878c7",
@@ -28317,7 +28317,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "912f1cd85c747f4be68123852566a0917fcd3c4f",
@@ -28340,7 +28340,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "85cf3434d5f016b26d9f1b26a02c8c6d8ee8282b",
@@ -28364,7 +28364,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "98394ceb8ec40ee75c8f434b751316544cb81ec2",
@@ -28388,7 +28388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "b1c0f22ad8c192a3de34a0be4c7671d83cd52b6d",
@@ -28410,7 +28410,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "6c620e8ef8e2222f2e3c2d9cadb90b1527d4045a",
@@ -28433,7 +28433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "31a2e1edb756e6b42ecd7ff405e488647d8ea27a",
@@ -28456,7 +28456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "9dc5ac4337b09df8c28b6d678485a4894d354970",
@@ -28479,7 +28479,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2dcaf42727d90421a5e73417c8f970377394237f",
@@ -28501,7 +28501,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "85cf3434d5f016b26d9f1b26a02c8c6d8ee8282b",
@@ -28524,7 +28524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "67e59aca1632e0f2311c3418541360f51a306ba9",
@@ -28547,7 +28547,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "wemake-services/wemake-python-styleguide",
     "base_commit": "a47422db1e4261b8be23dd2d015d0db977100b53",
@@ -28570,7 +28570,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "d45c06c0ca13a4efd55f5b5620ebdff10281cd6f",
@@ -28592,7 +28592,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "1d20ac3c5e56e7cbfea4ab6818834ef5153aa456",
@@ -28615,7 +28615,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "59de6749732381006f3c97806b0e8c1d07c99efa",
@@ -28638,7 +28638,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "2fe1dcf39e2ed9601dae534cdf6359807f926235",
@@ -28660,7 +28660,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "56a3a9bd61b7391ae91e3d8179b3b33918ef4932",
@@ -28683,7 +28683,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "a565d6607d1d16933dbb1ea42cfb9de39ef80980",
@@ -28707,7 +28707,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "aa3a910cdef8e0a3cb4e893f4c371b58015f52e0",
@@ -28731,7 +28731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aiogram/aiogram",
     "base_commit": "7807981252562846f3848065d5893504a79ddf79",
@@ -28753,7 +28753,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "f2bd4bc25b24587aef40f486087412b9da8f1d94",
@@ -28777,7 +28777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gptme/gptme",
     "base_commit": "209b623793ec179089fb298efb9bc51a9a4007f6",
@@ -28800,7 +28800,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "camel-ai/camel",
     "base_commit": "ce214d3db4f289d6f36004ceb5712e8ab7027168",
@@ -28822,7 +28822,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "98b3cb01f6865550eb083646d3f9e4e5dfcfda82",
@@ -28846,7 +28846,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "64d45cb8f45a38109b729cd3e1835e2dd36e65fc",
@@ -28869,7 +28869,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e25b357d6eab29fcb64ee04340f2d0d479ea09bf",
@@ -28891,7 +28891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "934719dd51ed3a582981aca4fbe0ac227b495292",
@@ -28913,7 +28913,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ee71be9e906dc43c63e8319c849f9e4b20c9db3f",
@@ -28935,7 +28935,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "de28d1e43777e3782a06b74d9091c3471636eb70",
@@ -28959,7 +28959,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "projectmesa/mesa",
     "base_commit": "2dedca4a8fa7d9bd27e0b2942584009443524aee",
@@ -28983,7 +28983,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f0bddeb301cdeb96598b3291cc93b2d433e38ca6",
@@ -29005,7 +29005,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "38a9021dc6de3d540620ec2696a7bc1ed896249b",
@@ -29027,7 +29027,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "ebed0c050d61366dc81aea41e75bbbf86bde0963",
@@ -29050,7 +29050,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "199c31fa64f46d2b3dff59b0921eb0472f72570b",
@@ -29073,7 +29073,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "b8220b5b975e3f4e19d078033aa1e68da28e2c9b",
@@ -29096,7 +29096,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "2c22ae5a2e9ae968148948dd416faa051c3964e3",
@@ -29119,7 +29119,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "b56e1ae626617a1e5982126302e0e4c2abd7e649",
@@ -29142,7 +29142,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pwr-Solaar/Solaar",
     "base_commit": "8fbd643110a79edbb695cd1fa8181112897ee017",
@@ -29165,7 +29165,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "qtile/qtile",
     "base_commit": "ff90e5cfae7418ad62d0accc3cb38757fca2cdb9",
@@ -29187,7 +29187,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "bf3686e59347320c95503573979a4fc3ad6be9ab",
@@ -29210,7 +29210,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "fc48b266a8c6005dca7d21ff96f4392ef62c0ccf",
@@ -29234,7 +29234,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "0698b62870f094f2e9681e8ee0d2c53f6588b0a0",
@@ -29257,7 +29257,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jupyterlab/jupyter-ai",
     "base_commit": "0a6a0296e61e04936d8ef97d5fbdbc1a6d2575f4",
@@ -29279,7 +29279,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "277031cfb256933921531403fa70d036f863f459",
@@ -29302,7 +29302,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "679d03897951eaeb0de6ae45894bbe08ad204c5a",
@@ -29325,7 +29325,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "90485a1edc3a6795705d3545e25e359786ce32fa",
@@ -29347,7 +29347,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "5e7703e98faa8d682a679832872094258a172629",
@@ -29370,7 +29370,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "7d689209e70625938af7549bdd17feac79436b2f",
@@ -29393,7 +29393,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/starlette",
     "base_commit": "b68a142a356ede730083347f254e1eae8b5c803e",
@@ -29416,7 +29416,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "c4510cae31e37f5dd8fe7ac8c3843e72ec8492ee",
@@ -29438,7 +29438,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "767012b66a61ff350f8bd021e338bd504c3e222b",
@@ -29460,7 +29460,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "bf07ca9344e6e161bacfda47fa38ffcd6b55d452",
@@ -29483,7 +29483,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "527f6d40b7ab6c541b82db69d68b9aea11ee0eca",
@@ -29506,7 +29506,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "modelcontextprotocol/python-sdk",
     "base_commit": "2628e01f4b892b9c59f3bdd2abbad718c121c87a",
@@ -29530,7 +29530,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c1ff7590f233ba7a2338c705028eae98c7234dde",
@@ -29554,7 +29554,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1fdb2047935848f0f74bcabbf7482d6f0243f519",
@@ -29577,7 +29577,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "932cf2db54f62b6c83bf82254dec6134de275970",
@@ -29600,7 +29600,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "1d18d7e257529913da76adea222c33bc0ff1a00e",
@@ -29623,7 +29623,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "97d8e6d81433a5077fcd622ec16d40e587e937f1",
@@ -29645,7 +29645,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "cb89483750de606cd21310edab2c843717a51ef9",
@@ -29668,7 +29668,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "d37cb0821ab6940cba8afcdf62aeeff32b921993",
@@ -29691,7 +29691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "shapely/shapely",
     "base_commit": "5b61787eb708db4990a8eb40bf4c069d04d3aa24",
@@ -29715,7 +29715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "576daec845cbc83cebb040e018ba9fdae1902738",
@@ -29738,7 +29738,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "c4a7f5bb76bdcf5e5d72654a622c9991d78ed354",
@@ -29760,7 +29760,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "5b8408aac760e363be49a330e3cdbd3e1da48506",
@@ -29782,7 +29782,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "db50579bbfdd89aeaf17b73d0dcd50b5ea93f1dc",
@@ -29805,7 +29805,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "f828064e3b7426f273ebf86ee28f05659284aa39",
@@ -29828,7 +29828,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "ef50ceb0f05df7ba2bd406f935a75fad6a13255d",
@@ -29851,7 +29851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "18d4b17070b9974149310c874286b074226fb8d4",
@@ -29874,7 +29874,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ad97c32e65650d5310d435a347d55031634e568f",
@@ -29896,7 +29896,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a6eb97ac7ecc6c09a67c33f013d110ed207319a1",
@@ -29919,7 +29919,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "899b10c2f327aecb4603c36d33ac6e1561c694c3",
@@ -29941,7 +29941,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "885818bb7f63783ac93ff2f81bb50fe5a1cb5831",
@@ -29964,7 +29964,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "1bfa879f4feaa0c540341fec40a7bb59f7b4cb84",
@@ -29987,7 +29987,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "47a5f750c18864f66b7fb2cd297bc50f2d74e4e3",
@@ -30009,7 +30009,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "4aa80b1f403f96dc3f6503c83dbea21b18e8a337",
@@ -30031,7 +30031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "37aaa9eb762fa4784f87788d6b61a8b5beafd25d",
@@ -30053,7 +30053,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "a209f4ed5bdbdddc0c9eac70106b8370a4cd31d3",
@@ -30075,7 +30075,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "a831422fb22a0fd874b22bb2e81a0491457b86a7",
@@ -30098,7 +30098,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "1841aec11e479ed75d912bb01db7cc90dd2c4e47",
@@ -30121,7 +30121,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "4005202304fdef04a5e87de2e8b09c9de506dcae",
@@ -30145,7 +30145,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reata/sqllineage",
     "base_commit": "a93b89479e6f8764c4bd617c35752bb2e61589f9",
@@ -30167,7 +30167,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "ebb49d39e0a6c43c8d9f7a059d01b5f2c9f00399",
@@ -30190,7 +30190,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "56c0f60bb8458b6edf517866c7ddf074f0c67671",
@@ -30213,7 +30213,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "6bbdc0e8e91a547c9f89c175d365c9abeeb45fb2",
@@ -30237,7 +30237,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "88efb088fba2669db30df083285c826ded400cae",
@@ -30261,7 +30261,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "754f13207650a93bab351d0c31bfd5324d3cf8e4",
@@ -30284,7 +30284,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "5cbdd1e5ef55ae1c7634e76fd44d0a8c2785f617",
@@ -30307,7 +30307,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "e082c5b58f1f64aadc5270838a28459b0ab198c5",
@@ -30330,7 +30330,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "8f57a3f428f19bec4f24c4cc3d3b1b119c103344",
@@ -30353,7 +30353,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Flexget/Flexget",
     "base_commit": "be3c243f9968122cd23543b22d597352922c6bfa",
@@ -30377,7 +30377,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "48f526719d95454efed652e147fcdb0c5a8edf83",
@@ -30399,7 +30399,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a474e3d67c1a0acfc4f8fa7db2f71de4bd089466",
@@ -30422,7 +30422,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "1940c9fe9444d15a507c422338ef64d6e67ab169",
@@ -30445,7 +30445,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "580137e726f52665d2cc19ab5a0aaac55da0d47a",
@@ -30468,7 +30468,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "ff1983e39f905d154ed757543d005e5de47bc724",
@@ -30491,7 +30491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "b19794e126c1077b83eba90fe74ab1f67362b1ba",
@@ -30514,7 +30514,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "42b88d01fdd93846d925b1097167d36ea31c7733",
@@ -30536,7 +30536,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "6fe26dac768b64e3e4d33b51410bb12524860dca",
@@ -30559,7 +30559,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "c4fafd9b04a6d0988a23ecda626c2473891ef7e5",
@@ -30582,7 +30582,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "d3e13462d0622d7cc20c383d976bf566b6b8ad76",
@@ -30605,7 +30605,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "61cec0e88e1a49ee09c39b78fa0396c1da3239ea",
@@ -30628,7 +30628,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "6af547cdd9beac3b18420ccb204f801603e11519",
@@ -30650,7 +30650,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "cd72f110dd6bff4a6b85e26637106d8b90746ccd",
@@ -30674,7 +30674,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "26abe697a8802de40cb2761fc98b843fe1b2d5f6",
@@ -30697,7 +30697,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "52f2435b4217a35886f9bfa5140f8f6e7e0a7409",
@@ -30720,7 +30720,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "9237f90d35a64561aba5117c66cfbd43839528f8",
@@ -30742,7 +30742,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "e64d4539b43b259d5222d49c7f6ac929ce0bd979",
@@ -30764,7 +30764,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "43dc5a4548dcda23fda646087702886287deffe9",
@@ -30787,7 +30787,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8ea6c9ccdb70f2ed05c3b61c9f83690ebc079c4c",
@@ -30809,7 +30809,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "e3556f867de863a479c6eba5173d806612e0a944",
@@ -30831,7 +30831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "2fd5adb8fec09c51cbd607e4e852f2c1d4293348",
@@ -30854,7 +30854,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "5f3846f8c6c3c40262ca02c733affc9ec8c71c23",
@@ -30876,7 +30876,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keras-team/keras",
     "base_commit": "2305fada8889e86463493bb4893b13ee8a8f0573",
@@ -30898,7 +30898,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "6d65aa311a9601986ac7ac8564448edd15ddfdb0",
@@ -30921,7 +30921,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "46259b9f5b89a226d47e2119afb40ad7b4fa5e63",
@@ -30944,7 +30944,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8f1d89a6acab43cfa6a6e1931442ba362d48617a",
@@ -30967,7 +30967,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "7cdac78423b259e77641fe3a1cf3a0b1cc5ec049",
@@ -30990,7 +30990,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "d9a257ec85ff58b1a706d0a4f05952399cbd755b",
@@ -31014,7 +31014,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "facebookresearch/hydra",
     "base_commit": "d0b8e73ad52ba9fa8ff42ba1f28e2b03f216dff7",
@@ -31037,7 +31037,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5c3f2f60b9f6ed062e3891043824d03c964d2a03",
@@ -31060,7 +31060,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c361744fa45be644670a8bf476d2bafccafe7f16",
@@ -31083,7 +31083,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "b772c1127c5d553a3f790341a7360c2f439ae683",
@@ -31105,7 +31105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pwr-Solaar/Solaar",
     "base_commit": "704a87696febf8175e86c890ec66afd520d16d51",
@@ -31128,7 +31128,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "base_commit": "5f88b01afcd7d429ffb6e549f028b34be6b28ba0",
@@ -31151,7 +31151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-control/python-control",
     "base_commit": "394e1c2c638cc0fe37d584fee6e4799794b3666e",
@@ -31175,7 +31175,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "17f22ba4cb5c158b63785c8e441597369dafdb61",
@@ -31198,7 +31198,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "89716761adb198a943da521cb7f7ce00c49aec4d",
@@ -31221,7 +31221,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtune",
     "base_commit": "f200da58c8f5007b61266504204c61a171f6b3dd",
@@ -31243,7 +31243,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "55e0a36fac1e3931b92f5f11508f6c09d903e0cc",
@@ -31265,7 +31265,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kubernetes-client/python",
     "base_commit": "df43d155d9252ab980bf5454e4b9574c5d5c7348",
@@ -31288,7 +31288,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "df99e5b9126e7c2962b22a8691bec7379ea01d92",
@@ -31310,7 +31310,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "c516d3fe48e7ca469ca94a293f12df56f7964fe3",
@@ -31333,7 +31333,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "base_commit": "d008e331ba11f6cb648ff447756e14e3252b368d",
@@ -31355,7 +31355,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "e2c15e36531685c694d7ec4b6af0c2c8534672c0",
@@ -31378,7 +31378,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "base_commit": "bcb1825679aa1aa8d637c4b948a172fa690bec58",
@@ -31400,7 +31400,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "reflex-dev/reflex",
     "base_commit": "4219a78e7c404a223ad791f3a9a4130b416a8418",
@@ -31423,7 +31423,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "00789fa4d5f1ed8734d6e2561db4fd52c3feddc8",
@@ -31446,7 +31446,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "d5acc2700f9495325411ff10b0e4971b19c296fc",
@@ -31469,7 +31469,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "instructlab/instructlab",
     "base_commit": "a9f4f60b3974a0d1611427412d32656876c8fd80",
@@ -31492,7 +31492,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "13d4c3d91bf1ec7c1ebe36cf2b1f6874a319ef25",
@@ -31516,7 +31516,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "88d03589084167471262d004a183fea39985a616",
@@ -31539,7 +31539,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "11cf3af55948c9cdb5b28313c6f57403fc1b3a0e",
@@ -31561,7 +31561,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "2fe12358e3336cbbebf2b4a05bee819dcb726554",
@@ -31584,7 +31584,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "ac0032b54a52f7dadc4614e97ecb59a678f32327",
@@ -31606,7 +31606,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "60f24cdc742ef650df4bedc88b7db80bf163ac16",
@@ -31628,7 +31628,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "4d2cf04b6635663275a747333754410ef255e54c",
@@ -31650,7 +31650,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "ed88d823f1fd2c572d8600d2c461bff1a86237c1",
@@ -31672,7 +31672,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "2823adf747be78382dcc35c13228d9a7c12e8113",
@@ -31695,7 +31695,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/cibuildwheel",
     "base_commit": "dcecda6962ea9dd93b87b53191758cc10dd91446",
@@ -31718,7 +31718,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "5e86ac25bca11ca018cfaf89a5a7d617693075d4",
@@ -31741,7 +31741,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "browser-use/browser-use",
     "base_commit": "637c41dbd7ffe9559bc28b00b20c99b73df2067c",
@@ -31763,7 +31763,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "267b6a5976808ba858b46efc8821c3a749a14196",
@@ -31786,7 +31786,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "SciTools/cartopy",
     "base_commit": "aedaad977556e0ad15b9256e9cafd15913108fd4",
@@ -31808,7 +31808,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyinfra-dev/pyinfra",
     "base_commit": "e7ee8cce9f90471cdb877d7c2d04b7ebb3a5c6ed",
@@ -31830,7 +31830,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtitan",
     "base_commit": "4c4388f65047393acd91deb3f7a31d673d41701f",
@@ -31852,7 +31852,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "e88aa8a4502b1efc1ebfbb6cfd98d191b8c34cd2",
@@ -31875,7 +31875,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "02a16551a0ec58a603b20f8a72e800c436ba7fe8",
@@ -31897,7 +31897,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "42c5c36383f0005db6e16614ddfe6fd1d9a26829",
@@ -31920,7 +31920,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "ed5963235706741560b095bd7e5a8865e3be1009",
@@ -31942,7 +31942,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "celery/django-celery-beat",
     "base_commit": "673dbc5590288f5a1f610c4569d4f4c797abefe0",
@@ -31965,7 +31965,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "200808c2eaa7f9524d4be6508807fb1db68671ad",
@@ -31988,7 +31988,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "f45614717eb06d2b357fdb4985c0bd909deccee8",
@@ -32010,7 +32010,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "a213dfca85b7dbb0e7f982015922b73f51e5caa9",
@@ -32032,7 +32032,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "679191810fc962e282b606622c90355f2e6f58ad",
@@ -32054,7 +32054,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "urllib3/urllib3",
     "base_commit": "9996e0fbf90b77083ad3c73737a6c6395703faa9",
@@ -32076,7 +32076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "apify/crawlee-python",
     "base_commit": "cf092e6424bbb0780f9fda3f74c7e47c07bbd562",
@@ -32098,7 +32098,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "dc443d5d9deb574ee931ed760a6225d0337a1db9",
@@ -32121,7 +32121,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "8241059c14f99ad750ae3ac0de6a4795bf990f61",
@@ -32143,7 +32143,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "690a1e423015289fa4373d045f7546b270bf7e4f",
@@ -32166,7 +32166,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "simonw/llm",
     "base_commit": "70092f2e78eab225cca5e8486d8456d91ea3ead7",
@@ -32188,7 +32188,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "3483d81fbed1f395d00b636b5043b0e9e80ca853",
@@ -32211,7 +32211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Pyomo/pyomo",
     "base_commit": "457f436bf7aecfde8f57b7f88b62ca800bdd0264",
@@ -32233,7 +32233,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dbt-labs/dbt-core",
     "base_commit": "da6f0a1bd7f1de30fe5b211b6be79cde71df30d0",
@@ -32255,7 +32255,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Pyomo/pyomo",
     "base_commit": "18def9506eb83c00670d4d20ee5aecb03d2fa0ec",
@@ -32277,7 +32277,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "579763058031bc637c4c51fcdfb9201a1fce35a1",
@@ -32300,7 +32300,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "eventlet/eventlet",
     "base_commit": "8e81dd9bc6dbfcecb0dccea7dc1f19b453042bd4",
@@ -32322,7 +32322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "ed80f698e987d5709a1360bb1899a603a81bb59b",
@@ -32345,7 +32345,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytorch/torchtitan",
     "base_commit": "ed2bbc07dda35ce26187bb0d743115381e884b35",
@@ -32368,7 +32368,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "graphistry/pygraphistry",
     "base_commit": "3da7135397ece851d19af9af8b09e98d0bb89f33",
@@ -32390,7 +32390,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "a282bf021545be3411d0562f1e1a02ffcd63318e",
@@ -32412,7 +32412,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fsspec/filesystem_spec",
     "base_commit": "26f1ea75351e39a80b29b27bea792351f3e8da9f",
@@ -32434,7 +32434,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyca/cryptography",
     "base_commit": "d58244efd6d88895fe7d4c0cafab544015a386af",
@@ -32456,7 +32456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Azure/azure-sdk-for-python",
     "base_commit": "9712d82ba07e6d8987ba052896fbdb66f13ba0ef",
@@ -32478,7 +32478,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dpkp/kafka-python",
     "base_commit": "26fbd2eed37224a6815cf61f4f302bf060945576",
@@ -32501,7 +32501,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mesonbuild/meson",
     "base_commit": "5463c644c86167fc8b4c6a9c389aaa6bd8b116ec",
@@ -32524,7 +32524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "piskvorky/smart_open",
     "base_commit": "a1a311099bf3b2b43233f3c616285da9448600ff",
@@ -32547,7 +32547,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dbcli/mycli",
     "base_commit": "aea28a4516b6594b593fbd024f7547ae67793a64",
@@ -32569,7 +32569,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "1f339c035aaafd618ee3f78b638d0929b2f3e470",
@@ -32592,7 +32592,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "AgentOps-AI/agentops",
     "base_commit": "3145b2ce6cc1c86b031cd5105758e98d7d2a8cf1",
@@ -32614,7 +32614,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pvlib/pvlib-python",
     "base_commit": "216386ef2f2fcdcaf1b3ecb5913abdf54e9eabaf",
@@ -32637,7 +32637,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "38d7b961253f372ea61255a357267183c1dbda41",
@@ -32659,7 +32659,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7c33f5b9584beeaa274cef7dd03c5d01c37053ea",
@@ -32682,7 +32682,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-powertools/powertools-lambda-python",
     "base_commit": "b3d59abbf38ea274c4c2d6a2cf85804d03163a4a",
@@ -32704,7 +32704,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mlco2/codecarbon",
     "base_commit": "62bd43400518892c46e0ac29745fc3112bd6c72a",
@@ -32727,7 +32727,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "346b1c064e4e9f0a63c08fda669ac07fefb29fd6",
@@ -32750,7 +32750,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "68233f6ff328f35c7ac26a7efdd325ae1248468b",
@@ -32773,7 +32773,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "2823adf747be78382dcc35c13228d9a7c12e8113",
@@ -32796,7 +32796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapinghub/dateparser",
     "base_commit": "114f5c51935073d75ffb18679316166e7fc360e5",
@@ -32819,7 +32819,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "c27385da78595fc4a47bef689f259317a3739904",
@@ -32841,7 +32841,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/molecule",
     "base_commit": "fd3fae0dfc23c70abca9b548a28be71097d2dcf6",
@@ -32863,7 +32863,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "cloudtools/troposphere",
     "base_commit": "a9a2d7c4d5ebdf4beb2cc5a2cbfe5587da69d486",
@@ -32885,7 +32885,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pymodbus-dev/pymodbus",
     "base_commit": "ef44d0f1b645d7e41770616a5fc5446ad664c4ae",
@@ -32907,7 +32907,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "80d08a54a42bc6ba5dce85e42f025dcd916c175d",
@@ -32930,7 +32930,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gitpython-developers/GitPython",
     "base_commit": "c8ebc8be50e5fcf5ae2334713a054b61efbe0aaa",
@@ -32953,7 +32953,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "7eb6ea3f47a7d749d2ed9a1b6a2bca4c89399c42",
@@ -32976,7 +32976,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "15571205e3d2c6327aa5c4294725398ea227e25b",
@@ -32998,7 +32998,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MervinPraison/PraisonAI",
     "base_commit": "bb9187367e1f0b63434d478af6395874da3e197c",
@@ -33020,7 +33020,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "1914c9626121c61cd8f9bae1ed1e4a294ba7b093",
@@ -33042,7 +33042,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "f2caa70a95f21c7cf661762b62b030eec231d5e8",
@@ -33064,7 +33064,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "6d44f2384287178577a1a05e13e585fe34589be6",
@@ -33087,7 +33087,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7dd077d69c622553e039d754c4a1d5a90e755a95",
@@ -33109,7 +33109,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "1d893a90a0f7fb572ffb67361b93d9d34433f245",
@@ -33132,7 +33132,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "traceloop/openllmetry",
     "base_commit": "bfa7b38b494988133dea49c89c0f72e68ab142a9",
@@ -33154,7 +33154,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "theskumar/python-dotenv",
     "base_commit": "01f899733de664cda0550207067eb36a1795062f",
@@ -33177,7 +33177,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "01e919a56be1bb4eedba70f221c0a22486074fc2",
@@ -33199,7 +33199,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "cf876705e4dbe54473cb0870406dc786e8966f66",
@@ -33222,7 +33222,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "TorchIO-project/torchio",
     "base_commit": "66562b510f72989cc3e7dd7afa182e838f80899b",
@@ -33244,7 +33244,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "apify/crawlee-python",
     "base_commit": "aeb06dc9679ae317ff072c4280f8f47d69f7afbf",
@@ -33267,7 +33267,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "py-pdf/pypdf",
     "base_commit": "487a9cbbf6479fbfa337a28f0e0acf17a2f042d1",
@@ -33289,7 +33289,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "9674ebc8ad5ad00285a4b4720b01051c2f35d958",
@@ -33311,7 +33311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "AgentOps-AI/agentops",
     "base_commit": "0267c6f3b776910acbd01be8c8418527da7a85c5",
@@ -33333,7 +33333,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mesonbuild/meson",
     "base_commit": "fde514ccb07f2fd955ac53e5e46e8c295b70f6ba",
@@ -33355,7 +33355,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "09e0de72e604edc4035d1a3fd8512772f91eee95",
@@ -33377,7 +33377,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "156e6c4b236fada0ba236f07365ab41d538264d7",
@@ -33399,7 +33399,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "b914077fcf1f59bfaa353accae260ef781fc6deb",
@@ -33422,7 +33422,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "a9674548e487afbb7c9a6e05bacadf758ff1dfc8",
@@ -33445,7 +33445,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "certbot/certbot",
     "base_commit": "0075104805e2e4fd9cf0e6ec69d80ab203e03655",
@@ -33467,7 +33467,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "TobikoData/sqlmesh",
     "base_commit": "f8005292a446e92f2bd2874dfbe7804858d4387d",
@@ -33489,7 +33489,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "slackapi/python-slack-sdk",
     "base_commit": "2f75504e9761ea3b7a5f934c542701c1247e8b7a",
@@ -33512,7 +33512,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "AgentOps-AI/agentops",
     "base_commit": "8705cdd5a933823297539b9b2cb0102afa333cd0",
@@ -33534,7 +33534,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hynek/structlog",
     "base_commit": "de3dfc8dce7c31c73064db5fdee7322f2b5f112b",
@@ -33557,7 +33557,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "4c216de113e58126d8a8e25b5f4bdc643aeaea70",
@@ -33579,7 +33579,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "d0869457b1b34b38229aa7203463ad1de201ce59",
@@ -33601,7 +33601,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "commaai/opendbc",
     "base_commit": "fc84c6602f90ad6f64d750fe2d6aaed838eda92b",
@@ -33623,7 +33623,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "py-pdf/pypdf",
     "base_commit": "e314629aa84ccba3f7a185e31b0b6d631759e00f",
@@ -33645,7 +33645,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "7dd077d69c622553e039d754c4a1d5a90e755a95",
@@ -33668,7 +33668,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "py-pdf/pypdf",
     "base_commit": "5f84a8b89c02e5365ea6c5b90aaa61ecdab3a563",
@@ -33690,7 +33690,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "HypothesisWorks/hypothesis",
     "base_commit": "8b0a35be9830a3c6af00860eba0518befde374ad",
@@ -33712,7 +33712,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mikedh/trimesh",
     "base_commit": "a45d8a80abd53cb2ba568637f15721f2b516a0b1",
@@ -33734,7 +33734,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "29297c4b52f0c0dcbc8c97309ef86a5c2c2bf874",
@@ -33757,7 +33757,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "ee458799cdb8c95864a0331bd945b4bb11337db9",
@@ -33779,7 +33779,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/lighteval",
     "base_commit": "317cb5046640c2f92d12d99a6e07788c5e7130dc",
@@ -33801,7 +33801,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "48f347efa674992d9904262252db2d1b135ed417",
@@ -33824,7 +33824,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dynaconf/dynaconf",
     "base_commit": "82a3f61d1798a0048a2af76d5ea747d116765b62",
@@ -33846,7 +33846,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "6dcfa9d94bff3d672b59a57e98b1d94ed624b02a",
@@ -33868,7 +33868,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "3ded7a6266514c1569452b0e26bcd4e75c1ee6db",
@@ -33891,7 +33891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "1364f4408e8e0d8bec1d6ac8337f68b3b888a4a7",
@@ -33914,7 +33914,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdfminer/pdfminer.six",
     "base_commit": "2eb6e4f7a2bcc99c8bb35935f84394d611ead222",
@@ -33936,7 +33936,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "0f2478333fa1f9f586a854085a1528e49227bd8b",
@@ -33959,7 +33959,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "9ea20d5f475adec43de2ba5db4aef7d160e09240",
@@ -33982,7 +33982,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "40bfa8654e9f110ec59a9284e19d8add4e72e613",
@@ -34005,7 +34005,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-telegram-bot/python-telegram-bot",
     "base_commit": "89556d02e36f3a9647cf480fe117647b5749f4be",
@@ -34028,7 +34028,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "6bf9c969a278225b0a43c61fcfda0d4d4d78a169",
@@ -34051,7 +34051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-poetry/poetry",
     "base_commit": "d8ef1d1b163ab29b2754859b7b7076e294b90fe0",
@@ -34074,7 +34074,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "7ed917be1c3ec063210d3d09d69d2950e408bd16",
@@ -34096,7 +34096,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "0f0d54799d4a30b6ed8821dcd79f1703cef3a225",
@@ -34119,7 +34119,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "TorchIO-project/torchio",
     "base_commit": "6482baebfec4c57a13361b2d7ca802a677a3b94d",
@@ -34141,7 +34141,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "AgentOps-AI/agentops",
     "base_commit": "891044977f7aeb3d4c9bcfd68f179083da538137",
@@ -34163,7 +34163,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Azure/azure-sdk-for-python",
     "base_commit": "4a3aba24e4d29e3923bf962363289a6d9bccd1fd",
@@ -34185,7 +34185,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hardbyte/python-can",
     "base_commit": "2b1f6f6d04fe3585dbd5b093e2fe52637378b624",
@@ -34208,7 +34208,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fsspec/filesystem_spec",
     "base_commit": "353ba73310f5f7ebe9c98c7c4251a0c987ca3231",
@@ -34230,7 +34230,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "ecdff785f79f4bca04bcbfcf055e61d892126bf5",
@@ -34252,7 +34252,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "8e57c919f45e57f6b9199aaae415d423ad033c5d",
@@ -34274,7 +34274,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "a68a9f3ef87f1fe8c51f36110a6f166302ed550a",
@@ -34296,7 +34296,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "e3f9da13d0df40b5898e480c725ee329ca175858",
@@ -34319,7 +34319,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "e9be1898ca185de61c8b29569bb307a2a1e22166",
@@ -34342,7 +34342,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "run-llama/llama_deploy",
     "base_commit": "4f540e85fe2eb95927b4bea712c0892af2959254",
@@ -34365,7 +34365,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mesonbuild/meson",
     "base_commit": "7f908d909ea6874af0512e2258777f5cd42be790",
@@ -34388,7 +34388,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "dff78057170e1dc42e09480c2a2829a01854ee02",
@@ -34410,7 +34410,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "2de14bb19826da8d42bf8ad698577849fcd6529c",
@@ -34433,7 +34433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "encode/django-rest-framework",
     "base_commit": "33d59fefaa5af04f4bed9312239eb1e5e6def2a2",
@@ -34456,7 +34456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Lightning-AI/LitServe",
     "base_commit": "1ca73c562134f24f31ae4d347a9b5cfdd0bfb7cc",
@@ -34478,7 +34478,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "facelessuser/pymdown-extensions",
     "base_commit": "fbf4bf22da3bc864f24b4ee6a2c05b145fb6c304",
@@ -34500,7 +34500,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "AgentOps-AI/agentops",
     "base_commit": "85a20412062d08e6a3902aaa81d4b36d8094158e",
@@ -34522,7 +34522,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dpkp/kafka-python",
     "base_commit": "48dd596462be5fc7cda004c85b26db823c184a39",
@@ -34545,7 +34545,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "d50b353e55de9ff6364a20cc49fc2458d2b1808e",
@@ -34567,7 +34567,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "67a8f1249be45422662d9e661bb558a9adde5e8c",
@@ -34590,7 +34590,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "1b8f958365637bd1859ee75cc8373658dea15f9a",
@@ -34612,7 +34612,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "44e015c9597dd4260d0be64a2d7b602af2d4e44f",
@@ -34635,7 +34635,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Tuxemon/Tuxemon",
     "base_commit": "56f846427f712564814f00217ebb35a3885569ce",
@@ -34657,7 +34657,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "86e2822989b555778505c847fe92cc11e04cb853",
@@ -34680,7 +34680,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "b05b0739ef1be47f242ecd1685c3f4a6defcee9e",
@@ -34702,7 +34702,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "589adce8a799c2afd2e819dfc0730d0bdb03a145",
@@ -34725,7 +34725,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Pyomo/pyomo",
     "base_commit": "dc503c2835ea2e41569b1a119caedb248ae2939d",
@@ -34748,7 +34748,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "b1a173cdf7d3ce38ff287e78897d26dc98f52b26",
@@ -34771,7 +34771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/twine",
     "base_commit": "4b6c50bf858604df5cab98f15c2c691eb3bf9dfe",
@@ -34794,7 +34794,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "praw-dev/praw",
     "base_commit": "a580ebc7493ebb964a9f0fba08f74f5ea9fec132",
@@ -34816,7 +34816,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/smolagents",
     "base_commit": "ba871cd2a601a1dc0c69a82f322efb7d1eded6fd",
@@ -34838,7 +34838,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "0886c0e92666b3fc7625e371692330ffc2c33bef",
@@ -34860,7 +34860,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/black",
     "base_commit": "24e4cb20ab03c20af390fec7303207af2a4a09e8",
@@ -34882,7 +34882,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "bd0c0ce80d581281cf14e0d93099f5c1a5f50b5b",
@@ -34905,7 +34905,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "5260e3f5197750585b6d548a3396a540d3910c76",
@@ -34927,7 +34927,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/pipx",
     "base_commit": "e6ae882bf36e230e107afb7e4b2f41bf1496afbb",
@@ -34950,7 +34950,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "e4ec979a3d76f3375637f3a06bb92d406a36a31e",
@@ -34972,7 +34972,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "simonw/llm",
     "base_commit": "e6dcd414a5c0f417fad020a79b38073fbad8ac9a",
@@ -34994,7 +34994,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "c4d941f67174e0416ca4b8c0731dfec1eefcbc5a",
@@ -35016,7 +35016,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "77481a6e36fa7fa6b8530e9a300af840867e4df4",
@@ -35039,7 +35039,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "tox-dev/tox",
     "base_commit": "957f2f8a35f9519a3b01327888fac2e01f45d066",
@@ -35061,7 +35061,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pynamodb/PynamoDB",
     "base_commit": "f0bc9171f95ee9a74c32b1bedec762e2012bd8f2",
@@ -35083,7 +35083,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "d98dd975ffea68a8af73e4447031a0b01dc036b8",
@@ -35105,7 +35105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "base_commit": "6be86761d55688fccfc7aec80de615d324cce275",
@@ -35128,7 +35128,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "1c881a3e5fb2699067aa9f5ac687b881dcaeab5e",
@@ -35151,7 +35151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-powertools/powertools-lambda-python",
     "base_commit": "82e7fd52201d7c8d6735048e65579a56fdab41d1",
@@ -35173,7 +35173,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Lightning-AI/LitServe",
     "base_commit": "7672379f00a145e9a7225744c0533fa8707d9845",
@@ -35195,7 +35195,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "google/adk-python",
     "base_commit": "675faefc670b5cd41991939fe0fc604df331111a",
@@ -35218,7 +35218,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "677204238c2a56bd09ff1cef34d9c4ff919c0e12",
@@ -35241,7 +35241,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "5b05e80d8b558c7af6dd163a00150d4fa2d536fb",
@@ -35264,7 +35264,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "81c681ba2215b6436a3088621faf99bf7f1ccf00",
@@ -35287,7 +35287,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "fddba5412e9b2276390540dc61ba5c7f829269f0",
@@ -35310,7 +35310,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pymodbus-dev/pymodbus",
     "base_commit": "bc1404e0731ae0fbcc6d8778c0c2d8eda299885b",
@@ -35333,7 +35333,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "94a91d3292e0145aa1401687a6f42939aecb2568",
@@ -35355,7 +35355,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "6ecdad60202ead5f1c27c0e8aaa18030bc09766b",
@@ -35377,7 +35377,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "5b6bec62458db536ee6a52f01be3855dfec44e37",
@@ -35399,7 +35399,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "fdaf95ed253c5a72f87924a6b50f8379e2749a23",
@@ -35422,7 +35422,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "lektor/lektor",
     "base_commit": "7a8d506e3d8bda7a8b7ccf583f67c633da1ab4b7",
@@ -35445,7 +35445,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Textualize/textual",
     "base_commit": "0f2478333fa1f9f586a854085a1528e49227bd8b",
@@ -35467,7 +35467,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Flexget/Flexget",
     "base_commit": "dd85272a458a3cf757e3c4824801743a4cb316f5",
@@ -35490,7 +35490,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "5ae9b1d822af51bcbe7e25d217bb4307053a942e",
@@ -35512,7 +35512,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pymodbus-dev/pymodbus",
     "base_commit": "b4cecc36e72c03645178320d516d53a3a58ee092",
@@ -35535,7 +35535,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "e17a094d9229424e7c9ad4ffc508d647e1eba355",
@@ -35558,7 +35558,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "b89cb893a1657a30d9306d2fb0cd9ddeea5467b9",
@@ -35581,7 +35581,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Azure-Samples/azure-search-openai-demo",
     "base_commit": "0c07ba65abaf5aa6a566ad37f9b195cf8676b0c4",
@@ -35603,7 +35603,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/ansible-lint",
     "base_commit": "581df9951ac715a77da45fb9ac579f3ec30a4931",
@@ -35625,7 +35625,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "809e9e02f3c92786dc724107cc763cc74e61fa8b",
@@ -35647,7 +35647,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "e8921f9e7b49c9dbdd00637de5343ad2cc8d794a",
@@ -35669,7 +35669,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "ed6176a8cb51712e0604473add3e053378b0c4b8",
@@ -35692,7 +35692,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "644a20cebc89fcc06dca41099e217d474f2e1aba",
@@ -35715,7 +35715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "celery/kombu",
     "base_commit": "867c243e8acb2b53ca240e5ab388c1582a21ff1c",
@@ -35738,7 +35738,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "104e4cb1bcaea2d420a5685492b51404beee4033",
@@ -35761,7 +35761,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "ed80e0e37c57faac21163a6b54ec5164d20db153",
@@ -35784,7 +35784,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "a7ce4a84706ab0bae1c7e7a5f347ef30e1a9a073",
@@ -35806,7 +35806,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydicom/pydicom",
     "base_commit": "6da2a7301dbd0b67eac9476bf2821ac6111e1d7f",
@@ -35828,7 +35828,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "bb0de9de5e73a4b689783aeff27b7c5f3349b229",
@@ -35851,7 +35851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bridgecrewio/checkov",
     "base_commit": "5766ea27eb13181aa586c83a6970ff482f370778",
@@ -35874,7 +35874,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "4ab34c733805c0553803230be21ae4b42a78d02a",
@@ -35896,7 +35896,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "716e82cf8457ed8ec240e695cf1032a83d244a98",
@@ -35919,7 +35919,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "certbot/certbot",
     "base_commit": "48f34938c6d4aa8c1456602152deba102db3c5a8",
@@ -35942,7 +35942,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "b95676ac7e3e4b5ac086cf5a848d381083037bd4",
@@ -35964,7 +35964,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "022cace6164f2e94563fcaffd9ccb6dc70ca33f4",
@@ -35987,7 +35987,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "a297149a75218330ccd447ba7a6fb4dc5d668a15",
@@ -36009,7 +36009,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Unidata/MetPy",
     "base_commit": "9e8c9ea9080f689540c5ed8afe0eb9a70dc717b3",
@@ -36031,7 +36031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "82791e920f604c310a50dc69d9c0ea3502fdaf58",
@@ -36053,7 +36053,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "streamlink/streamlink",
     "base_commit": "987c4176f5d23efb845a0c0b884eac926e650d47",
@@ -36076,7 +36076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "albumentations-team/albumentations",
     "base_commit": "aa276b16476bbb2d46611e55e9928f59c5c387d0",
@@ -36098,7 +36098,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "alandtse/alexa_media_player",
     "base_commit": "e4a425db50878b40b121e004041ee7a0415dfb9b",
@@ -36120,7 +36120,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "7edd74a20b59d8b61a7349b59056b8706058878b",
@@ -36142,7 +36142,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-guardian/django-guardian",
     "base_commit": "0697e33c6d77b3b9181ebc38382d330cec8580c0",
@@ -36165,7 +36165,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "908ec43cb283abec52c24240d7fa28e77caf44ac",
@@ -36188,7 +36188,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "d04840560a31ede819f4951f49b15e63d55ff23c",
@@ -36210,7 +36210,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "feature-engine/feature_engine",
     "base_commit": "cd3e7f0a2344ce342bf939a9374a95d7138a775f",
@@ -36232,7 +36232,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "441b4871477579fe47fcf9e73440bfa5b735d63d",
@@ -36254,7 +36254,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "llamastack/llama-stack",
     "base_commit": "ac25e35124df747a11de0315a25854ee7bb34dc4",
@@ -36277,7 +36277,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "4616d4f135745400888ab19bfec3838d02f26e9c",
@@ -36300,7 +36300,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "78a7c85f496d36f899f5d73306404786ff8c36b5",
@@ -36322,7 +36322,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keon/algorithms",
     "base_commit": "cad4754bc71742c2d6fcbd3b92ae74834d359844",
@@ -36344,7 +36344,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hgrecco/pint",
     "base_commit": "a0264aa4aa3a74f84930e320b1ca69f13b29609d",
@@ -36366,7 +36366,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "3f24e401fd16069c620c7fff21e897bda7473909",
@@ -36389,7 +36389,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "NVIDIA/garak",
     "base_commit": "4e678599d508694b80764fc76ca04d5773e4ef94",
@@ -36411,7 +36411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/lerobot",
     "base_commit": "378e1f0338749bae1d2d1d50d01e944b8a2d9f55",
@@ -36433,7 +36433,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "39891434b2501e8f961b1009796408d114b1ea11",
@@ -36456,7 +36456,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "10da583f64568a1fdac426c71688dd604d3ff51d",
@@ -36478,7 +36478,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "3784889e5d62513fe4088b2269ad6dc87fc43933",
@@ -36500,7 +36500,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "361473cb5fe29c91d0ee7b4fddc2967115f4f80f",
@@ -36522,7 +36522,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f8d3a82997d48f4f033387d06ec77e78582746f0",
@@ -36544,7 +36544,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "67f9b32352e2d4db54e8f554f1238550d80b6df2",
@@ -36566,7 +36566,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "6879ffd11d9c382782008a515e78765e46c178d6",
@@ -36589,7 +36589,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pdm-project/pdm",
     "base_commit": "b728ef778f4d693a67bd9d11eaab00ad30c6802f",
@@ -36611,7 +36611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "SYSTRAN/faster-whisper",
     "base_commit": "4bd98d5c5bf5dfd52a8fcd8b27c1492a3ec41f57",
@@ -36634,7 +36634,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vacanza/holidays",
     "base_commit": "305b3d6c679682ed6b736e9242e29745664c23c6",
@@ -36657,7 +36657,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Flexget/Flexget",
     "base_commit": "0a4a69862cb008bea7a6677d52306b25638a805e",
@@ -36679,7 +36679,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ibis-project/ibis",
     "base_commit": "8641087cbfdb847bf5f1e9e3fd920be55bf659c7",
@@ -36702,7 +36702,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vacanza/holidays",
     "base_commit": "5be50a51942ff918449d62b025a9db006ab4f887",
@@ -36725,7 +36725,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/molecule",
     "base_commit": "e5e165a6c94d58433d76282dee7df25a118b922f",
@@ -36747,7 +36747,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "4b6c17531eecdef5e9ebf45584cca45ed0cbb57b",
@@ -36769,7 +36769,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-guardian/django-guardian",
     "base_commit": "0697e33c6d77b3b9181ebc38382d330cec8580c0",
@@ -36791,7 +36791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "848115c65edb98fe600d71cb398f8a5e4c874f76",
@@ -36814,7 +36814,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/huggingface_hub",
     "base_commit": "73b8e36ce316ecc1f30aa0d2212d2429b2572339",
@@ -36836,7 +36836,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "90f66b77008a5d4876a83095feae29207163d11e",
@@ -36859,7 +36859,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "NewFuture/DDNS",
     "base_commit": "485e6a3e26c5aab9c6c9a7287efd24e00c9ee159",
@@ -36882,7 +36882,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "aca8ebd4d7f0e4da249e7873d359fb730e709ddd",
@@ -36905,7 +36905,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MDAnalysis/mdanalysis",
     "base_commit": "d412c9a9a56312c1bd4e33e6dd3afc4cec7783ca",
@@ -36927,7 +36927,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "1f2dc816faa6b567fd5abecf83c959d4735494a1",
@@ -36949,7 +36949,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "73efc82d92951c5245ff25c824f29a16d040be7b",
@@ -36971,7 +36971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spulec/freezegun",
     "base_commit": "5dff43d7fd04a2e10101447d835d85ca835ea129",
@@ -36993,7 +36993,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "e027bc6a872d71c625de1d037b49e643a915e5d9",
@@ -37015,7 +37015,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "google/adk-python",
     "base_commit": "51be7a899ca313d7189b019bb4f603e124c79a86",
@@ -37037,7 +37037,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "4d0c438d617e49b77d68cd98208f7b2d371a1381",
@@ -37060,7 +37060,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "396e71f30cda43e82c302969860880e9f2e22ec7",
@@ -37082,7 +37082,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "6184e898b722d484e25621330d9a5d9ff5294800",
@@ -37104,7 +37104,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "braindecode/braindecode",
     "base_commit": "d94b12403968b3054b7afc46a61fa5e41201c249",
@@ -37126,7 +37126,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "c3d1176a69599b2080acfaeedf7a5be1b4bd9715",
@@ -37148,7 +37148,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "50038d1e70cc673989daf209df211e53ca41d7ed",
@@ -37171,7 +37171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "4c91314307e9e13a4cce20f4f29a9c86e4c3fd3c",
@@ -37193,7 +37193,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "4ed144a36663a76194afa216ec2b40f5791951f9",
@@ -37216,7 +37216,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/black",
     "base_commit": "bbc36ea205292e213b0c9a448f630d19726605e4",
@@ -37239,7 +37239,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "dff0548d1381481897839d9dd5d0cd03db5adf93",
@@ -37261,7 +37261,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/huggingface_hub",
     "base_commit": "d23abb3030d786e0db46d91561c024bd692555af",
@@ -37283,7 +37283,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "authlib/authlib",
     "base_commit": "731f618d0fb1d24a512e52179c07cc5f1591e68c",
@@ -37306,7 +37306,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "4275fed8c4486093801aff884ec7b76f2db694d8",
@@ -37328,7 +37328,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "commaai/opendbc",
     "base_commit": "f0a8cc2cce91ce08b37e9c13e5b81a4bb32745ff",
@@ -37350,7 +37350,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "QuantEcon/QuantEcon.py",
     "base_commit": "34f4a47a466ca3bd50c040a6f4e089c4f1ecfcd1",
@@ -37373,7 +37373,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "4445c87bf4a1ea8462880ab2ce7d1c553822f67b",
@@ -37396,7 +37396,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "keephq/keep",
     "base_commit": "33eddb2ba8a950a0abb4b4d21dfc3cac00fb6d20",
@@ -37419,7 +37419,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "NVIDIA/NeMo-Guardrails",
     "base_commit": "6da80105dbb00d652217908f95bbfc24abd01fd8",
@@ -37442,7 +37442,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "5188c67c6c2e09590b58df01b54edc71bfcbead3",
@@ -37465,7 +37465,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "ec84e8e4e0a648f370d1571319ad2688f04e124a",
@@ -37488,7 +37488,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dbt-labs/dbt-core",
     "base_commit": "70ad9319d2b791a3b89ca167deb23404ae0e9f05",
@@ -37510,7 +37510,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "huggingface/lerobot",
     "base_commit": "8c577525c199642047062225f490eca71906a7c5",
@@ -37532,7 +37532,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "94caa57142c057ce52504cdf239ae0ed3168f9b5",
@@ -37554,7 +37554,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapinghub/dateparser",
     "base_commit": "abf713031793b6be1ef912a820bbe13539474122",
@@ -37576,7 +37576,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "35e69369dc456e47040039b4e55b4b814efa0046",
@@ -37599,7 +37599,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "146a5438fff365f4cb5b813264510cd557176722",
@@ -37622,7 +37622,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "c529ef892c020320e8196628419e175bedca7a05",
@@ -37644,7 +37644,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "41b7ed4f472b7c26cc6cb879e8fda1197b422f49",
@@ -37667,7 +37667,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "75af36804fb595cabd768d2bc3ccf9b64445a014",
@@ -37690,7 +37690,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "b3ff76164479aee977ed29be10fd8411d9c73e5b",
@@ -37712,7 +37712,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-json-api/django-rest-framework-json-api",
     "base_commit": "142c76edadf7bf4d6c6692da307c03355103b1f6",
@@ -37735,7 +37735,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "4bac38807fc7ae6b0ce8b90d31fa5d68874d47a3",
@@ -37757,7 +37757,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/Radicale",
     "base_commit": "cdfee329db2bd65a79d41637b2504d1376a523d2",
@@ -37779,7 +37779,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "33b2b83ce803d19d6a53d6ecc03668967e3d2b9c",
@@ -37801,7 +37801,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyinfra-dev/pyinfra",
     "base_commit": "c557b997646948e904d758ee44fbbd0baccc7198",
@@ -37824,7 +37824,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "lastmile-ai/mcp-agent",
     "base_commit": "4923d94fcb82aa74989193eb67d21f3c23e106a1",
@@ -37846,7 +37846,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "e8ab0ba46ba4d7791193af9478d973f91dbd5d25",
@@ -37868,7 +37868,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "coderamp-labs/gitingest",
     "base_commit": "4ee598c406c11cbfd71cf72452f19ba0f1cefc79",
@@ -37890,7 +37890,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "2a0637e5b8874f02782676bbb694ff8621c0321e",
@@ -37912,7 +37912,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "bf70dab2d09b61048a8b720e33efae18281a3313",
@@ -37934,7 +37934,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "29386a0dbba672881f4a729973ebc5fd95417cd3",
@@ -37957,7 +37957,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "33a19f9f55ca41eaf70582228209c259f860737e",
@@ -37979,7 +37979,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "b5bf795b6c537e6d56dea1815c2f6602f436dac8",
@@ -38002,7 +38002,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "quantumlib/Cirq",
     "base_commit": "0e87d095c2f1f983d9b0a60c1ec8fe2493001013",
@@ -38024,7 +38024,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-guardian/django-guardian",
     "base_commit": "0697e33c6d77b3b9181ebc38382d330cec8580c0",
@@ -38046,7 +38046,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "certtools/intelmq",
     "base_commit": "b95f9e6183787818b747c4b604c5e24fd53b12de",
@@ -38068,7 +38068,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "4d75ff42b4306de981be8db127c27d2402af4894",
@@ -38091,7 +38091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-pillow/Pillow",
     "base_commit": "640f55a655f41b9d0216c3017b956a114118895a",
@@ -38114,7 +38114,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/asgiref",
     "base_commit": "f22bea26ff268c26253e827b127be76b61a612cf",
@@ -38136,7 +38136,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hgrecco/pint",
     "base_commit": "db0247017fd9bd2445db13b694d766880b7e3c20",
@@ -38158,7 +38158,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "a90df79c7c7c745bf64de8bb1eb7be240788fcdf",
@@ -38180,7 +38180,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hgrecco/pint",
     "base_commit": "16775fdc99688c4afd7954f51e1d61b9a491ab09",
@@ -38203,7 +38203,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "5de3b5849ed973fa09b0e78fbe2a65f1b3073035",
@@ -38225,7 +38225,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "cbac235320fe91056a0fb6dba74cd8bef7fc21d9",
@@ -38247,7 +38247,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "a005941a565df898bf58c4b45e54866865027992",
@@ -38269,7 +38269,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "celery/celery",
     "base_commit": "da4a80dc449301fde4355153b47af8c42caed37c",
@@ -38292,7 +38292,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vega/altair",
     "base_commit": "3d05d6b0a7c9d0d7afad6e903f903a7d2c03a3d9",
@@ -38315,7 +38315,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dbcli/pgcli",
     "base_commit": "a74eab8d0f76f09894526ab02bb5adc0a913c0c3",
@@ -38337,7 +38337,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pex-tool/pex",
     "base_commit": "409bd8fc4ec695d4ae839b60a27a43bdb5061c2f",
@@ -38359,7 +38359,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "d8733421051db4f05b717ed68f62558b7f104691",
@@ -38381,7 +38381,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "82efd3e7809606497b5c9a1f58e4abdbc7f98330",
@@ -38403,7 +38403,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "259ec1bb98037d8c8b3fe9f45418374152b39c0b",
@@ -38425,7 +38425,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "8ec80c76f34ccb5df0ab197eef597da49d86f029",
@@ -38447,7 +38447,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "9bf744240db61a7257f9f98f0f3285ba3a8feaf6",
@@ -38469,7 +38469,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-pillow/Pillow",
     "base_commit": "d74fdc4b5de5a22b91e82c123292ff7780dd20a4",
@@ -38491,7 +38491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "copier-org/copier",
     "base_commit": "4831f35290d2a6c4ca84f60dbf0e86e7c29bbfa5",
@@ -38514,7 +38514,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "2d851adf9c1a599ac0aa6b68da288853754966cc",
@@ -38536,7 +38536,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "lastmile-ai/mcp-agent",
     "base_commit": "170a1068fd3654de0d3fa8094f1b6e2ffde4ca3f",
@@ -38558,7 +38558,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "typeddjango/django-stubs",
     "base_commit": "14ddbf73ce10f6317d6fbcee1090e29f3a784bda",
@@ -38580,7 +38580,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "b9b1652fd47bb4ea6587505604a0451480f7e6de",
@@ -38602,7 +38602,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "5a786075d8c366ee753c62fa36857589023ed561",
@@ -38624,7 +38624,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "ad062e5c4ef505f0aabe568708a4a8a3c6bbaa2e",
@@ -38647,7 +38647,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gboeing/osmnx",
     "base_commit": "b5538d0182b012fe20da46d682db3b6df43f3f6a",
@@ -38669,7 +38669,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "typeddjango/django-stubs",
     "base_commit": "128deea62d9c6280bb78869f404b74e0c76b54a8",
@@ -38692,7 +38692,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vacanza/holidays",
     "base_commit": "08d72dd5728024e18ab2dabf7afbebd203468841",
@@ -38714,7 +38714,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "0e0fc252b85ceb3d76e07c88b3cf150a182dc883",
@@ -38736,7 +38736,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f4db64523180efc7b484dede494063a7861d56a2",
@@ -38758,7 +38758,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ibis-project/ibis",
     "base_commit": "0f4fd454c49abfb04a82732c23fe9f2675bbd91b",
@@ -38780,7 +38780,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "dottxt-ai/outlines",
     "base_commit": "bc334e630cabc549f743161e1d68e5f975d9fd4d",
@@ -38802,7 +38802,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "c8e7d1dd5af65939d30d88a0fbc6aa2f2c920935",
@@ -38825,7 +38825,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "aedf7777732ad4611ba84813579aeefb05316c78",
@@ -38848,7 +38848,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "5de3b5849ed973fa09b0e78fbe2a65f1b3073035",
@@ -38871,7 +38871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "d3491dc8151d87d46b0b29b859eee0d972292bb0",
@@ -38893,7 +38893,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "traceloop/openllmetry",
     "base_commit": "168236a91d85638f642ec7e0f3b177baa964286f",
@@ -38915,7 +38915,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "0e1d92ddfd23b0f8ec28beceb05bd6f0e7badc90",
@@ -38937,7 +38937,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MechanicalSoup/MechanicalSoup",
     "base_commit": "9261643ef90e83eee2212043763fdefa0e028eea",
@@ -38960,7 +38960,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pgmpy/pgmpy",
     "base_commit": "09efe732416e2f93810d6043c321c5d85433da1a",
@@ -38982,7 +38982,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "d0de78ec0ac45aca420a7b1c19f07cbc4bbb3f50",
@@ -39004,7 +39004,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "8cd992ca307426c9adf14ac58ea5104e3ce284ed",
@@ -39027,7 +39027,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/ansible-lint",
     "base_commit": "4a73fdc2bda100a79b317aa9ab12715494e10658",
@@ -39049,7 +39049,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "da482fdee1560de668f9ada9ecf764cb13c8548b",
@@ -39072,7 +39072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "3b9b1ae802dd34676b34fe408f64dba35c9c6604",
@@ -39094,7 +39094,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyinfra-dev/pyinfra",
     "base_commit": "c557b997646948e904d758ee44fbbd0baccc7198",
@@ -39117,7 +39117,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "947590d8f4fdeb01dae9277137b2a1314f9ccf2a",
@@ -39140,7 +39140,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-attrs/attrs",
     "base_commit": "af349876f4fb5df2b71a3f4878239b775bc89230",
@@ -39162,7 +39162,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "dc6de8106b1537beeaa1374f6706e48de13993a3",
@@ -39184,7 +39184,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "1460cef36a6e15915af6a2aa57f3384cc05693bb",
@@ -39206,7 +39206,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "0943f8749689c8e6913ba142d4cd750724c4a085",
@@ -39228,7 +39228,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "f4513c503371e5c5c6ba7ac27603bcc7cb0b89ff",
@@ -39250,7 +39250,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "rthalley/dnspython",
     "base_commit": "97ea7aa691f57afaa152cbf786c05742927fa9f5",
@@ -39272,7 +39272,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/black",
     "base_commit": "b085473cc65da4fe76bbd6b1723ea76897e5e40b",
@@ -39295,7 +39295,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "23867233a374a461d9f2a979c9bfc66538d7aaf2",
@@ -39317,7 +39317,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "f20aa40f56ec374841dfe6e4f3d6118c8e32fb2b",
@@ -39339,7 +39339,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "89ea045335200022a08aefa933beaa9b4c73e10d",
@@ -39361,7 +39361,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "a3eb219fb9a1c4d700b897ebd5e0ba95d2846c35",
@@ -39383,7 +39383,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "QuantEcon/QuantEcon.py",
     "base_commit": "c8489d081506c735ea5165dfbbe9b85095c2a9de",
@@ -39405,7 +39405,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "dcdc6aef0470ac5c013c6c29541b308ad34a6ebf",
@@ -39427,7 +39427,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "23a82f328f4c3b91b168f786a350e8b2d592a4df",
@@ -39450,7 +39450,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "5c0d0551c877e931557a4cab4ce6aa83ac262c68",
@@ -39473,7 +39473,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "6259dc46e9c07fe79e2bc7f21506e8a8105f4634",
@@ -39496,7 +39496,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astronomer/dag-factory",
     "base_commit": "ae69f1e5ce41510137e25924d7cd393c1487031f",
@@ -39519,7 +39519,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "ad948680afaefee8cf530052807e2367db3826b3",
@@ -39542,7 +39542,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "edc9ee7e143c5f8d688151a20b918ef021389b36",
@@ -39564,7 +39564,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "braindecode/braindecode",
     "base_commit": "8a14a339519016cf97a799caf89a4bbfaf6cfeb7",
@@ -39586,7 +39586,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "bc8ad50b2df16d2d18e7b70e5170ca1287984cb5",
@@ -39608,7 +39608,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "nonebot/nonebot2",
     "base_commit": "4d97ce7e155e78ea227f9afaf5c3bcc48401b01a",
@@ -39630,7 +39630,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "arrow-py/arrow",
     "base_commit": "0fe5f065718e5af3ab47903d1bec82d87d202a63",
@@ -39652,7 +39652,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Aider-AI/aider",
     "base_commit": "a785b0f46347f06909abeab65881c52e4625990c",
@@ -39674,7 +39674,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "kedro-org/kedro",
     "base_commit": "94c35e92d00b621f4477967366d04af2be21facd",
@@ -39696,7 +39696,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "6904dcbbdbf211aa2542a1e824db28985a0e914b",
@@ -39718,7 +39718,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vacanza/holidays",
     "base_commit": "ffbc1eb615e83d912dd917cde08cde484e279f0f",
@@ -39741,7 +39741,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "f95be56c4d4425db41ab975d0f2eda90600ced2e",
@@ -39764,7 +39764,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "323274e17478394fdc73f9e47c4eeefded3fa657",
@@ -39786,7 +39786,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "celery/celery",
     "base_commit": "ce7fe8a65f5edf2efca3476bdf94193d17f70192",
@@ -39808,7 +39808,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "64dff4273d7b7140d66fe947b598005be3fd0a9c",
@@ -39831,7 +39831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "google/adk-python",
     "base_commit": "bb4ff2cc3d40452cb9e0b47b83cb9b2b20f3eb45",
@@ -39854,7 +39854,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MDAnalysis/mdanalysis",
     "base_commit": "b4ab7e5f2223ac6cbb40483bb2c0c6c2996bfb6b",
@@ -39876,7 +39876,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-json-api/django-rest-framework-json-api",
     "base_commit": "87108d4d6472b0c76e8c8fff53a6f08a026dd319",
@@ -39898,7 +39898,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "5881f391140fbea444cdcaabaadd0b1b1b6b6550",
@@ -39920,7 +39920,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "fade6c599140253cef47b6e4ac97bdd8667a9e43",
@@ -39942,7 +39942,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "94299c7edbbe39cbb086cff892e3902e27cb2f1d",
@@ -39965,7 +39965,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/black",
     "base_commit": "bdd7fcd9396350b2887e22dec67072db3aeeeaa9",
@@ -39987,7 +39987,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "llamastack/llama-stack",
     "base_commit": "77d2c8e95d95625e506d7ae06105e213b69351d9",
@@ -40009,7 +40009,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "freqtrade/freqtrade",
     "base_commit": "6e38b72601613826de784af810d49aa31aa8e40d",
@@ -40032,7 +40032,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "0f21c8aedb0251c6269934f9543021ee10e9489e",
@@ -40054,7 +40054,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "e6597f44b8fc3dfb4fe5b4c45dfb3b337705cb7c",
@@ -40076,7 +40076,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "cloud-custodian/cloud-custodian",
     "base_commit": "9a38db80b0ad2947e0e6a5dcc67577872f2524bc",
@@ -40098,7 +40098,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "llamastack/llama-stack",
     "base_commit": "9a03526672dd34e65940015d477db9ec6f4532ba",
@@ -40120,7 +40120,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "b2e8b936e057ffc7b0d1505c5703988172041d4b",
@@ -40142,7 +40142,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "b09d37d8326c5d21760aaf10e9ff2eb8a01ebdaa",
@@ -40164,7 +40164,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astronomer/dag-factory",
     "base_commit": "5ed0b48ff4018562d1d2bb0753bc355c3dc96bce",
@@ -40186,7 +40186,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "e8147f2bdcd8899109fe1a9cffc770c436de95dc",
@@ -40209,7 +40209,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Tuxemon/Tuxemon",
     "base_commit": "1431208586118b46e9d7860fd55618f0b117726d",
@@ -40231,7 +40231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "a400b4e963fb140290007835ff7e2872b9d330b9",
@@ -40253,7 +40253,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kinto/kinto",
     "base_commit": "7881aa28abd015ee2d8fc72c606c43b83df9bae2",
@@ -40276,7 +40276,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "vega/altair",
     "base_commit": "8a75faa8f597df667d2b6132734c94ff5bad7483",
@@ -40299,7 +40299,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "8006e22a0813d737b0897702ac5f5bb2469619a4",
@@ -40321,7 +40321,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "c0c12f4ad424e87cca6bf5246786d45150e2ac19",
@@ -40343,7 +40343,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "coderamp-labs/gitingest",
     "base_commit": "84450506c93c8e62ff665d019be3b2db906969a2",
@@ -40365,7 +40365,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "31b7ff0937738b958d1c7cb8ce8ca5373f69364c",
@@ -40387,7 +40387,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jazzband/djangorestframework-simplejwt",
     "base_commit": "930cf85c83333451393cf78b740d576fe8a1dfba",
@@ -40409,7 +40409,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "77bdc9de200a45149c09cbfabfe82de0744d53a7",
@@ -40431,7 +40431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PriorLabs/TabPFN",
     "base_commit": "0ef6e485880fab72912da5d0286f834378943fb2",
@@ -40453,7 +40453,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "3c160d60d6add0401b3ab91f7931a60e94fd52ec",
@@ -40475,7 +40475,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gaphor/gaphor",
     "base_commit": "cc95146ab558d48049b888e1fd79feeb98e62f47",
@@ -40497,7 +40497,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "4d0c438d617e49b77d68cd98208f7b2d371a1381",
@@ -40520,7 +40520,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "b304589a15ddeab55978c4d58670876d4ab1fa3b",
@@ -40542,7 +40542,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "patroni/patroni",
     "base_commit": "e8911304a33cb8f0c6c048d3f8bae717633aca09",
@@ -40564,7 +40564,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "f20aa40f56ec374841dfe6e4f3d6118c8e32fb2b",
@@ -40586,7 +40586,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "ca73078b80438ac290e557efd2a0379f6b1f26b2",
@@ -40609,7 +40609,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "31b7ff0937738b958d1c7cb8ce8ca5373f69364c",
@@ -40631,7 +40631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "4834e7d10c44ba62b9de800bcdaca93b4b981426",
@@ -40653,7 +40653,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "c0b01ceb1fe2e6243729bee0470059e0d38e9268",
@@ -40675,7 +40675,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "58b6a0663e169df556d5eb3dfba491fadbe952f0",
@@ -40698,7 +40698,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/black",
     "base_commit": "262ad62ca9f1d1b1537cc95a91643fb781d7c501",
@@ -40720,7 +40720,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "ad948680afaefee8cf530052807e2367db3826b3",
@@ -40743,7 +40743,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "bit-team/backintime",
     "base_commit": "37d5f0468d7ee89fad3685963dcee4de8f2ef144",
@@ -40765,7 +40765,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Lightning-AI/LitServe",
     "base_commit": "e3136bf82214fb3ffa651cdef6c0526195d7c844",
@@ -40787,7 +40787,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "quantumlib/Cirq",
     "base_commit": "6b6a7ff03ba871a1c81bcf492189d42bd67cf899",
@@ -40810,7 +40810,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "1f3f82d245f97632b9bd9ccb63746acad9c87f71",
@@ -40832,7 +40832,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astronomer/dag-factory",
     "base_commit": "f35955f23223f02ab7f5702468092470259ee320",
@@ -40855,7 +40855,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "fc64884819b37c944a9580c022698c19102a37eb",
@@ -40877,7 +40877,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "ed48e9e965d75844427360610f0b45affe8c735c",
@@ -40899,7 +40899,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "privacyidea/privacyidea",
     "base_commit": "32fb48302e5f47da846519722e57421620026d09",
@@ -40922,7 +40922,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "f11870b212fbfad34f1e83de29a65d4475e705f4",
@@ -40944,7 +40944,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "667009ab8a6553435ba09712e1d94f08d7cf2726",
@@ -40967,7 +40967,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Unidata/MetPy",
     "base_commit": "cb85c10c0e4e44f99a21fbd5c607ddfda58d4bdf",
@@ -40989,7 +40989,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MDAnalysis/mdanalysis",
     "base_commit": "91146c581eee22aa6508a4d45cc271cb4d9d1509",
@@ -41012,7 +41012,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "94b1eb9d6e75cf12dccffc04f9f96f3bb8921bba",
@@ -41035,7 +41035,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beeware/briefcase",
     "base_commit": "f71ceec46eaf94cfff525fe80166a8dc739b5f32",
@@ -41057,7 +41057,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyinstaller/pyinstaller",
     "base_commit": "bfa2f51c35d3fb24fe6f38234ad435b8fb7e46dc",
@@ -41079,7 +41079,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sissbruecker/linkding",
     "base_commit": "5cc8c9c010175e9f438d9c1c31117b7ce735a46a",
@@ -41102,7 +41102,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "36e8a1ee85ca0ab4195a486451ca7d72153e2e00",
@@ -41124,7 +41124,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "dc478bf884d4637bf470975f0ada4218dd1cc1f5",
@@ -41146,7 +41146,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "fed8c20760e90e80a21e5b4df102ad01778e76b1",
@@ -41169,7 +41169,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "0cb018ab1e96a748969b2231c33bf651dd7483a8",
@@ -41191,7 +41191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "cacaa905665a9a3360b23ea6e91d6ddfa1a42fb6",
@@ -41213,7 +41213,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gitpython-developers/GitPython",
     "base_commit": "4d529b71905edae12e4699170f7d9e0a665801b5",
@@ -41236,7 +41236,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Azure-Samples/azure-search-openai-demo",
     "base_commit": "085f9d88f52cd967ed82d443c19060521a588fe9",
@@ -41258,7 +41258,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "116b92bae7b5dbf5e6bd36fd9b0c6804973e5554",
@@ -41280,7 +41280,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spulec/freezegun",
     "base_commit": "2bb47113a5f9f290d26630c92732e58f49557179",
@@ -41303,7 +41303,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "f3df5392f3b49459c6a8ae3bc482ccd1e6beb461",
@@ -41325,7 +41325,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "b84a43ee5732bde7748d54a19f60fd08abe881e1",
@@ -41347,7 +41347,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "conan-io/conan",
     "base_commit": "5ec22cfb4784cfc6c9e09c44d0b11032cc3f155b",
@@ -41369,7 +41369,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "hgrecco/pint",
     "base_commit": "f4aa63eb23a22cedb5f90d7bc8934efba26538c4",
@@ -41391,7 +41391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "4089d82159eed4027fbcde1530c9f959854d10a8",
@@ -41414,7 +41414,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "aws-cloudformation/cfn-lint",
     "base_commit": "11dc6213168d3d56aff2d244e099bf21a80e64e6",
@@ -41436,7 +41436,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MervinPraison/PraisonAI",
     "base_commit": "016f020718dca4e75d876116858febe3d0a2f2a5",
@@ -41458,7 +41458,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "awslabs/mcp",
     "base_commit": "23c52894145564df5559b9c8bb1ea3de1e5d3610",
@@ -41480,7 +41480,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "d3eb7b5abf7e9c5af5c3304977597a47234c2ae6",
@@ -41502,7 +41502,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "35e69369dc456e47040039b4e55b4b814efa0046",
@@ -41524,7 +41524,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "google/adk-python",
     "base_commit": "a2b7909fc36e7786a721f28e2bf75a1e86ad230d",
@@ -41546,7 +41546,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "geopandas/geopandas",
     "base_commit": "a266d565b605ec3e7ccb86b52e7231ebcc7778c0",
@@ -41568,7 +41568,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "ecf18d91bcdba40f445f0b8cf5844ddbefc26889",
@@ -41590,7 +41590,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pipecat-ai/pipecat",
     "base_commit": "78cdefd1912997ba31cf3406f2ecb3fe67bbc5df",
@@ -41612,7 +41612,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ag2ai/faststream",
     "base_commit": "8018bba64d576f854bfeb6c6d7e474df19eef48d",
@@ -41635,7 +41635,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "c06726d2bf7e32ccf7a896dea7077332786b99db",
@@ -41658,7 +41658,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "3ffae8f8046aef20e559e19c21a5f9464a2c89ca",
@@ -41680,7 +41680,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-poetry/poetry",
     "base_commit": "beadd424cd60127136f7aa7e54b113cbf6c23fcc",
@@ -41702,7 +41702,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fonttools/fonttools",
     "base_commit": "7b50bde2ee3ac6c9e1936ea8c5351ffd84e4606c",
@@ -41725,7 +41725,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kozea/WeasyPrint",
     "base_commit": "121e6b37f9ea8eb24ea1061b517cb1c783a8b588",
@@ -41747,7 +41747,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "1b2ec16eee5070f117d401420b8cf1ce44de9e60",
@@ -41769,7 +41769,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "celery/celery",
     "base_commit": "166f705adcae57a43423b0ae7286ab828b55b244",
@@ -41791,7 +41791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "stanfordnlp/dspy",
     "base_commit": "2e60022f9a524dfd406edc04444114f835d017a0",
@@ -41813,7 +41813,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "95dafdc20b0988dfcbfc06cfe92c1d076c82f2c4",
@@ -41836,7 +41836,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "falconry/falcon",
     "base_commit": "50b652584825883132e1c2eb98a6e3e12cf4e5ff",
@@ -41859,7 +41859,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "10da583f64568a1fdac426c71688dd604d3ff51d",
@@ -41882,7 +41882,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networkx/networkx",
     "base_commit": "36e8a1ee85ca0ab4195a486451ca7d72153e2e00",
@@ -41904,7 +41904,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gboeing/osmnx",
     "base_commit": "efcc3a77db83c0da40c8fd4680182471cd505fad",
@@ -41927,7 +41927,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "docling-project/docling",
     "base_commit": "8820b5558ba18306cfa7a2def3f04cbd480fef94",
@@ -41950,7 +41950,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "e7dcd88882eeb916a077a25847d3a28f76818096",
@@ -41972,7 +41972,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "b16592765f251c93de8acf535cddc9af9a310801",
@@ -41994,7 +41994,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "c7c7ba69fbe093b0889228119964f357653e6973",
@@ -42017,7 +42017,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Kinto/kinto",
     "base_commit": "f4da0160f7eec83b5571548954ab64c59d63695a",
@@ -42039,7 +42039,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "2126828b5cb6291f47ca15d56c0e870950f17536",
@@ -42061,7 +42061,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "trailofbits/algo",
     "base_commit": "0ddd994ff489a39a80d91ee7194618f744a807c1",
@@ -42083,7 +42083,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Lightning-AI/LitServe",
     "base_commit": "0ededb428d283861b18a589832eccd74f42fa8e2",
@@ -42106,7 +42106,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "d09138688a63d11ae96d78e912b7e73be5d6fcc5",
@@ -42128,7 +42128,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-babel/babel",
     "base_commit": "d7a7589a6cee3aa4c68de60f4d69a9cdad50a7ff",
@@ -42150,7 +42150,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django-json-api/django-rest-framework-json-api",
     "base_commit": "0394cf91b87f6d488be3da8ef585df325786c73a",
@@ -42173,7 +42173,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "gptme/gptme",
     "base_commit": "e5b4fb97a486ef73b3c2608b06ea99ae93e20d18",
@@ -42195,7 +42195,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sdv-dev/SDV",
     "base_commit": "47f915bf4db31a8f37833129e9f6ad71a5ea627b",
@@ -42218,7 +42218,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "2b75c9e5754b80631c6b3fed80df6d4d38a13935",
@@ -42241,7 +42241,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "quantumlib/Cirq",
     "base_commit": "dc69fa11eda12f7a8abaa4db5af3720538320d49",
@@ -42263,7 +42263,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "HypothesisWorks/hypothesis",
     "base_commit": "dc0ce69011455bca202f3c4efdb04ed9adc104c1",
@@ -42285,7 +42285,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "open-telemetry/opentelemetry-python",
     "base_commit": "cb4e3ba5f329b21084e5f295c6eb3d86d5a29ab3",
@@ -42307,7 +42307,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "af665e759bbba078afef0366a47adc9521eec2f8",
@@ -42329,7 +42329,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "4f1c510510ed5dd76e998d4938781f9b02ddb2ce",
@@ -42351,7 +42351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PriorLabs/TabPFN",
     "base_commit": "85cb0197fb33d2adcd9b98cdcf0762723026b385",
@@ -42373,7 +42373,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "5f3c37d287a4fa882d59161a20f762e9102bc6aa",
@@ -42396,7 +42396,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astronomer/dag-factory",
     "base_commit": "899a2e550de40cbb2a5ce080490b2bb064b7f0f6",
@@ -42419,7 +42419,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "52ce211ec09dca5a30aa3e800e612b0894e4b956",
@@ -42441,7 +42441,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "magic-wormhole/magic-wormhole",
     "base_commit": "3404a35c55e1b18543d9de411209a7d7fd583fc9",
@@ -42463,7 +42463,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "PyPSA/PyPSA",
     "base_commit": "03686184a56007b43f2e4f74d3b2caa1370d4e69",
@@ -42486,7 +42486,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "e30a46fac3f94cd493cb75018c496dd88119fbe5",
@@ -42509,7 +42509,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "spesmilo/electrum",
     "base_commit": "392400295e733e1dd3f0cb14189466e8a76890ef",
@@ -42532,7 +42532,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "deepset-ai/haystack",
     "base_commit": "8bb8b67f8a353d86db92767bd407e27fd858792a",
@@ -42554,7 +42554,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "1f8ff336c84e15e648c5ce7379fc29c523d821a2",
@@ -42576,7 +42576,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "networktocode/ntc-templates",
     "base_commit": "cf876705e4dbe54473cb0870406dc786e8966f66",
@@ -42598,7 +42598,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ipython/ipython",
     "base_commit": "d47970f7097668ec89a47120e14625d44b617d68",
@@ -42620,7 +42620,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "casbin/pycasbin",
     "base_commit": "daf3827732d68d83605675a848c689bb6569a136",
@@ -42643,7 +42643,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Archmonger/django-dbbackup",
     "base_commit": "ced35bd28540ea0630a759b336054b5e4779f765",
@@ -42665,7 +42665,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "koxudaxi/datamodel-code-generator",
     "base_commit": "a34acbfad2043178e14de1a7068a8ec3784caf43",
@@ -42688,7 +42688,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scrapinghub/dateparser",
     "base_commit": "0667cb357185317df55636c34af845e3aca5875d",
@@ -42710,7 +42710,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "Pyomo/pyomo",
     "base_commit": "de14e283810157420ced81a9c077a964c1095633",
@@ -42732,7 +42732,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "beetbox/beets",
     "base_commit": "6c21482b7aa293808f0222472da310c311e03b47",
@@ -42755,7 +42755,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sooperset/mcp-atlassian",
     "base_commit": "aaeb824f782d08b777ea57565c70930f91ede2e4",
@@ -42777,7 +42777,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "9dd778309ea83e357998cad15d9e0b145501145f",
@@ -42800,7 +42800,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pallets/flask",
     "base_commit": "85c5d93cbd049c4bd0679c36fd1ddcae8c37b642",
@@ -42822,7 +42822,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pyinfra-dev/pyinfra",
     "base_commit": "c557b997646948e904d758ee44fbbd0baccc7198",
@@ -42845,7 +42845,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "llamastack/llama-stack",
     "base_commit": "58e164b8bcbe6821b5a735ce52883ff7f27ff426",
@@ -42867,7 +42867,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "3be2628e5b816a614e47f40cabc093296ab8eec0",
@@ -42889,7 +42889,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "certbot/certbot",
     "base_commit": "33d3162c24ee550bc77255f840bb518f8e9776d7",
@@ -42911,7 +42911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python-pillow/Pillow",
     "base_commit": "2b39f7581e9637a7262c070d5cebb12fa70f2c86",
@@ -42934,7 +42934,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "openai/openai-agents-python",
     "base_commit": "db85a6d0310de3bb608555ee6b43bc9579e26e0c",
@@ -42956,7 +42956,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pypa/cibuildwheel",
     "base_commit": "352e01339f0a173aa2a3eb57f01492e341e83865",
@@ -42979,7 +42979,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "fsspec/filesystem_spec",
     "base_commit": "81a5fd53cb17c3c1fffb9661d1563ea2d62b6d71",
@@ -43001,7 +43001,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "oumi-ai/oumi",
     "base_commit": "f3026ae14fbd3ce98d555fab584e567dd7caf0e7",
@@ -43023,7 +43023,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "813f5cdf639099dcad1365202e1819b34dfb52e6",
@@ -43046,7 +43046,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "MDAnalysis/mdanalysis",
     "base_commit": "10eba92d326e57f0c5070d251f9a1ac1d0219ef5",
@@ -43068,7 +43068,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "microsoft/graphrag",
     "base_commit": "e84df28e6429e338595e1b7730be2a89153b6c18",
@@ -43091,7 +43091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "cb0897384d8723815df8ef909a23272ec6d63e9c",
@@ -43113,7 +43113,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "browser-use/browser-use",
     "base_commit": "f5f0ccc4cfe0f279d1920784f01a95e46a6ff02d",
@@ -43136,7 +43136,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "HypothesisWorks/hypothesis",
     "base_commit": "34c02559e8d94dfbbffd07ceee9109505bc550cb",
@@ -43158,7 +43158,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "authlib/authlib",
     "base_commit": "0d03ee9dd758f95853356fa1eea3fbce37109eb0",
@@ -43180,7 +43180,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "abd9424039fd7b1f7da6b5c143a27c5b682371ee",
@@ -43202,7 +43202,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pybamm-team/PyBaMM",
     "base_commit": "1a39a994298a90fbcdd4d5dfea5958428740f150",
@@ -43225,7 +43225,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "octodns/octodns",
     "base_commit": "470df43b5a3631f72378a7d69c0091f2743eb0bc",
@@ -43248,7 +43248,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "python/mypy",
     "base_commit": "5b28b62d9f87ac72e8dd5b65cf2cb9fa84fa4be5",
@@ -43271,7 +43271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "949ad9a81b50a9a2bde027bf8d62b2260307f73b",
@@ -43294,7 +43294,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "a2aproject/a2a-python",
     "base_commit": "a371461c3b77aa9643c3a3378bb4405356863bff",
@@ -43316,7 +43316,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "joke2k/faker",
     "base_commit": "73efc82d92951c5245ff25c824f29a16d040be7b",
@@ -43338,7 +43338,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mlco2/codecarbon",
     "base_commit": "e5489e2af4a7835118379fedb72c1c37e60b171f",
@@ -43360,7 +43360,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "BerriAI/litellm",
     "base_commit": "4fc4304f37f3254e4412e125c4a5938d71c3d1e2",
@@ -43382,7 +43382,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "base_commit": "011d12f1d6f67f1ae66cb8860b323cc75409d26b",
@@ -43404,7 +43404,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "ansible/ansible-lint",
     "base_commit": "f16e1ce1a2ab8f94f03121ea4e499ba042677d2a",
@@ -43426,7 +43426,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "jlowin/fastmcp",
     "base_commit": "19a4dd85d43d01f705227c4c96fc3c3832b859ef",
@@ -43448,7 +43448,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "iterative/dvc",
     "base_commit": "76cfe929608017d9d2f760eca26259b26ea10368",
@@ -43470,7 +43470,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "IBM/mcp-context-forge",
     "base_commit": "dd7092ead2f5ffed0ffc57076540ad086f470bf2",

--- a/cubes/swebench-verified-cube/scripts/create_task_metadata.py
+++ b/cubes/swebench-verified-cube/scripts/create_task_metadata.py
@@ -31,7 +31,7 @@ from typing import Any
 # Make the package importable when executed from the cube root without venv activation.
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from cube.container import ContainerConfig
+from cube.resource import ContainerConfig
 from datasets import load_dataset
 
 from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmarkConfig, _DATASET_NAME

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task_metadata.json
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task_metadata.json
@@ -11,7 +11,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -31,7 +31,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -51,7 +51,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -71,7 +71,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "1-4 hours",
@@ -91,7 +91,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -111,7 +111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "1-4 hours",
@@ -131,7 +131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -151,7 +151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -171,7 +171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -191,7 +191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "<15 min fix",
@@ -211,7 +211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -231,7 +231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "1-4 hours",
@@ -251,7 +251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -271,7 +271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -291,7 +291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -311,7 +311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "<15 min fix",
@@ -331,7 +331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "<15 min fix",
@@ -351,7 +351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "<15 min fix",
@@ -371,7 +371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -391,7 +391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -411,7 +411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -431,7 +431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "astropy/astropy",
     "difficulty": "15 min - 1 hour",
@@ -451,7 +451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -471,7 +471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -491,7 +491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -511,7 +511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -531,7 +531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -551,7 +551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -571,7 +571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -591,7 +591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -611,7 +611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -631,7 +631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -651,7 +651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -671,7 +671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -691,7 +691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -711,7 +711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -731,7 +731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -751,7 +751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -771,7 +771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -791,7 +791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -811,7 +811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -831,7 +831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -851,7 +851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -871,7 +871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -891,7 +891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -911,7 +911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -931,7 +931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -951,7 +951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -971,7 +971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -991,7 +991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1011,7 +1011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1031,7 +1031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1051,7 +1051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1071,7 +1071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1091,7 +1091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1111,7 +1111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1131,7 +1131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1151,7 +1151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1171,7 +1171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1191,7 +1191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1211,7 +1211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1231,7 +1231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1251,7 +1251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1271,7 +1271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1291,7 +1291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1311,7 +1311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -1331,7 +1331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1351,7 +1351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1371,7 +1371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1391,7 +1391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1411,7 +1411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1431,7 +1431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1451,7 +1451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1471,7 +1471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1491,7 +1491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1511,7 +1511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1531,7 +1531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1551,7 +1551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1571,7 +1571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1591,7 +1591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1611,7 +1611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1631,7 +1631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -1651,7 +1651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1671,7 +1671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1691,7 +1691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1711,7 +1711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -1731,7 +1731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1751,7 +1751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1771,7 +1771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1791,7 +1791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1811,7 +1811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1831,7 +1831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1851,7 +1851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1871,7 +1871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1891,7 +1891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1911,7 +1911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -1931,7 +1931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1951,7 +1951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1971,7 +1971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -1991,7 +1991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2011,7 +2011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2031,7 +2031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2051,7 +2051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2071,7 +2071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2091,7 +2091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2111,7 +2111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2131,7 +2131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2151,7 +2151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2171,7 +2171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2191,7 +2191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2211,7 +2211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2231,7 +2231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2251,7 +2251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2271,7 +2271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2291,7 +2291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2311,7 +2311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2331,7 +2331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2351,7 +2351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2371,7 +2371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2391,7 +2391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2411,7 +2411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2431,7 +2431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2451,7 +2451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2471,7 +2471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2491,7 +2491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2511,7 +2511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2531,7 +2531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2551,7 +2551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2571,7 +2571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2591,7 +2591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2611,7 +2611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2631,7 +2631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2651,7 +2651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2671,7 +2671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2691,7 +2691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2711,7 +2711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2731,7 +2731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2751,7 +2751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2771,7 +2771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -2791,7 +2791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2811,7 +2811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2831,7 +2831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2851,7 +2851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -2871,7 +2871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2891,7 +2891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2911,7 +2911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2931,7 +2931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2951,7 +2951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2971,7 +2971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -2991,7 +2991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3011,7 +3011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3031,7 +3031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3051,7 +3051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3071,7 +3071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3091,7 +3091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3111,7 +3111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3131,7 +3131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3151,7 +3151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3171,7 +3171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3191,7 +3191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3211,7 +3211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3231,7 +3231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3251,7 +3251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3271,7 +3271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -3291,7 +3291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3311,7 +3311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3331,7 +3331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3351,7 +3351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3371,7 +3371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3391,7 +3391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3411,7 +3411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3431,7 +3431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3451,7 +3451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3471,7 +3471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3491,7 +3491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3511,7 +3511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3531,7 +3531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3551,7 +3551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3571,7 +3571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3591,7 +3591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3611,7 +3611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -3631,7 +3631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3651,7 +3651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3671,7 +3671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -3691,7 +3691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3711,7 +3711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3731,7 +3731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3751,7 +3751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3771,7 +3771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3791,7 +3791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3811,7 +3811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3831,7 +3831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3851,7 +3851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3871,7 +3871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -3891,7 +3891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -3911,7 +3911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3931,7 +3931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3951,7 +3951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3971,7 +3971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -3991,7 +3991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4011,7 +4011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4031,7 +4031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -4051,7 +4051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4071,7 +4071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4091,7 +4091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4111,7 +4111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4131,7 +4131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4151,7 +4151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4171,7 +4171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4191,7 +4191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4211,7 +4211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4231,7 +4231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -4251,7 +4251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4271,7 +4271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4291,7 +4291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4311,7 +4311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4331,7 +4331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4351,7 +4351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4371,7 +4371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4391,7 +4391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4411,7 +4411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4431,7 +4431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4451,7 +4451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4471,7 +4471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -4491,7 +4491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4511,7 +4511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4531,7 +4531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4551,7 +4551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4571,7 +4571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4591,7 +4591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4611,7 +4611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4631,7 +4631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4651,7 +4651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -4671,7 +4671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4691,7 +4691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4711,7 +4711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4731,7 +4731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "1-4 hours",
@@ -4751,7 +4751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4771,7 +4771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4791,7 +4791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4811,7 +4811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4831,7 +4831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4851,7 +4851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4871,7 +4871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4891,7 +4891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4911,7 +4911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4931,7 +4931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4951,7 +4951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -4971,7 +4971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -4991,7 +4991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -5011,7 +5011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -5031,7 +5031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "15 min - 1 hour",
@@ -5051,7 +5051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "django/django",
     "difficulty": "<15 min fix",
@@ -5071,7 +5071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5091,7 +5091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5111,7 +5111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5131,7 +5131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5151,7 +5151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5171,7 +5171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5191,7 +5191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5211,7 +5211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5231,7 +5231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5251,7 +5251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5271,7 +5271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5291,7 +5291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5311,7 +5311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5331,7 +5331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5351,7 +5351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5371,7 +5371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5391,7 +5391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5411,7 +5411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5431,7 +5431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5451,7 +5451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5471,7 +5471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5491,7 +5491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5511,7 +5511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5531,7 +5531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5551,7 +5551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5571,7 +5571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5591,7 +5591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5611,7 +5611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5631,7 +5631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5651,7 +5651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5671,7 +5671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "<15 min fix",
@@ -5691,7 +5691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5711,7 +5711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5731,7 +5731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "matplotlib/matplotlib",
     "difficulty": "15 min - 1 hour",
@@ -5751,7 +5751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mwaskom/seaborn",
     "difficulty": "15 min - 1 hour",
@@ -5771,7 +5771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "mwaskom/seaborn",
     "difficulty": "15 min - 1 hour",
@@ -5791,7 +5791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pallets/flask",
     "difficulty": "<15 min fix",
@@ -5811,7 +5811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5831,7 +5831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5851,7 +5851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5871,7 +5871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5891,7 +5891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5911,7 +5911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "15 min - 1 hour",
@@ -5931,7 +5931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "<15 min fix",
@@ -5951,7 +5951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
     "difficulty": "15 min - 1 hour",
@@ -5971,7 +5971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -5991,7 +5991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6011,7 +6011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6031,7 +6031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6051,7 +6051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6071,7 +6071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "1-4 hours",
@@ -6091,7 +6091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "<15 min fix",
@@ -6111,7 +6111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "<15 min fix",
@@ -6131,7 +6131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "<15 min fix",
@@ -6151,7 +6151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "<15 min fix",
@@ -6171,7 +6171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6191,7 +6191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6211,7 +6211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6231,7 +6231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "<15 min fix",
@@ -6251,7 +6251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6271,7 +6271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6291,7 +6291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6311,7 +6311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6331,7 +6331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": ">4 hours",
@@ -6351,7 +6351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6371,7 +6371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6391,7 +6391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pydata/xarray",
     "difficulty": "15 min - 1 hour",
@@ -6411,7 +6411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "1-4 hours",
@@ -6431,7 +6431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "15 min - 1 hour",
@@ -6451,7 +6451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "15 min - 1 hour",
@@ -6471,7 +6471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "<15 min fix",
@@ -6491,7 +6491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "15 min - 1 hour",
@@ -6511,7 +6511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "15 min - 1 hour",
@@ -6531,7 +6531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "<15 min fix",
@@ -6551,7 +6551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "15 min - 1 hour",
@@ -6571,7 +6571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "<15 min fix",
@@ -6591,7 +6591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pylint-dev/pylint",
     "difficulty": "1-4 hours",
@@ -6611,7 +6611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6631,7 +6631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6651,7 +6651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "1-4 hours",
@@ -6671,7 +6671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6691,7 +6691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6711,7 +6711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "1-4 hours",
@@ -6731,7 +6731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6751,7 +6751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6771,7 +6771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "1-4 hours",
@@ -6791,7 +6791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6811,7 +6811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6831,7 +6831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6851,7 +6851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6871,7 +6871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6891,7 +6891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6911,7 +6911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6931,7 +6931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6951,7 +6951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "<15 min fix",
@@ -6971,7 +6971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "pytest-dev/pytest",
     "difficulty": "15 min - 1 hour",
@@ -6991,7 +6991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7011,7 +7011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7031,7 +7031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7051,7 +7051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7071,7 +7071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7091,7 +7091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7111,7 +7111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7131,7 +7131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7151,7 +7151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7171,7 +7171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7191,7 +7191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7211,7 +7211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7231,7 +7231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7251,7 +7251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7271,7 +7271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7291,7 +7291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7311,7 +7311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7331,7 +7331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7351,7 +7351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7371,7 +7371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7391,7 +7391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7411,7 +7411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7431,7 +7431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7451,7 +7451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7471,7 +7471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "1-4 hours",
@@ -7491,7 +7491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7511,7 +7511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7531,7 +7531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7551,7 +7551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "<15 min fix",
@@ -7571,7 +7571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7591,7 +7591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7611,7 +7611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "scikit-learn/scikit-learn",
     "difficulty": "15 min - 1 hour",
@@ -7631,7 +7631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7651,7 +7651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7671,7 +7671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7691,7 +7691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7711,7 +7711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7731,7 +7731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7751,7 +7751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7771,7 +7771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "1-4 hours",
@@ -7791,7 +7791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7811,7 +7811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7831,7 +7831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7851,7 +7851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": ">4 hours",
@@ -7871,7 +7871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7891,7 +7891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7911,7 +7911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7931,7 +7931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -7951,7 +7951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7971,7 +7971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -7991,7 +7991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8011,7 +8011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8031,7 +8031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8051,7 +8051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8071,7 +8071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8091,7 +8091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8111,7 +8111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "1-4 hours",
@@ -8131,7 +8131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8151,7 +8151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8171,7 +8171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8191,7 +8191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8211,7 +8211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8231,7 +8231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8251,7 +8251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "1-4 hours",
@@ -8271,7 +8271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8291,7 +8291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8311,7 +8311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8331,7 +8331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8351,7 +8351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8371,7 +8371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "1-4 hours",
@@ -8391,7 +8391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8411,7 +8411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8431,7 +8431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8451,7 +8451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "15 min - 1 hour",
@@ -8471,7 +8471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8491,7 +8491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sphinx-doc/sphinx",
     "difficulty": "<15 min fix",
@@ -8511,7 +8511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8531,7 +8531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8551,7 +8551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8571,7 +8571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8591,7 +8591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -8611,7 +8611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8631,7 +8631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8651,7 +8651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8671,7 +8671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8691,7 +8691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8711,7 +8711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8731,7 +8731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8751,7 +8751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8771,7 +8771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8791,7 +8791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -8811,7 +8811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8831,7 +8831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": ">4 hours",
@@ -8851,7 +8851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8871,7 +8871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -8891,7 +8891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8911,7 +8911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8931,7 +8931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -8951,7 +8951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8971,7 +8971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -8991,7 +8991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9011,7 +9011,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9031,7 +9031,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9051,7 +9051,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9071,7 +9071,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9091,7 +9091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9111,7 +9111,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -9131,7 +9131,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9151,7 +9151,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9171,7 +9171,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9191,7 +9191,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9211,7 +9211,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9231,7 +9231,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -9251,7 +9251,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9271,7 +9271,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9291,7 +9291,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "1-4 hours",
@@ -9311,7 +9311,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9331,7 +9331,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9351,7 +9351,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9371,7 +9371,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9391,7 +9391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9411,7 +9411,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9431,7 +9431,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9451,7 +9451,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9471,7 +9471,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9491,7 +9491,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9511,7 +9511,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9531,7 +9531,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9551,7 +9551,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9571,7 +9571,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9591,7 +9591,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9611,7 +9611,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9631,7 +9631,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9651,7 +9651,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9671,7 +9671,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9691,7 +9691,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9711,7 +9711,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9731,7 +9731,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9751,7 +9751,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9771,7 +9771,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9791,7 +9791,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9811,7 +9811,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9831,7 +9831,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9851,7 +9851,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9871,7 +9871,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9891,7 +9891,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9911,7 +9911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9931,7 +9931,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",
@@ -9951,7 +9951,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9971,7 +9971,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "<15 min fix",
@@ -9991,7 +9991,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "repo": "sympy/sympy",
     "difficulty": "15 min - 1 hour",

--- a/cubes/terminalbench2-cube/scripts/create_task_metadata.py
+++ b/cubes/terminalbench2-cube/scripts/create_task_metadata.py
@@ -32,7 +32,7 @@ from pathlib import Path
 # Make the package importable when executed from the cube root without venv activation.
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from cube.container import ContainerConfig
+from cube.resource import ContainerConfig
 
 from terminalbench2_cube.benchmark import REPO_URL, TerminalBench2BenchmarkConfig
 from terminalbench2_cube.task import TerminalBench2TaskMetadata

--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/task_metadata.json
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/task_metadata.json
@@ -11,7 +11,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "scientific-computing",
@@ -36,7 +36,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "scientific-computing",
@@ -59,7 +59,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -81,7 +81,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "debugging",
@@ -105,7 +105,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -132,7 +132,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -159,7 +159,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "machine-learning",
@@ -182,7 +182,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -206,7 +206,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "games",
@@ -226,7 +226,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -248,7 +248,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "easy",
     "category": "software-engineering",
@@ -270,7 +270,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -292,7 +292,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -315,7 +315,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "system-administration",
@@ -339,7 +339,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "personal-assistant",
@@ -365,7 +365,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "model-training",
@@ -391,7 +391,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -415,7 +415,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "debugging",
@@ -439,7 +439,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "file-operations",
@@ -463,7 +463,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "machine-learning",
@@ -487,7 +487,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "scientific-computing",
@@ -510,7 +510,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "scientific-computing",
@@ -533,7 +533,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "file-operations",
@@ -553,7 +553,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "file-operations",
@@ -577,7 +577,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "mathematics",
@@ -599,7 +599,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "mathematics",
@@ -621,7 +621,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -643,7 +643,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-processing",
@@ -668,7 +668,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "security",
@@ -692,7 +692,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "easy",
     "category": "software-engineering",
@@ -715,7 +715,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -737,7 +737,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "file-operations",
@@ -759,7 +759,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -782,7 +782,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -806,7 +806,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -826,7 +826,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -849,7 +849,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -874,7 +874,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "system-administration",
@@ -901,7 +901,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -925,7 +925,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "file-operations",
@@ -950,7 +950,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "mathematics",
@@ -975,7 +975,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "machine-learning",
@@ -1000,7 +1000,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-processing",
@@ -1024,7 +1024,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -1047,7 +1047,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1069,7 +1069,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1091,7 +1091,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "data-science",
@@ -1116,7 +1116,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "debugging",
@@ -1139,7 +1139,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "mathematics",
@@ -1161,7 +1161,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "scientific-computing",
@@ -1187,7 +1187,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -1210,7 +1210,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -1234,7 +1234,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-processing",
@@ -1261,7 +1261,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -1283,7 +1283,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -1308,7 +1308,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "easy",
     "category": "debugging",
@@ -1332,7 +1332,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "security",
@@ -1356,7 +1356,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1378,7 +1378,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1400,7 +1400,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -1422,7 +1422,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1445,7 +1445,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "optimization",
@@ -1469,7 +1469,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "scientific-computing",
@@ -1493,7 +1493,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "easy",
     "category": "software-engineering",
@@ -1515,7 +1515,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -1538,7 +1538,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "model-training",
@@ -1562,7 +1562,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "model-training",
@@ -1586,7 +1586,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -1608,7 +1608,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -1630,7 +1630,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -1653,7 +1653,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "scientific-computing",
@@ -1678,7 +1678,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1700,7 +1700,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-processing",
@@ -1724,7 +1724,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -1748,7 +1748,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "data-science",
@@ -1772,7 +1772,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "data-science",
@@ -1796,7 +1796,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -1820,7 +1820,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -1842,7 +1842,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "data-querying",
@@ -1866,7 +1866,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "debugging",
@@ -1888,7 +1888,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "system-administration",
@@ -1911,7 +1911,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1933,7 +1933,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",
@@ -1955,7 +1955,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "model-training",
@@ -1978,7 +1978,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "scientific-computing",
@@ -2003,7 +2003,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "video-processing",
@@ -2025,7 +2025,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "security",
@@ -2048,7 +2048,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "medium",
     "category": "software-engineering",
@@ -2072,7 +2072,7 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
-      "_type": "cube.container.ContainerConfig"
+      "_type": "cube.resource.ContainerConfig"
     },
     "difficulty": "hard",
     "category": "software-engineering",


### PR DESCRIPTION
## What

Normalize the committed `ContainerConfig` `_type` strings from `cube.container.ContainerConfig` → `cube.resource.ContainerConfig`, and point the 3 metadata generators at the new import path.

`ContainerConfig` moved to `cube.resource` (it's now a `ResourceConfig`) in **cube-standard #201**. This is the cube-harness half of that move.

## ⚠️ Depends on cube-standard #201

The new `_type` strings only resolve against a cube-standard that has `cube.resource.ContainerConfig` (i.e. #201). cube-standard's re-export keeps the **old** `cube.container` strings working, so the dependency runs one way: **merge this after #201** lands in the installed cube-standard.

## Change (mechanical)

- **3 `task_metadata.json`** — only the `_type` value changes (swebench-verified 500, swebench-live 1895, terminalbench2 89 = **2,484 entries**). No task content changes — the diff is purely `_type` lines (verified: 0 non-`_type` JSON lines changed).
- **3 `create_task_metadata.py`** — `from cube.container import ContainerConfig` → `from cube.resource import ContainerConfig`.

This is not a data regeneration — the generators were not re-run (no HF download / repo clone). A `_type` rename is a string substitution on the committed artifacts.

## Verification

cube-standard's `scripts/smoke/container_config_unify.py`, built against #201, deserializes **all 2,484 regenerated blobs** as `ContainerConfig` (a `ResourceConfig`) with `docker` in `requirements()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
