### PR TITLE
feat(auto-cube): root each session at ~/auto_cube/<session-id>/ (experiments + journal)

### DIFF
--- a/.claude/skills/new-auto-cube-use-case/templates/use_case_skill.md
+++ b/.claude/skills/new-auto-cube-use-case/templates/use_case_skill.md
@@ -85,8 +85,8 @@ N rounds, etc.).>
 ## Cross-session state
 
 <TODO: Does this use-case read/write the shared
-`~/cube_auto_cube_journal/coverage.json` ledger? Does it have its own
-ledger (e.g. `~/cube_auto_cube_journal/capability.json`)? Or is it
+`~/auto_cube/coverage.json` ledger? Does it have its own
+ledger (e.g. `~/auto_cube/capability.json`)? Or is it
 purely single-session? Document the format here so future sessions
 can interoperate.>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,8 +219,9 @@ Each use_case has a `recipe.py` (Pydantic `InvestigatorRecipe`) and a `SKILL.md`
 `.claude/skills/investigator-<name>` so Claude Code picks them up.
 
 Per-batch synthesis (`meta_analysis.json` + `.md`) is mirrored into
-`~/cube_auto_cube_journal/<experiment>/` for cross-iteration narrative —
-the only artefact the Investigator writes outside the experiment dir.
+`<journal-dir>/<experiment>/` (default `~/auto_cube/`; Auto-CUBE points it at
+the per-session `~/auto_cube/<session-id>/journal/`) for cross-iteration
+narrative — the only artefact the Investigator writes outside the experiment dir.
 
 ## Auto-CUBE use cases
 

--- a/openspec/specs/auto-fix/spec.md
+++ b/openspec/specs/auto-fix/spec.md
@@ -220,8 +220,8 @@ for pr in $(open_prs_by_auto_cube):
 
 The integration worktree is **per session**, not machine-wide: multiple
 Auto-CUBE sessions can run concurrently on one machine, each owning its
-worktree + `.venv` + journal subdir
-(`~/cube_auto_cube_journal/<session-slug>/`). Cross-session isolation is
+worktree + `.venv` + session dir
+(`~/auto_cube/<session-id>/`). Cross-session isolation is
 preserved by picking **orthogonal scopes** — different cubes by default
 (one session on tbench2, one on swe-bench, etc.). Sessions may still file
 fixes against shared layers (infra, tool, LLM wrapper); those PRs land in

--- a/scripts/smoke/investigator_e2e.py
+++ b/scripts/smoke/investigator_e2e.py
@@ -345,7 +345,7 @@ def main(
         typer.echo(f"Calling investigate_experiment(...) with recipe={recipe.name} synthesize={synthesize} ...")
         # `synthesis_model=""` is the programmatic skip-synthesis hatch; the
         # smoke uses a per-run tempdir for journaling so it never pollutes
-        # the user's real `~/cube_auto_cube_journal/`.
+        # the user's real `~/auto_cube/`.
         config = InvestigationConfig(
             recipe=recipe,
             driver=chosen,

--- a/src/cube_harness/analyze/investigator/cli.py
+++ b/src/cube_harness/analyze/investigator/cli.py
@@ -116,7 +116,7 @@ def run_cmd(
             "--journal-dir",
             help="Mirror meta_analysis.{json,md} into <journal-dir>/<experiment>/.",
         ),
-    ] = Path("~/cube_auto_cube_journal").expanduser(),
+    ] = Path("~/auto_cube").expanduser(),
     extra_prompt: Annotated[
         str | None,
         typer.Option(
@@ -145,7 +145,8 @@ def run_cmd(
     """Batch-investigate episodes in an experiment directory.
 
     By default investigates every eligible (uninvestigated) episode, runs the post-batch
-    meta-analysis, and mirrors the synthesis into ~/cube_auto_cube_journal/.
+    meta-analysis, and mirrors the synthesis into ~/auto_cube/ (Auto-CUBE points
+    --journal-dir at the per-session ~/auto_cube/<session-id>/journal).
     """
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,

--- a/src/cube_harness/analyze/investigator/core.py
+++ b/src/cube_harness/analyze/investigator/core.py
@@ -112,8 +112,9 @@ class InvestigationConfig(TypedBaseModel):
 
     # Journal mirror — `meta_analysis.{json,md}` is copied into
     # `<journal_dir>/<experiment_basename>/`. Default is the conventional
-    # machine-local journal dir; override or point at a tempdir to redirect.
-    journal_dir: Path = Field(default_factory=lambda: Path("~/cube_auto_cube_journal").expanduser())
+    # machine-local journal dir; Auto-CUBE points it at the per-session
+    # `~/auto_cube/<session-id>/journal`. Override or point at a tempdir to redirect.
+    journal_dir: Path = Field(default_factory=lambda: Path("~/auto_cube").expanduser())
 
     # Optional biasing fragment appended to every per-episode user prompt.
     # Lets an Auto-CUBE use-case (or any caller) add use-case-specific

--- a/src/cube_harness/auto_cube/README.md
+++ b/src/cube_harness/auto_cube/README.md
@@ -59,11 +59,14 @@ directory:
    - `ANTHROPIC_API_KEY` — Investigator + Genny when using `claude-*` models
    - `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` — for `azure/gpt-*`
    - Cube-specific infra: `DAYTONA_API_KEY`, `EAI_PROFILE`, AWS, etc.
-3. **Journal path**: `~/cube_auto_cube_journal/` is created on first
-   run; sessions live in `<journal>/<session-slug>/`. The
-   cross-session ledger lives at `<journal>/coverage.json`.
+3. **Session path**: each session lives at `~/auto_cube/<session-id>/`,
+   created on first run, holding the journal (`session.md`,
+   `round_<N>/`, `REPORT.md`) under `journal/` and trajectory output
+   under `experiments/` (export
+   `CH_EXP_DIR=~/auto_cube/<session-id>/experiments` at session start).
+   The cross-session ledger lives at `~/auto_cube/coverage.json`.
 4. **Parallel sessions on the same machine**: each session needs its
-   own integration worktree + `.venv` + journal subdir. See
+   own integration worktree + `.venv` + session dir. See
    [§6 of the methodology spec](../../../openspec/specs/auto-fix/spec.md).
 
 ## Prompt template (debug use-case)
@@ -72,9 +75,10 @@ Drop this into a fresh Claude Code session (cube-harness as cwd; the
 `auto-cube-debug` skill auto-loads). Fill the angle-bracket slots:
 
 > Use the Auto-CUBE debug use-case to **<objective>** on `<cube-name>`.
-> Start a session in `~/cube_auto_cube_journal/` with slug
-> `<cube>-<focus>-r0`. Set up an integration worktree off `origin/dev`
-> with its own `.venv`. Read `~/cube_auto_cube_journal/coverage.json`
+> Start a session at `~/auto_cube/<cube>-<focus>-r0/`. Set up an
+> integration worktree off `origin/dev` with its own `.venv`, and
+> export `CH_EXP_DIR=~/auto_cube/<cube>-<focus>-r0/experiments`. Read
+> `~/auto_cube/coverage.json`
 > to identify the highest-value gap relevant to my focus, and scan
 > `~/cube_harness_results/` for reusable experiments the Investigator
 > hasn't seen yet.
@@ -89,8 +93,9 @@ Drop this into a fresh Claude Code session (cube-harness as cwd; the
 > Reports per `openspec/specs/auto-fix/spec.md` for confirmed root
 > causes; update `coverage.json` as cells get classified.
 >
-> Land experiment outputs inside the session dir, not the default
-> `~/cube_harness_results/`. Per-round budget ≈ `$<X>`. Stop when the
+> Experiment outputs land under the session's `experiments/` (via
+> `CH_EXP_DIR`), not the default `~/cube_harness_results/`. Per-round
+> budget ≈ `$<X>`. Stop when the
 > ledger gap is closed or independent failure modes are exhausted.
 > Final deliverable: `REPORT.md`.
 
@@ -102,12 +107,12 @@ agent's SKILL.md describes the discipline; you set the focus.
 
 | Artefact | Where | Purpose |
 |---|---|---|
-| `REPORT.md` | `~/cube_auto_cube_journal/<slug>/REPORT.md` | Single human-readable rollup: scope, arc, findings ledger, shipped/open PRs, design signals, cost |
-| `session.md` | same dir | Live scope + tracker (lighter than REPORT.md) |
-| `round_<N>/notes.md` | same dir | Per-round hypothesis → result trail |
-| `round_<N>/results/` | same dir | Experiment output (overrides default `~/cube_harness_results/`) |
-| `done.json` | same dir | Per-task dispositions for this session |
-| `coverage.json` | `~/cube_auto_cube_journal/coverage.json` | **Cross-session** sparse coverage ledger across `task × infra × tool × model × agent-config` |
+| `REPORT.md` | `~/auto_cube/<session-id>/journal/REPORT.md` | Single human-readable rollup: scope, arc, findings ledger, shipped/open PRs, design signals, cost |
+| `session.md` | same `journal/` dir | Live scope + tracker (lighter than REPORT.md) |
+| `round_<N>/notes.md` | same `journal/` dir | Per-round hypothesis → result trail |
+| experiment output | `~/auto_cube/<session-id>/experiments/` | Trajectories (via `CH_EXP_DIR`; overrides default `~/cube_harness_results/`) |
+| `done.json` | same `journal/` dir | Per-task dispositions for this session |
+| `coverage.json` | `~/auto_cube/coverage.json` | **Cross-session** sparse coverage ledger across `task × infra × tool × model × agent-config` |
 | Fix Report PRs | cube-harness (or cube-standard) | One PR per fix; body matches `templates/fix_report.md` |
 | `design-debt` issues | cube-harness | L2/L3 fixes that need refactoring; stay open across PRs |
 | `meta_analysis.{json,md}` | each experiment dir + journal mirror | Investigator's structured per-batch synthesis |

--- a/src/cube_harness/auto_cube/use_cases/debug/SKILL.md
+++ b/src/cube_harness/auto_cube/use_cases/debug/SKILL.md
@@ -37,7 +37,7 @@ confidence that systemic issues won't go undetected.
 ## Cross-session ledger
 
 The source of truth across sessions is
-**`~/cube_auto_cube_journal/coverage.json`** (loose schema; evolve as
+**`~/auto_cube/coverage.json`** (loose schema; evolve as
 you learn):
 
 ```json
@@ -74,8 +74,13 @@ for this model as a pass.
 - **Set up the session worktree** off `origin/dev` with its own
   `.venv` (per §6 of
   [`openspec/specs/auto-fix/spec.md`](../../../../../openspec/specs/auto-fix/spec.md)).
-  The session journal lives at `~/cube_auto_cube_journal/<slug>/` —
-  pick a unique slug (e.g. `swebench-verified-daytona-r0`).
+  The session lives at `~/auto_cube/<session-id>/` — pick a unique
+  session id (e.g. `swebench-verified-daytona-r0`) — holding both the
+  journal (`session.md`, `round_<N>/`, `REPORT.md`) under `journal/`
+  and all trajectory output under `experiments/`. **Export
+  `CH_EXP_DIR=~/auto_cube/<session-id>/experiments`** at session start
+  so every run in this session lands there instead of polluting
+  `~/cube_harness_results/`.
 - **Copy `session.md`** from
   [`src/cube_harness/auto_cube/templates/session.md`](../../templates/session.md)
   and fill in scope, target axes, ledger gaps you intend to fill.
@@ -101,13 +106,14 @@ fast and cheaply, then narrow.
   Use judgment: ~20–100 tasks for a typical cube is the right order
   of magnitude, but adapt. Wider when the cube is large and cheap;
   narrower when each task burns budget.
-- **Override the experiment output dir** so it lands inside the
-  session: `~/cube_auto_cube_journal/<slug>/round_<N>/results/`.
-  Self-contained sessions don't pollute `~/cube_harness_results/` and
-  are easy to archive or delete as one unit.
+- Experiments land under `~/auto_cube/<session-id>/experiments/`
+  automatically (the `CH_EXP_DIR` exported at session start), so a
+  session is self-contained — easy to archive or delete as one unit —
+  and never pollutes `~/cube_harness_results/`.
 - Run the experiment, then dispatch the Investigator on the output
-  directory. **Point `ch-investigate --context-dir` at the session
-  dir** (`~/cube_auto_cube_journal/<slug>/`) so the Opus codebase-map
+  directory with **`--journal-dir ~/auto_cube/<session-id>/journal`**
+  so its synthesis mirrors into the session. **Point `ch-investigate
+  --context-dir` at the session dir** (`~/auto_cube/<session-id>/`) so the Opus codebase-map
   agent runs **once per (session, benchmark)** and the map is reused
   across all rounds — per-session keying keeps the map matched to this
   worktree's installed code. The Investigator emits `BaseFindings` per


### PR DESCRIPTION
## Problem

Auto-CUBE launches experiments via the copied `exp_config.py`, which builds `Experiment(...)` with no `output_dir` → falls back to `EXP_DIR` (`~/cube_harness_results/`). So **every auto-cube run pollutes the main results folder** (and `make report`), while the journal lived separately at `~/cube_auto_cube_journal/`.

## Change

Unify a session's trajectories and journal under one per-session root:

```
~/auto_cube/
  coverage.json                      # cross-session ledger
  <session-id>/
    experiments/                     # trajectories (via CH_EXP_DIR)
    journal/                         # session.md, round_<N>/, REPORT.md,
                                     #   + Investigator meta_analysis mirror
```

- **Session start** exports `CH_EXP_DIR=~/auto_cube/<session-id>/experiments` → every run in the session lands there; `~/cube_harness_results/` stays clean for real runs.
- The **Investigator** is dispatched with `--journal-dir ~/auto_cube/<session-id>/journal`.
- A session is self-contained — archive or delete as one unit.

## What's in the diff

- **Code** (small): the Investigator's default `journal_dir` moves `~/cube_auto_cube_journal` → `~/auto_cube` ([core.py](src/cube_harness/analyze/investigator/core.py), [cli.py](src/cube_harness/analyze/investigator/cli.py)); Auto-CUBE passes the per-session path explicitly.
- **Methodology + docs**: debug [`SKILL.md`](src/cube_harness/auto_cube/use_cases/debug/SKILL.md), [`auto_cube/README.md`](src/cube_harness/auto_cube/README.md), `AGENTS.md`/`CLAUDE.md`, the auto-fix spec, the new-use-case template, and the `investigator_e2e` smoke comment.

No `cube_auto_cube_journal` references remain. The exp_config templates need no change — `CH_EXP_DIR` redirects output for free.

## Notes

- The `CH_EXP_DIR` mechanism + the Investigator `--journal-dir` flag already exist; this PR adopts them into a single per-session convention.
- No test asserts the old default; lint clean. CI runs the investigator suite with full deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)