### PR TITLE
feat(agent): description overrides + benchmark-clarifications recipe glue

### DIFF
--- a/openspec/specs/agent/spec.md
+++ b/openspec/specs/agent/spec.md
@@ -14,12 +14,21 @@ factory.
 ### `AgentConfig` (abstract, serializable)
 ```python
 class AgentConfig(TypedBaseModel, ABC):
+    description_overrides: dict[str, str] = {}   # action_name -> replacement description
+
     @abstractmethod
     def make(self, action_set: list[ActionSchema] | None = None, **kwargs) -> Agent
 ```
 
 Workers receive the config, deserialize, and call `.make(action_set)` with the task's
 filtered action set.
+
+`description_overrides` is an experiment-time knob for testing better action wording
+without editing the tool: an agent applies `apply_description_overrides(...)` to its
+encoded tool schemas, replacing the docstring-derived description for each named action
+before the schema reaches the LLM. Keys must match an action in the current action set
+(it raises otherwise — catching typos and stale keys after a rename). A proven override
+graduates into the tool's docstring at the source via a PR.
 
 ### `Agent` (abstract)
 ```python

--- a/src/cube_harness/agent.py
+++ b/src/cube_harness/agent.py
@@ -3,12 +3,43 @@
 from abc import ABC, abstractmethod
 
 from cube.core import ActionSchema, Observation, ValidatedConfig
+from pydantic import Field
 
 from cube_harness.core import AgentOutput
 
 
+def apply_description_overrides(encoded_tools: list[dict], overrides: dict[str, str]) -> None:
+    """Replace tool-schema descriptions in place from ``{action_name: description}``.
+
+    ``encoded_tools`` are dicts in LLM tool-schema form (``ActionSchema.as_dict()``).
+    Raises ``ValueError`` on a key that matches no tool in ``encoded_tools`` — this
+    catches typos and keys left stale after an action was renamed. No-op when empty.
+    """
+    if not overrides:
+        return
+    by_name = {t["function"]["name"]: t for t in encoded_tools}
+    unknown = set(overrides) - set(by_name)
+    if unknown:
+        raise ValueError(
+            f"description_overrides target unknown actions {sorted(unknown)}; the action space has {sorted(by_name)}"
+        )
+    for name, description in overrides.items():
+        by_name[name]["function"]["description"] = description
+
+
 class AgentConfig(ValidatedConfig, ABC):
     """Configuration for creating an Agent."""
+
+    description_overrides: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Experiment-time overrides for action descriptions, keyed by action name "
+            "(the unique name the LLM sees). Replaces the docstring-derived description "
+            "before the tool schema is built — a toggleable knob for testing better "
+            "wording without editing the tool. A proven override graduates into the "
+            "tool's docstring at the source via a PR."
+        ),
+    )
 
     @property
     def agent_name(self) -> str:

--- a/src/cube_harness/agents/genny.py
+++ b/src/cube_harness/agents/genny.py
@@ -34,13 +34,14 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import cast
 
+from cube.benchmark import BenchmarkConfig
 from cube.core import Action, ActionSchema, Observation, ValidatedConfig
 from cube.task import STOP_ACTION
 from litellm import Message
 from pydantic import Field
 from termcolor import colored
 
-from cube_harness.agent import Agent, AgentConfig
+from cube_harness.agent import Agent, AgentConfig, apply_description_overrides
 from cube_harness.core import AgentOutput
 from cube_harness.llm import LLM, LLMCall, LLMConfig, Prompt, get_reasoning
 
@@ -268,6 +269,24 @@ class GennyConfig(AgentConfig):
             name += f"+{self.summarize_llm_config.model_name}".replace("/", "_")
         return name
 
+    def with_benchmark_clarifications(self, benchmark_config: BenchmarkConfig) -> "GennyConfig":
+        """Return a copy with this benchmark's prompt overlay folded in.
+
+        Pulls ``benchmark_config.load_benchmark_clarifications()`` (the sidecar
+        ``BENCHMARK_HINT`` + ``TASK_CLARIFICATION``) and merges it: the hint fills
+        ``benchmark_hint_prompt`` (kept if the overlay has none), and the per-task
+        clarifications are merged into ``task_clarification`` (overlay wins per
+        task id). Call it in a recipe when building the agent config; to run a
+        clean baseline, simply don't.
+        """
+        overlay = benchmark_config.load_benchmark_clarifications()
+        return self.model_copy(
+            update={
+                "benchmark_hint_prompt": overlay.benchmark_hint or self.benchmark_hint_prompt,
+                "task_clarification": {**self.task_clarification, **overlay.task_clarification},
+            }
+        )
+
     def make(self, action_set: list[ActionSchema] | None = None, task_id: str | None = None, **kwargs) -> "Genny":
         return Genny(config=self, action_schemas=action_set or [], task_id=task_id)
 
@@ -319,6 +338,9 @@ class Genny(Agent):
         self.summarize_llm: LLM = self._summarize_llm_config.make()
         self.token_counter = config.llm_config.make_counter()
         self.action_schemas: list[ActionSchema] = action_schemas
+        # Encode tools once; apply experiment-time description overrides (raises on unknown keys).
+        self._api_tools: list[dict] = _encode_tools(action_schemas)
+        apply_description_overrides(self._api_tools, config.description_overrides)
         self.goal: list[dict] = []
         self.summaries: list[str] = []  # Mode B: one summary per step (raw, no action suffix)
         self.summary_actions: list[str] = []  # Mode B: action taken per step, separate message for cache stability
@@ -472,8 +494,7 @@ class Genny(Agent):
         messages = self._build_base_prompt()
         messages.extend(self._latest_obs)
         messages.append({"role": "user", "content": self.config.summarize_prompt})
-        api_tools = _encode_tools(self.action_schemas)
-        prompt = Prompt(messages=messages, tools=api_tools)
+        prompt = Prompt(messages=messages, tools=self._api_tools)
         response = self.summarize_llm(prompt)
         llm_call = LLMCall(
             tag="summary",
@@ -571,8 +592,7 @@ class Genny(Agent):
     def _act(self, budget_msg: str | None = None) -> tuple[Message, list[LLMCall]]:
         """Build context, encode tools, call act LLM; retry up to max_format_errors times on no tool calls."""
         messages = self._choose_context(budget_msg)
-        api_tools = _encode_tools(self.action_schemas)
-        prompt = Prompt(messages=messages, tools=api_tools)
+        prompt = Prompt(messages=messages, tools=self._api_tools)
         logger.info(f"Act pass — estimated prompt tokens: {self.token_counter(messages=messages)}")
         try:
             response = self.llm(prompt)
@@ -602,7 +622,7 @@ class Genny(Agent):
                 response.message,
                 {"role": "user", "content": "No tool calls found. Every response MUST include at least one tool call."},
             ]
-            prompt = Prompt(messages=messages, tools=api_tools)
+            prompt = Prompt(messages=messages, tools=self._api_tools)
             response = self.llm(prompt)
             llm_calls.append(
                 LLMCall(

--- a/src/cube_harness/agents/react.py
+++ b/src/cube_harness/agents/react.py
@@ -5,7 +5,7 @@ from cube.task import STOP_ACTION
 from litellm import Message
 from termcolor import colored
 
-from cube_harness.agent import Agent, AgentConfig
+from cube_harness.agent import Agent, AgentConfig, apply_description_overrides
 from cube_harness.core import AgentOutput, LLMCall
 from cube_harness.llm import LLMConfig, Prompt
 from cube_harness.utils import parse_actions
@@ -69,6 +69,7 @@ class ReactAgent(Agent):
             if not stop_tool["function"]["parameters"].get("type"):
                 stop_tool["function"]["parameters"] = {"type": "object", "properties": {}}
             self.tools.append(stop_tool)
+        apply_description_overrides(self.tools, config.description_overrides)
 
         self.history: list[dict | Message] = []
         self._actions_cnt = 0

--- a/src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py
@@ -1,0 +1,59 @@
+"""Hinter round <N> experiment config — Auto-CUBE hinter use case.
+
+Copied from this template and edited per round. This file IS the config. NO
+`# /// script` header on purpose: run it with the repo venv, not standalone uv —
+
+    /path/to/cube-harness/.venv/bin/python <this_dir>/exp_config.py --limit 3
+
+The hinter raises performance by applying prompt-level interventions and then
+promoting the ones that generalize. This template shows the two highest-reg
+knobs the harness exposes; both read from sources the hinter edits, so an
+intervention proven here graduates to its source via a PR:
+
+  * the benchmark's clarification overlay — ``BENCHMARK_HINT`` (benchmark-wide
+    orientation) + per-task clarifications — from the benchmark's
+    ``benchmark_clarifications.py`` sidecar, and
+  * per-action description overrides — better wording for an action, before it
+    is promoted into the tool's docstring.
+"""
+
+from miniwob_cube import MINIWOB_CONFIGS
+
+from cube_harness.agents.genny_configs import GENNY_CONFIGS
+from cube_harness.experiment import Experiment
+from cube_harness.llm import LLMConfig
+from cube_harness.recipe import run
+
+# --- vary per round -------------------------------------------------------
+
+TASK_IDS = [
+    # explicit subset for this round — the tasks the intervention targets
+    "book-flight",
+]
+MODEL = "gpt-5.4-mini"  # cheap; bump only with a reason in notes.md
+
+# --- assemble -------------------------------------------------------------
+
+benchmark = MINIWOB_CONFIGS["default"].subset_from_list(TASK_IDS)
+
+# (1) Fold in the benchmark's clarification overlay. No-op until the benchmark
+# ships a benchmark_clarifications.py sidecar; this is where curated benchmark
+# hints + per-task clarifications reach the agent.
+agent = GENNY_CONFIGS["default"].with_benchmark_clarifications(benchmark)
+agent.llm_config = LLMConfig(model_name=MODEL, temperature=1.0)
+
+# (2) Test better action wording before promoting it into the tool docstring.
+# Keys must name an action in the benchmark's action space (raises otherwise).
+agent.description_overrides = {
+    # "click": "Click an element by its numeric ref id (shown in the AX tree), not its text.",
+}
+
+exp = Experiment(
+    name="auto-cube-hinter-r<N>",
+    agent_config=agent,
+    benchmark_config=benchmark,
+    max_steps=10,
+)
+
+if __name__ == "__main__":
+    run(exp)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,11 +2,34 @@
 
 import json
 
+import pytest
 from cube.core import Action, Content, Observation
 from PIL import Image
 
-from cube_harness.agent import Agent, AgentConfig
+from cube_harness.agent import Agent, AgentConfig, apply_description_overrides
 from cube_harness.core import AgentOutput
+
+
+def _encoded_tool(name: str, description: str) -> dict:
+    return {"type": "function", "function": {"name": name, "description": description, "parameters": {}}}
+
+
+class TestApplyDescriptionOverrides:
+    def test_replaces_matching_descriptions(self) -> None:
+        tools = [_encoded_tool("click", "Click."), _encoded_tool("type_text", "Type.")]
+        apply_description_overrides(tools, {"click": "Click an element by its id."})
+        assert tools[0]["function"]["description"] == "Click an element by its id."
+        assert tools[1]["function"]["description"] == "Type."  # untouched
+
+    def test_empty_overrides_is_noop(self) -> None:
+        tools = [_encoded_tool("click", "Click.")]
+        apply_description_overrides(tools, {})
+        assert tools[0]["function"]["description"] == "Click."
+
+    def test_unknown_key_raises(self) -> None:
+        tools = [_encoded_tool("click", "Click.")]
+        with pytest.raises(ValueError, match="unknown actions"):
+            apply_description_overrides(tools, {"clik": "typo"})
 
 
 class TestAgentConfig:

--- a/tests/test_genny.py
+++ b/tests/test_genny.py
@@ -8,6 +8,7 @@ step) use MagicMock so the test suite stays fast.
 from unittest.mock import MagicMock
 
 import pytest
+from cube.benchmark import BenchmarkClarifications
 from cube.core import Action, ActionSchema, Observation
 
 from cube_harness.agents.genny import (
@@ -1022,3 +1023,35 @@ class TestCompaction:
         )
         content = system_msg.get("content") if isinstance(system_msg, dict) else getattr(system_msg, "content", "")
         assert "old work summary" in content
+
+
+class TestPromptOverlayWiring:
+    def test_description_overrides_applied_to_encoded_tools(self) -> None:
+        config = GennyConfig(llm_config=_llm_config(), description_overrides={"click": "Better click description."})
+        agent = Genny(config=config, action_schemas=[_make_schema(name="click")])
+        descriptions = [t["function"]["description"] for t in agent._api_tools]
+        assert "Better click description." in descriptions
+
+    def test_unknown_description_override_raises(self) -> None:
+        config = GennyConfig(llm_config=_llm_config(), description_overrides={"nope": "x"})
+        with pytest.raises(ValueError, match="unknown actions"):
+            Genny(config=config, action_schemas=[_make_schema(name="click")])
+
+    def test_with_benchmark_clarifications_folds_overlay(self) -> None:
+        class _StubBench:
+            def load_benchmark_clarifications(self) -> BenchmarkClarifications:
+                return BenchmarkClarifications(benchmark_hint="Use the filter UI.", task_clarification={"t1": "clar"})
+
+        cfg = GennyConfig(llm_config=_llm_config()).with_benchmark_clarifications(_StubBench())
+        assert cfg.benchmark_hint_prompt == "Use the filter UI."
+        assert cfg.task_clarification == {"t1": "clar"}
+
+    def test_with_benchmark_clarifications_empty_overlay_keeps_existing(self) -> None:
+        class _EmptyBench:
+            def load_benchmark_clarifications(self) -> BenchmarkClarifications:
+                return BenchmarkClarifications()
+
+        base = GennyConfig(llm_config=_llm_config(), benchmark_hint_prompt="keep", task_clarification={"t0": "x"})
+        cfg = base.with_benchmark_clarifications(_EmptyBench())
+        assert cfg.benchmark_hint_prompt == "keep"
+        assert cfg.task_clarification == {"t0": "x"}


### PR DESCRIPTION
Completes the high-reg prompt-mechanism layer for the hinter use case — two cube-harness pieces.

## 1. `AgentConfig.description_overrides` (toggleable action descriptions)

`description_overrides: dict[str, str]` (`{action_name: description}`) — an **experiment-time knob to test better action wording without editing the tool**. A shared `apply_description_overrides()` replaces the docstring-derived description on the encoded tool schemas **before they reach the LLM**.

- Applied in **Genny** (tools encoded once in `__init__`, cached as `_api_tools`) and **ReAct**.
- **Raises** on an override key that matches no action in the current action space — catches typos and keys left stale after a rename. Action names are unique by construction (`Toolbox` enforces it), so the name is an unambiguous key.
- A proven override **graduates into the tool's docstring at the source via a PR**.

## 2. `GennyConfig.with_benchmark_clarifications(benchmark_config)` (design-time glue)

Folds the benchmark's prompt overlay — cube-standard's `load_benchmark_clarifications()` (`BENCHMARK_HINT` + `TASK_CLARIFICATION`) — into a **copy** of the agent config at experiment-design time:
- hint → `benchmark_hint_prompt` (kept if the overlay has none),
- per-task clarifications merged into `task_clarification` (overlay wins per task id).

## Example

Both APIs are demonstrated in a new exp_config template that **seeds the auto-cube hinter use case**: [`src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py`](src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py). No `SKILL.md` yet — the full hinter use case (router + promotion synthesizer + methodology) lands in a follow-up; the skill-sync script skips `SKILL.md`-less dirs, so this is inert until then. `recipes/` is left untouched.

## Tests

- `tests/test_agent.py` — `apply_description_overrides`: replaces, no-op on empty, raises on unknown key.
- `tests/test_genny.py` — overrides reach Genny's encoded tools (+ unknown-key raises); `with_benchmark_clarifications` folds an overlay and is a no-op on an empty one.
- Full unit suite green (631 passed; the only collection errors are unrelated missing optional deps — `pandas`/xray). `agent` spec updated.

## Notes / out of scope

- The **MCP-server** description mirror is deferred (a separate consumer, not `AgentConfig`-driven).
- The deprecated legacy agent does not honor the overrides.
- Depends on cube-standard **#202** (merged to `dev`); CI installs `cube-standard@dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)