### PR TITLE
refactor(xray): drop the background bulk-loader (steps loaded lazily)

### DIFF
--- a/scripts/smoke/xray_stale_flip.py
+++ b/scripts/smoke/xray_stale_flip.py
@@ -221,8 +221,7 @@ def main() -> int:
         # 2. Load it into XRayState and poll refresh_experiment like the dashboard timer does.
         print("[2] loading into XRayState, polling refresh like the 1s dashboard timer…")
         state = XRayState(results_dir=results_dir)
-        state.load_experiment(exp_dir)
-        _poll(lambda: state._bg_loading_done, timeout=5)
+        state.load_experiment(exp_dir)  # synchronous: stats come from the metadata stub, no bulk-loader
         for _ in range(3):
             time.sleep(0.8)
             state.refresh_experiment()

--- a/scripts/smoke/xray_stale_flip.py
+++ b/scripts/smoke/xray_stale_flip.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""SMOKE: XRay live dashboard flips a dead experiment's episodes ▶️/🕐 → 👻 (BUG-1 regression).
+
+End-to-end test that XRay's live refresh picks up a *status-only* transition — the bug fixed by
+keying change-detection off the episode-directory mtime + re-injecting status onto stubs.
+
+Flow:
+  1. Launch a deterministic mock-cube experiment (sequential, no LLM/browser), slow enough to catch
+     episodes mid-flight.
+  2. Drive the real ``XRayState`` the way the viewer does: ``load_experiment`` then a 1s
+     ``refresh_experiment`` poll loop (exactly what the dashboard's ``gr.Timer`` calls). Confirm the
+     live view shows in-flight episodes (running/queued) and no stale.
+  3. SIGINT the driver mid-run → experiment_status becomes INTERRUPTED, leaving orphaned episodes.
+  4. Run the ghost-sweep (``_promote_ghost_episodes`` — the exact function XRay runs on Refresh),
+     which writes STALE into the orphaned episodes' status.json *only* (no trajectory write).
+  5. Assert the live ``refresh_experiment`` loop flips the view ▶️/🕐 → 👻. Before the BUG-1 fix the
+     refresh keyed off trajectory-file mtimes and never noticed a status-only flip; after it, the
+     per-dir-mtime detection (started episodes) and stub re-inject (queued episodes) propagate it.
+
+Why ``XRayState`` and not Playwright: the bug lives in ``refresh_experiment`` (the timer's function),
+and asserting there is deterministic. Driving the Gradio DataFrame's experiment-selection checkbox
+headlessly is flaky and orthogonal to the fix; the rendered DOM has its own coverage in
+``tests/test_xray_e2e.py``.
+
+Run:
+    .venv/bin/python scripts/smoke/xray_stale_flip.py
+    .venv/bin/python scripts/smoke/xray_stale_flip.py --keep   # keep the temp results dir
+
+Final line follows the cube-harness smoke contract:
+    SMOKE OK: xray_stale_flip     (exit 0 — live refresh flipped to 👻)
+    SMOKE FAIL: xray_stale_flip   (exit 1 — view never flipped, or setup failed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
+from cube.core import Action, Observation
+from cube.task import Task, TaskConfig, TaskMetadata
+from cube.tool import Tool, ToolConfig, tool_action
+
+from cube_harness.agent import Agent, AgentConfig
+from cube_harness.analyze import xray_utils
+from cube_harness.analyze.xray import XRayState
+from cube_harness.analyze.xray_utils import _promote_ghost_episodes
+from cube_harness.core import AgentOutput
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
+from cube_harness.exp_runner import run_sequentially
+from cube_harness.experiment import Experiment
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
+
+NAME = "xray_stale_flip"
+N_TASKS = int(os.environ.get("XRAY_SMOKE_N_TASKS", "5"))
+STEP_SECS = float(os.environ.get("XRAY_SMOKE_STEP_SECS", "2.5"))
+
+
+# ---------------------------------------------------------------------------
+# Deterministic, LLM-free, browser-free mock benchmark + agent
+# ---------------------------------------------------------------------------
+
+
+class _NoopTool(Tool):
+    @tool_action
+    def click(self, element_id: str) -> str:
+        """Click an element.
+
+        Args:
+            element_id: The element to click.
+        """
+        return f"clicked {element_id}"
+
+
+class _NoopToolConfig(ToolConfig):
+    def make(self, container: object = None) -> _NoopTool:
+        _ = container
+        return _NoopTool()
+
+
+class _MockTask(Task):
+    def reset(self) -> tuple[Observation, dict]:
+        return Observation.from_text("smoke task goal"), {}
+
+    def evaluate(self, obs: Observation | None = None) -> tuple[float, dict]:
+        _ = obs
+        return 1.0, {"success": True}
+
+
+class _MockTaskConfig(TaskConfig):
+    def make(self, runtime_context: object = None) -> _MockTask:
+        _ = runtime_context
+        return _MockTask(metadata=TaskMetadata(id=self.task_id), tool_config=self.tool_config or _NoopToolConfig())
+
+
+class _MockBenchmark(Benchmark):
+    def _setup(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _SmokeBenchmarkConfig(BenchmarkConfig):
+    benchmark_metadata = BenchmarkMetadata(name="xray-smoke", version="0.1.0", description="XRay smoke benchmark")
+    task_metadata = {f"smoke_task_{i}": TaskMetadata(id=f"smoke_task_{i}") for i in range(N_TASKS)}
+    task_config_class = _MockTaskConfig
+    benchmark_class = _MockBenchmark
+
+
+class _SlowAgentConfig(AgentConfig):
+    step_secs: float = STEP_SECS
+
+    def make(self, action_set: object = None, **kwargs: object) -> "Agent":
+        _ = action_set, kwargs
+        return _SlowAgent(config=self)
+
+
+class _SlowAgent(Agent):
+    name = "XRaySmokeAgent"
+    description = "Sleeps then submits final_step — deterministic, no LLM."
+    input_content_types = ["text"]
+    output_content_types = ["action"]
+
+    def step(self, obs: Observation) -> AgentOutput:
+        _ = obs
+        time.sleep(self.config.step_secs)  # keep the episode RUNNING long enough to catch it mid-flight
+        return AgentOutput(actions=[Action(name="final_step", arguments={})])
+
+
+def _run_experiment(output_dir: Path) -> None:
+    """Child entrypoint: run the mock experiment in-process (sequential, no Ray)."""
+    exp = Experiment(
+        name="xray_smoke",
+        output_dir=output_dir,
+        agent_config=_SlowAgentConfig(),
+        benchmark_config=_SmokeBenchmarkConfig(),
+        max_steps=2,
+    )
+    run_sequentially(exp)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration helpers
+# ---------------------------------------------------------------------------
+
+
+def _experiment_dir(results_dir: Path) -> Path | None:
+    for child in results_dir.iterdir():
+        if child.is_dir() and (child / EXPERIMENT_STATUS_FILENAME).exists():
+            return child
+    return None
+
+
+def _disk_statuses(exp_dir: Path) -> dict[str, str]:
+    episodes = exp_dir / "episodes"
+    if not episodes.exists():
+        return {}
+    out: dict[str, str] = {}
+    for ep_dir in episodes.iterdir():
+        if not ep_dir.is_dir() or ".archived_" in ep_dir.name:
+            continue
+        status = EpisodeStatus.read(ep_dir / STATUS_FILENAME)
+        if status is not None:
+            out[ep_dir.name] = status.status
+    return out
+
+
+def _view_statuses(state: XRayState) -> list[str]:
+    """The display statuses XRay would render for the loaded trajectories."""
+    return sorted(xray_utils.trajectory_status(t) for t in state.trajectories)
+
+
+def _poll(predicate, timeout: float, interval: float = 0.3) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _fail(msg: str) -> int:
+    print(f"  ✗ {msg}")
+    print(f"SMOKE FAIL: {NAME}")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keep", action="store_true", help="Keep the temp results dir on exit.")
+    args = parser.parse_args()
+
+    tmp = tempfile.mkdtemp(prefix="xray_stale_flip_")
+    results_dir = Path(tmp)
+    exp_proc: subprocess.Popen | None = None
+    try:
+        # 1. Launch the experiment; wait for an episode to actually be RUNNING on disk.
+        print(f"[1] launching mock-cube experiment ({N_TASKS} tasks, {STEP_SECS}s/episode)…")
+        exp_proc = subprocess.Popen([sys.executable, __file__, "_run_experiment", str(results_dir / "xray_smoke")])
+        if not _poll(
+            lambda: (d := _experiment_dir(results_dir)) is not None and "RUNNING" in _disk_statuses(d).values(),
+            timeout=30,
+        ):
+            return _fail("experiment never reached a RUNNING episode")
+        exp_dir = _experiment_dir(results_dir)
+        assert exp_dir is not None
+
+        # 2. Load it into XRayState and poll refresh_experiment like the dashboard timer does.
+        print("[2] loading into XRayState, polling refresh like the 1s dashboard timer…")
+        state = XRayState(results_dir=results_dir)
+        state.load_experiment(exp_dir)
+        _poll(lambda: state._bg_loading_done, timeout=5)
+        for _ in range(3):
+            time.sleep(0.8)
+            state.refresh_experiment()
+        before = _view_statuses(state)
+        if not any(s in ("running", "queued") for s in before):
+            return _fail(f"expected in-flight episodes (running/queued) in the view, got: {before}")
+        if "stale" in before:
+            return _fail(f"view already shows stale before the driver was killed: {before}")
+        print(f"      view before kill: {before}")
+
+        # 3. Kill the driver mid-run → INTERRUPTED experiment, orphaned episodes.
+        print("[3] SIGINT the driver mid-run…")
+        exp_proc.send_signal(signal.SIGINT)
+        try:
+            exp_proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            exp_proc.kill()
+        if not _poll(
+            lambda: (
+                (s := ExperimentStatus.read(exp_dir / EXPERIMENT_STATUS_FILENAME)) is not None
+                and s.status == "INTERRUPTED"
+            ),
+            timeout=15,
+        ):
+            return _fail("experiment_status never became INTERRUPTED after SIGINT")
+
+        # 4. Run the ghost-sweep (the function XRay calls on Refresh) → writes STALE to status.json only.
+        print("[4] running ghost-sweep (writes STALE into orphaned episodes)…")
+        _promote_ghost_episodes(exp_dir)
+        disk = _disk_statuses(exp_dir)
+        if "STALE" not in disk.values():
+            return _fail(f"ghost-sweep did not produce any STALE episode on disk: {disk}")
+
+        # 5. THE REGRESSION: the live refresh loop must flip the view ▶️/🕐 → 👻.
+        print("[5] polling refresh_experiment for the live ▶️/🕐 → 👻 flip…")
+        flipped = _poll(lambda: (state.refresh_experiment() or True) and "stale" in _view_statuses(state), timeout=15)
+        after = _view_statuses(state)
+        if not flipped:
+            return _fail(
+                "live refresh never surfaced 👻 stale — BUG-1 regression "
+                f"(status.json is STALE on disk but refresh_experiment missed it).\n"
+                f"      disk: {disk}\n      view: {after}"
+            )
+        print(f"      view after sweep: {after}")
+        print("  ✓ live refresh flipped the view to 👻 after a status-only transition")
+        print(f"SMOKE OK: {NAME}")
+        return 0
+    finally:
+        if exp_proc is not None and exp_proc.poll() is None:
+            exp_proc.kill()
+        if not args.keep:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "_run_experiment":
+        _run_experiment(Path(sys.argv[2]))
+    else:
+        sys.exit(main())

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -27,6 +27,7 @@ from PIL import Image
 from cube_harness import EXP_DIR
 from cube_harness.analyze import inspect_results, xray_utils
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
+from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 from cube_harness.storage import FileStorage
 
 # ---------------------------------------------------------------------------
@@ -280,38 +281,85 @@ class XRayState:
                 prev_mtime = self._traj_mtimes.get(traj_id, 0.0)
                 if mtime <= prev_mtime and traj_id in known_ids:
                     continue
+                # Record the mtime up front: a metadata-less stub fails load_trajectory
+                # every tick otherwise, re-reading it forever.
+                self._traj_mtimes[traj_id] = mtime
                 try:
                     full = storage.load_trajectory(traj_id)
-                    self._apply_agent_name(full, storage)
-                    self._apply_exp_tag(full, storage)
-                    self._traj_mtimes[traj_id] = mtime
-                    changed = True
-                    # Find the existing slot owned by this storage (avoids ID collision)
-                    idx = next(
-                        (
-                            i
-                            for i, t in enumerate(self.trajectories)
-                            if t.id == traj_id and self._traj_storages[i] is storage
-                        ),
-                        None,
-                    )
-                    if idx is not None:
-                        self.trajectories[idx] = full
-                        self._traj_storages[idx] = storage
-                        if self.current_trajectory is not None and self.current_trajectory.id == traj_id:
-                            self.current_trajectory = full
-                            self._env_step_indices = self._build_env_indices()
-                    else:
-                        self.trajectories.append(full)
-                        self._traj_storages.append(storage)
-                        known_ids.add(traj_id)
-                    if full.end_time is not None:
-                        self._completed_ids.add(traj_id)
                 except Exception:
-                    pass
+                    # No trajectory file yet (e.g. a QUEUED stub whose status.json flipped
+                    # to STALE on driver death) or an unreadable file: fall back to a cheap
+                    # status-only refresh so the terminal flip still surfaces live.
+                    if self._reinject_episode_status(traj_id, storage):
+                        changed = True
+                    continue
+                self._apply_agent_name(full, storage)
+                self._apply_exp_tag(full, storage)
+                changed = True
+                # Find the existing slot owned by this storage (avoids ID collision)
+                idx = next(
+                    (
+                        i
+                        for i, t in enumerate(self.trajectories)
+                        if t.id == traj_id and self._traj_storages[i] is storage
+                    ),
+                    None,
+                )
+                if idx is not None:
+                    self.trajectories[idx] = full
+                    self._traj_storages[idx] = storage
+                    if self.current_trajectory is not None and self.current_trajectory.id == traj_id:
+                        self.current_trajectory = full
+                        self._env_step_indices = self._build_env_indices()
+                else:
+                    self.trajectories.append(full)
+                    self._traj_storages.append(storage)
+                    known_ids.add(traj_id)
+                if full.end_time is not None:
+                    self._completed_ids.add(traj_id)
         if changed:
             self._last_change_time = time.time()
         return changed
+
+    def _reinject_episode_status(self, traj_id: str, storage: FileStorage) -> bool:
+        """Re-inject ``_episode_status`` (+ retry/error fields) from status.json onto an
+        already-loaded trajectory/stub that has no (new) trajectory file to load.
+
+        The cheap counterpart to a full reload: one small JSON read, no step decode. Lets
+        a status-only transition (e.g. QUEUED→STALE) update the display in place. Returns
+        True if the displayed status actually changed.
+        """
+        status = storage.read_episode_status(traj_id)
+        if status is None:
+            return False
+        idx = next(
+            (i for i, t in enumerate(self.trajectories) if t.id == traj_id and self._traj_storages[i] is storage),
+            None,
+        )
+        if idx is None:
+            return False
+        meta = self.trajectories[idx].metadata
+        changed = meta.get("_episode_status") != status.status
+        meta["_episode_status"] = status.status
+        meta["_retry_count"] = status.retry_count
+        meta["_error_type"] = status.error_type
+        meta["_error_message"] = status.error_message
+        return changed
+
+    def ray_dashboard_links(self) -> list[tuple[str, str]]:
+        """Return ``[(exp_name, ray_dashboard_url)]`` for selected experiments whose
+        experiment_status.json records a Ray dashboard URL.
+
+        Populated only in Ray mode while the driver is up (the URL points at the live Ray
+        cluster); empty for sequential runs and usually dead once the run completes. One
+        small file read per selected experiment — not per-episode.
+        """
+        links: list[tuple[str, str]] = []
+        for storage in self._storages:
+            status = ExperimentStatus.read(storage.output_dir / EXPERIMENT_STATUS_FILENAME)
+            if status is not None and status.ray_dashboard_url:
+                links.append((storage.output_dir.name, status.ray_dashboard_url))
+        return links
 
     def is_experiment_complete(self) -> bool:
         """Return True when every known trajectory has reached a terminal status."""
@@ -928,7 +976,12 @@ def run_xray(
                     )
                 )
         progress_html = xray_utils.build_progress_html(
-            n_completed, n_total, n_running, per_agent, state._selected_exp_names or None
+            n_completed,
+            n_total,
+            n_running,
+            per_agent,
+            state._selected_exp_names or None,
+            ray_dashboard_urls=state.ray_dashboard_links() or None,
         )
 
         experiment_done = state.is_experiment_complete() or state.is_experiment_stale()

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -13,7 +13,6 @@ import argparse
 import html as html_lib
 import json
 import re
-import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -70,11 +69,6 @@ class XRayState:
     # Per-storage timestamp tag (parsed from exp dir name); keyed by id(storage).
     # Always appended to agent_name so each trajectory is unambiguously identified.
     _exp_tags: dict[int, str] = field(default_factory=dict, repr=False)
-    # Set to True once the background bulk-loading thread has finished
-    _bg_loading_done: bool = field(default=True, repr=False)
-    # Incremented on each load_experiments call; background threads check this to self-abort
-    # when superseded by a newer load (prevents stale writes to self.trajectories).
-    _bg_gen: int = field(default=0, repr=False)
     # Per-storage backfill names for backwards-compat (agent class short name from config); keyed by id(storage).
     _backfill_names: dict[int, str | None] = field(default_factory=dict, repr=False)
     # Per-storage config JSON strings for the Config tabs; keyed by id(storage).
@@ -97,10 +91,12 @@ class XRayState:
         when multiple experiments share identical task/episode IDs.
 
         Returns True if at least one trajectory was loaded.
+
+        Stats (steps/tokens/cost/duration) come from each trajectory's persisted
+        ``summary_stats`` on the metadata stub, so the tables render without loading any
+        steps. Full steps are loaded lazily — by ``select_trajectory`` when you open a
+        trajectory, and by ``refresh_experiment`` for in-flight ones — never eagerly.
         """
-        # Increment generation FIRST so any running background thread sees the change
-        # immediately and aborts before it can write stale data into our new trajectory list.
-        self._bg_gen += 1
         self._storages = [FileStorage(d) for d in exp_dirs]
         self._selected_exp_names = [d.name for d in exp_dirs]
         self.trajectories = []
@@ -127,9 +123,12 @@ class XRayState:
         for storage in self._storages:
             self._traj_mtimes.update(storage.list_trajectory_ids_with_mtime())
         self._last_change_time = time.time()
-        self._bg_loading_done = False
-        self._start_background_loading()
         return len(self.trajectories) > 0
+
+    def should_poll(self) -> bool:
+        """Whether the live-refresh timer should run: an experiment is loaded and not yet
+        complete. (Historical/complete experiments need no polling.)"""
+        return bool(self.trajectories) and not self.is_experiment_complete()
 
     def load_experiment(self, exp_dir: Path) -> bool:
         """Convenience wrapper: load a single experiment directory."""
@@ -207,59 +206,6 @@ class XRayState:
                 agent_cfg, exp_cfg = self._storage_configs.get(id(storage), (None, None))
                 return agent_cfg or "", exp_cfg or ""
         return "", ""
-
-    def _start_background_loading(self) -> None:
-        """Spawn a daemon thread that loads all trajectory stubs into full trajectories.
-
-        Each trajectory is loaded and cached in-place in self.trajectories so that the
-        hierarchy tables (agent/task/seed) can display accurate step/token/cost stats
-        once loading completes.
-
-        NOTE: This background thread is a temporary workaround for the missing summary stats
-        on trajectory metadata stubs.  The long-term fix is to have the evaluation loop
-        persist per-episode stats (n_steps, tokens, cost, duration) directly into the
-        *.metadata.json file as it runs, making bulk loading unnecessary.
-        See: https://github.com/cube-harness/cube-harness/issues/TODO
-        """
-        if not self._storages:
-            self._bg_loading_done = True
-            return
-
-        # Capture a snapshot to avoid closure over mutable state
-        my_gen = self._bg_gen  # This thread's generation; abort if superseded
-        # Capture hard references to the owned lists so that load_experiments
-        # reassigning self.trajectories/self._traj_storages never redirects our writes.
-        my_trajs = self.trajectories
-        my_storages = list(self._traj_storages)  # index-parallel snapshot; no traj_id collision
-
-        def _load_all() -> None:
-            for i, traj in enumerate(my_trajs):
-                # Abort if a newer load_experiments call has started
-                if self._bg_gen != my_gen:
-                    return
-                # Skip if already fully loaded (e.g. user clicked it first)
-                if traj.steps:
-                    continue
-                # Skip missing stubs — they have no trajectory file to load
-                if traj.metadata.get("_missing"):
-                    continue
-                storage = my_storages[i]
-                try:
-                    full = storage.load_trajectory(traj.id)
-                    self._apply_agent_name(full, storage)
-                    self._apply_exp_tag(full, storage)
-                    if self._bg_gen == my_gen:
-                        my_trajs[i] = full
-                        if self.current_trajectory is not None and self.current_trajectory.id == traj.id:
-                            self.current_trajectory = full
-                            self._env_step_indices = self._build_env_indices()
-                except Exception:
-                    pass  # leave stub; table will show "-" for unavailable stats
-            if self._bg_gen == my_gen:
-                self._bg_loading_done = True
-
-        thread = threading.Thread(target=_load_all, daemon=True)
-        thread.start()
 
     def refresh_experiment(self) -> bool:
         """Incrementally reload new or changed trajectories from disk. Returns True if anything changed.
@@ -845,7 +791,6 @@ def run_xray(
         if set(selected_names) == set(state._selected_exp_names):
             return tuple(gr.skip() for _ in range(9))  # type: ignore[return-value]
         if not selected_names:
-            state._bg_gen += 1
             state._selected_exp_names = []
             state.trajectories = []
             state.selected_agent_key = None
@@ -853,14 +798,12 @@ def run_xray(
         exp_dirs = [state.results_dir / name for name in selected_names]
         state.load_experiments(exp_dirs)
         hierarchy = _load_and_build_hierarchy()
-        timer_active = not state._bg_loading_done
-        return (*hierarchy, gr.Timer(active=timer_active))
+        return (*hierarchy, gr.Timer(active=state.should_poll()))
 
     def on_archive_selected() -> tuple[Any, str, Any, Any, Any, StepId, gr.Tab, gr.Tab, gr.Tab, str, str, gr.Timer]:
         """Archive all currently selected experiments and reset state."""
         for name in list(state._selected_exp_names):
             xray_utils.archive_experiment(state.results_dir, name)
-        state._bg_gen += 1
         state._selected_exp_names = []
         state.trajectories = []
         state.selected_agent_key = None
@@ -929,16 +872,12 @@ def run_xray(
         return _rows_to_table(current_traj_rows, traj_id, "_traj_id"), StepId(step=0)
 
     def on_bg_load_tick() -> tuple[Any, Any, Any, Any, str, gr.Timer, gr.Tab, gr.Tab, gr.Tab]:
-        """Periodic refresh handler: bulk-loads stubs, then live-polls for new/changed trajectories.
+        """Periodic live-poll: pick up new/changed trajectory files from a running experiment.
 
-        Two phases share a single timer:
-        1. While _bg_loading_done is False: background thread is still bulk-loading stubs.
-        2. Once _bg_loading_done is True: calls refresh_experiment() to pick up new or
-           changed trajectory files written by a running experiment. Timer deactivates only
-           when is_experiment_complete() returns True (all trajectories have end_time set).
+        Deactivates the timer once the experiment is complete (all trajectories terminal)
+        or stale (no file changes for a long time — runner likely crashed).
         """
-        if state._bg_loading_done:
-            state.refresh_experiment()
+        state.refresh_experiment()
 
         exp_stats = xray_utils.compute_experiment_stats(state.trajectories)
         agent_rows = xray_utils.build_agent_table(state.trajectories)
@@ -985,8 +924,7 @@ def run_xray(
         )
 
         experiment_done = state.is_experiment_complete() or state.is_experiment_stale()
-        still_active = not state._bg_loading_done or not experiment_done
-        timer_update = gr.Timer(active=still_active)
+        timer_update = gr.Timer(active=not experiment_done)
         tab_labels = _make_tab_labels(agent_rows, traj_rows)
         return exp_stats, agent_table_data, traj_table_data, progress_html, timer_update, *tab_labels
 
@@ -1642,7 +1580,7 @@ def run_xray(
                 )
             state.load_experiments([state.results_dir / rows[0]["experiment"]])
             hierarchy = _load_and_build_hierarchy()
-            return (*hierarchy, gr.Timer(active=not state._bg_loading_done))
+            return (*hierarchy, gr.Timer(active=state.should_poll()))
 
         # Two independent demo.load calls: one populates the exp table,
         # the other pre-loads the first experiment so the viewer is immediately usable.

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -193,6 +193,7 @@ def build_progress_html(
     n_running: int,
     per_agent: list[tuple[str, int, int, int]] | None = None,
     exp_names: list[str] | None = None,
+    ray_dashboard_urls: list[tuple[str, str]] | None = None,
 ) -> str:
     """Return an HTML progress bar + label for experiment completion status.
 
@@ -203,6 +204,8 @@ def build_progress_html(
         per_agent: Optional list of (agent_name, n_completed, n_total, n_running).
                    When provided with > 1 entry, a per-agent breakdown is appended.
         exp_names: Names of selected experiment directories being monitored.
+        ray_dashboard_urls: Optional list of (exp_name, url). Each becomes a clickable
+                   link to the live Ray dashboard for that experiment.
     """
     header = ""
     if exp_names:
@@ -225,8 +228,10 @@ def build_progress_html(
         label += f", {n_running} running ⏳"
     label += "</div>"
 
+    links = _build_ray_dashboard_links_html(ray_dashboard_urls, multi=bool(exp_names and len(exp_names) > 1))
+
     if not per_agent or len(per_agent) <= 1:
-        return header + bar + label
+        return header + bar + label + links
 
     rows_html = ""
     for agent_name, agent_done, agent_total, agent_running in per_agent:
@@ -244,7 +249,26 @@ def build_progress_html(
             f'<div style="min-width:60px;text-align:right;white-space:nowrap;">{agent_done}/{agent_total}{running_str}</div>'
             f"</div>"
         )
-    return header + bar + label + rows_html
+    return header + bar + label + links + rows_html
+
+
+def _build_ray_dashboard_links_html(ray_dashboard_urls: list[tuple[str, str]] | None, *, multi: bool) -> str:
+    """Render clickable Ray-dashboard link(s). Empty string when no URLs are available.
+
+    ``multi`` prefixes each link with its experiment name (only useful when several
+    experiments are being monitored at once).
+    """
+    if not ray_dashboard_urls:
+        return ""
+    parts = []
+    for name, url in ray_dashboard_urls:
+        safe_url = html_lib.escape(url, quote=True)
+        prefix = f"{html_lib.escape(name)}: " if multi else ""
+        parts.append(
+            f'{prefix}<a href="{safe_url}" target="_blank" rel="noopener" '
+            f'style="color:#1d4ed8;text-decoration:none;">🔗 Ray dashboard</a>'
+        )
+    return '<div style="font-size:11px;margin-top:4px;">' + " &nbsp;·&nbsp; ".join(parts) + "</div>"
 
 
 def archive_experiment(results_dir: Path, exp_name: str) -> None:

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -312,6 +312,17 @@ class Episode:
             ep_status.error_message = str(e)[:500]
             raise e
         finally:
+            # Persist summary_stats on terminal failure paths too (the success path sets it
+            # above). With it on the metadata stub, the XRay tables render correct
+            # step/token/cost stats without loading any steps — which is what makes the
+            # background bulk-loader unnecessary. Best-effort: never mask the real error,
+            # and save_trajectory is a safe re-save (the id is already in _saved_ids).
+            if trajectory is not None and not trajectory.summary_stats:
+                try:
+                    trajectory.summary_stats = _compute_summary_stats(trajectory)
+                    self.storage.save_trajectory(trajectory)
+                except Exception:
+                    logger.exception("Failed to persist summary_stats on terminal path")
             ep_status.ended_at = time.time()
             ep_status.last_heartbeat_at = ep_status.ended_at
             try:

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -383,17 +383,27 @@ class FileStorage:
         return result
 
     def _list_ids_with_mtime(self) -> dict[str, float]:
+        """Return ``{trajectory_id: episode-dir mtime}`` for every non-archived V2 episode dir.
+
+        Uses the directory's own mtime as the single change signal — one ``stat()`` per
+        episode rather than statting each inner file (summary/metadata/failure). This is
+        both cheaper (matters for 1000-episode runs polled once per second) and *more*
+        complete: a directory's mtime advances on any entry add/remove inside it, which
+        includes every atomic ``status.json`` write (tmp + ``os.replace``). Because the
+        run loop heartbeats ``status.json`` once per turn (``episode.py``), an active
+        episode's dir mtime advances each turn — so this one signal covers BOTH
+        trajectory-content changes and status-only transitions (STALE via ghost-sweep,
+        CANCELLED via the stall-killer), including QUEUED stubs that have no trajectory
+        file yet. The per-file approach missed the latter. See
+        ``XRayState.refresh_experiment``.
+        """
         result: dict[str, float] = {}
-        for ep_dir in self._episode_dirs():
-            traj_id = ep_dir.name
-            summary_path = ep_dir / "episode_summary.jsonl"
-            mtime = (
-                summary_path.stat().st_mtime if summary_path.exists() else (ep_dir / EPISODE_METADATA).stat().st_mtime
-            )
-            failure_path = ep_dir / "failure.txt"
-            if failure_path.exists():
-                mtime = max(mtime, failure_path.stat().st_mtime)
-            result[traj_id] = mtime
+        episodes_dir = self.output_dir / EPISODES_DIR
+        if not episodes_dir.exists():
+            return result
+        for ep_dir in episodes_dir.iterdir():
+            if ep_dir.is_dir() and ARCHIVED_MARKER not in ep_dir.name:
+                result[ep_dir.name] = ep_dir.stat().st_mtime
         return result
 
     def _v1_list_ids_with_mtime(self) -> dict[str, float]:

--- a/tests/test_cube_episode.py
+++ b/tests/test_cube_episode.py
@@ -3,10 +3,31 @@
 import warnings
 
 import pytest
-from cube.core import EnvironmentOutput
+from cube.core import EnvironmentOutput, Observation
 
+from cube_harness.agent import Agent, AgentConfig
 from cube_harness.core import AgentOutput
 from cube_harness.episode import Episode
+from cube_harness.storage import FileStorage
+
+
+class _FailingAgentConfig(AgentConfig):
+    """Agent config whose agent raises on the first step — for failure-path tests."""
+
+    def make(self, action_set: object = None, **kwargs: object) -> "Agent":
+        _ = action_set, kwargs
+        return _FailingAgent(config=self)
+
+
+class _FailingAgent(Agent):
+    name = "FailingAgent"
+    description = "Raises on step()."
+    input_content_types = ["text"]
+    output_content_types = ["action"]
+
+    def step(self, obs: Observation) -> AgentOutput:
+        _ = obs
+        raise RuntimeError("boom")
 
 
 class TestCubeEpisode:
@@ -74,6 +95,29 @@ class TestCubeEpisode:
         assert "profiling" in trajectory.reward_info
         trajectory.reward_info.pop("profiling")  # ignore profiling info for this test
         assert trajectory.reward_info == {"reward": 1.0, "done": True, "success": True}
+
+    def test_failed_episode_persists_summary_stats(self, tmp_dir, mock_cube_task_config):
+        """A FAILED episode must persist summary_stats to its metadata stub, so the XRay
+        tables render correct stats without loading steps (no background bulk-loader)."""
+        episode = Episode(
+            id=0,
+            output_dir=tmp_dir,
+            agent_config=_FailingAgentConfig(),
+            task_config=mock_cube_task_config,
+            exp_name="cube_test",
+            max_steps=5,
+            storage=None,
+            runtime_context=None,
+        )
+        with pytest.raises(RuntimeError):
+            episode.run()
+
+        trajs = FileStorage(tmp_dir).load_all_trajectory_metadata()
+        assert len(trajs) == 1
+        # Metadata loaded with steps=[] — stats must come from persisted summary_stats.
+        assert not trajs[0].steps
+        assert trajs[0].summary_stats
+        assert "n_env_steps" in trajs[0].summary_stats
 
     def test_episode_load_from_config_round_trip(self, tmp_dir, mock_agent_config, mock_cube_task_config):
         """Save EpisodeConfig to disk; reload via load_episode_from_config() without benchmark arg."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1244,17 +1244,27 @@ class TestFailureTextInjection:
         loaded = storage.load_trajectory("task_1_ep0")
         assert loaded.metadata.get("_failure_text") == "crash trace"
 
-    def test_list_ids_with_mtime_uses_failure_txt_mtime(self, tmp_dir: Path) -> None:
-        """list_trajectory_ids_with_mtime returns failure.txt mtime when it's newer."""
+    def test_list_ids_with_mtime_advances_on_dir_writes(self, tmp_dir: Path) -> None:
+        """list_trajectory_ids_with_mtime keys off the episode-dir mtime, which advances on
+        any write inside the dir — including failure.txt and, crucially, a status.json
+        rewrite (how the live viewer detects status-only transitions like RUNNING→STALE)."""
         storage = FileStorage(tmp_dir)
         traj = Trajectory(id="task_1_ep0", metadata={"task_id": "task_1"})
         storage.save_trajectory(traj)
-        time.sleep(0.01)  # ensure different mtime
-        failure_path = storage._episode_dir("task_1_ep0") / "failure.txt"
-        failure_path.write_text("crash")
+        before = storage.list_trajectory_ids_with_mtime()["task_1_ep0"]
 
-        mtimes = storage.list_trajectory_ids_with_mtime()
-        assert mtimes["task_1_ep0"] >= failure_path.stat().st_mtime
+        time.sleep(0.01)
+        (storage._episode_dir("task_1_ep0") / "failure.txt").write_text("crash")
+        after_failure = storage.list_trajectory_ids_with_mtime()["task_1_ep0"]
+        assert after_failure > before
+
+        time.sleep(0.01)
+        storage.write_episode_status(
+            "task_1_ep0",
+            EpisodeStatus(status="STALE", task_id="task_1", episode_id=0, started_at=1.0),
+        )
+        after_status = storage.list_trajectory_ids_with_mtime()["task_1_ep0"]
+        assert after_status > after_failure
 
 
 class TestEpisodeResultAPI:

--- a/tests/test_xray_refresh.py
+++ b/tests/test_xray_refresh.py
@@ -1,0 +1,115 @@
+"""Tests for XRayState live-refresh status reconciliation (BUG-1).
+
+A status transition that rewrites only ``status.json`` — STALE via the ghost-sweep,
+CANCELLED via the stall-killer, or a never-started QUEUED episode going STALE — must be
+picked up by ``refresh_experiment`` during live polling. Previously the change-detection
+keyed off trajectory-file mtimes and missed these; now it keys off the episode-directory
+mtime (bumped by every atomic ``status.json`` write).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from cube_harness.analyze import xray_utils
+from cube_harness.analyze.xray import XRayState
+from cube_harness.core import Trajectory
+from cube_harness.episode_status import EpisodeStatus
+from cube_harness.storage import FileStorage
+
+
+def _wait_bg_done(state: XRayState, timeout: float = 5.0) -> None:
+    """Block until the background bulk-loader thread has finished."""
+    deadline = time.time() + timeout
+    while not state._bg_loading_done and time.time() < deadline:
+        time.sleep(0.01)
+
+
+def _bump_dir_mtime(ep_dir: Path) -> None:
+    """Force the episode dir's mtime forward so refresh treats it as changed regardless
+    of filesystem mtime granularity (writes within the same tick can otherwise tie)."""
+    future = time.time() + 100
+    os.utime(ep_dir, (future, future))
+
+
+def _status_of(state: XRayState, traj_id: str) -> str:
+    traj = next(t for t in state.trajectories if t.id == traj_id)
+    return xray_utils.trajectory_status(traj)
+
+
+def _write_status(storage: FileStorage, traj_id: str, task_id: str, status: str, *, heartbeat: bool) -> None:
+    storage.write_episode_status(
+        traj_id,
+        EpisodeStatus(
+            status=status,
+            task_id=task_id,
+            episode_id=0,
+            started_at=1.0,
+            last_heartbeat_at=time.time() if heartbeat else None,
+        ),
+    )
+
+
+def test_running_episode_to_stale_is_picked_up_live(tmp_path: Path) -> None:
+    """A started (metadata-having) RUNNING episode flipped to STALE in status.json only
+    must refresh to 'stale' — exercises the full-reload path off the dir mtime."""
+    exp_dir = tmp_path / "exp_run"
+    storage = FileStorage(exp_dir)
+    traj_id, task_id = "task_1_ep0", "task_1"
+    # A started episode: trajectory file exists, no end_time, status RUNNING.
+    storage.save_trajectory(Trajectory(id=traj_id, metadata={"task_id": task_id, "agent_name": "a"}, start_time=1.0))
+    _write_status(storage, traj_id, task_id, "RUNNING", heartbeat=True)
+
+    state = XRayState(results_dir=tmp_path)
+    assert state.load_experiment(exp_dir)
+    _wait_bg_done(state)
+    assert _status_of(state, traj_id) == "running"
+
+    # Worker dies → ghost-sweep rewrites only status.json (trajectory file untouched).
+    _write_status(storage, traj_id, task_id, "STALE", heartbeat=True)
+    _bump_dir_mtime(storage._episode_dir(traj_id))
+
+    assert state.refresh_experiment() is True
+    assert _status_of(state, traj_id) == "stale"
+
+
+def test_queued_stub_to_stale_is_picked_up_live(tmp_path: Path) -> None:
+    """A never-started QUEUED episode (config + status.json, no trajectory file) flipped to
+    STALE must refresh to 'stale' — exercises the stub re-inject fallback."""
+    exp_dir = tmp_path / "exp_queue"
+    storage = FileStorage(exp_dir)
+    traj_id, task_id = "task_2_ep0", "task_2"
+    ep_dir = storage._episode_dir(traj_id)
+    ep_dir.mkdir(parents=True)
+    (ep_dir / "episode_config.json").write_text(json.dumps({"task_id": task_id}))
+    _write_status(storage, traj_id, task_id, "QUEUED", heartbeat=False)
+
+    state = XRayState(results_dir=tmp_path)
+    assert state.load_experiment(exp_dir)
+    _wait_bg_done(state)
+    assert _status_of(state, traj_id) == "queued"
+
+    # Driver dies → ghost-sweep promotes the orphaned QUEUED episode to STALE.
+    _write_status(storage, traj_id, task_id, "STALE", heartbeat=False)
+    _bump_dir_mtime(ep_dir)
+
+    assert state.refresh_experiment() is True
+    assert _status_of(state, traj_id) == "stale"
+
+
+def test_no_status_change_is_not_reported_as_changed(tmp_path: Path) -> None:
+    """A refresh with no on-disk change must report nothing changed (no spurious reloads)."""
+    exp_dir = tmp_path / "exp_idle"
+    storage = FileStorage(exp_dir)
+    traj_id, task_id = "task_3_ep0", "task_3"
+    storage.save_trajectory(Trajectory(id=traj_id, metadata={"task_id": task_id, "agent_name": "a"}, start_time=1.0))
+    _write_status(storage, traj_id, task_id, "RUNNING", heartbeat=True)
+
+    state = XRayState(results_dir=tmp_path)
+    assert state.load_experiment(exp_dir)
+    _wait_bg_done(state)
+
+    assert state.refresh_experiment() is False

--- a/tests/test_xray_refresh.py
+++ b/tests/test_xray_refresh.py
@@ -21,13 +21,6 @@ from cube_harness.episode_status import EpisodeStatus
 from cube_harness.storage import FileStorage
 
 
-def _wait_bg_done(state: XRayState, timeout: float = 5.0) -> None:
-    """Block until the background bulk-loader thread has finished."""
-    deadline = time.time() + timeout
-    while not state._bg_loading_done and time.time() < deadline:
-        time.sleep(0.01)
-
-
 def _bump_dir_mtime(ep_dir: Path) -> None:
     """Force the episode dir's mtime forward so refresh treats it as changed regardless
     of filesystem mtime granularity (writes within the same tick can otherwise tie)."""
@@ -64,8 +57,7 @@ def test_running_episode_to_stale_is_picked_up_live(tmp_path: Path) -> None:
     _write_status(storage, traj_id, task_id, "RUNNING", heartbeat=True)
 
     state = XRayState(results_dir=tmp_path)
-    assert state.load_experiment(exp_dir)
-    _wait_bg_done(state)
+    assert state.load_experiment(exp_dir)  # synchronous: no bulk-loader to wait for
     assert _status_of(state, traj_id) == "running"
 
     # Worker dies → ghost-sweep rewrites only status.json (trajectory file untouched).
@@ -88,8 +80,7 @@ def test_queued_stub_to_stale_is_picked_up_live(tmp_path: Path) -> None:
     _write_status(storage, traj_id, task_id, "QUEUED", heartbeat=False)
 
     state = XRayState(results_dir=tmp_path)
-    assert state.load_experiment(exp_dir)
-    _wait_bg_done(state)
+    assert state.load_experiment(exp_dir)  # synchronous: no bulk-loader to wait for
     assert _status_of(state, traj_id) == "queued"
 
     # Driver dies → ghost-sweep promotes the orphaned QUEUED episode to STALE.
@@ -109,7 +100,6 @@ def test_no_status_change_is_not_reported_as_changed(tmp_path: Path) -> None:
     _write_status(storage, traj_id, task_id, "RUNNING", heartbeat=True)
 
     state = XRayState(results_dir=tmp_path)
-    assert state.load_experiment(exp_dir)
-    _wait_bg_done(state)
+    assert state.load_experiment(exp_dir)  # synchronous: no bulk-loader to wait for
 
     assert state.refresh_experiment() is False

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -1470,3 +1470,40 @@ class TestGetLogsTabMarkdownEpisodeStatus:
         traj = Trajectory(id="t", metadata={})
         result = xray_utils.get_logs_tab_markdown(traj, "")
         assert "Episode Status" not in result
+
+
+class TestBuildProgressHtml:
+    def test_progress_label_and_bar_width(self) -> None:
+        html = xray_utils.build_progress_html(3, 4, 1)
+        assert "3/4 episodes completed" in html
+        assert "1 running" in html
+        assert "width:75.0%" in html
+
+    def test_no_ray_link_when_url_absent(self) -> None:
+        html = xray_utils.build_progress_html(1, 2, 0)
+        assert "Ray dashboard" not in html
+
+    def test_ray_dashboard_link_is_clickable(self) -> None:
+        html = xray_utils.build_progress_html(1, 2, 1, ray_dashboard_urls=[("exp_a", "http://127.0.0.1:8265")])
+        assert '<a href="http://127.0.0.1:8265"' in html
+        assert 'target="_blank"' in html
+        assert "🔗 Ray dashboard" in html
+
+    def test_ray_dashboard_link_prefixes_name_for_multiple_experiments(self) -> None:
+        html = xray_utils.build_progress_html(
+            0,
+            2,
+            0,
+            exp_names=["exp_a", "exp_b"],
+            ray_dashboard_urls=[("exp_a", "http://a:8265"), ("exp_b", "http://b:8265")],
+        )
+        assert "exp_a: " in html
+        assert "exp_b: " in html
+        assert html.count("🔗 Ray dashboard") == 2
+
+    def test_ray_dashboard_url_is_escaped(self) -> None:
+        html = xray_utils.build_progress_html(
+            0, 1, 0, ray_dashboard_urls=[("e", 'http://x"><script>alert(1)</script>')]
+        )
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html


### PR DESCRIPTION
## Summary

Removes the XRay **background bulk-loader** — a documented temporary workaround that's
now obsolete.

It spawned a daemon thread that, on every experiment open, eagerly loaded the **full
steps of every trajectory** purely to compute the agent/task/seed table stats — and
**kept them in memory**, accumulating ~20 GB on image-heavy benchmarks (OSWorld). Its own
docstring named the long-term fix: *"persist per-episode stats… making bulk loading
unnecessary."* That's now the case:

- `summary_stats` is persisted into `episode.metadata.json`, the metadata stub carries it,
  and `compute_trajectory_stats` returns it directly — so **every table renders from stubs
  without loading any steps**. `_episode_status` comes from `status.json`.
- Full steps load **lazily**: `select_trajectory` for the one you open, `refresh_experiment`
  for in-flight ones — never eagerly for all.

## Changes

- **episode**: persist `summary_stats` on terminal **failure** paths too (success already
  did), so FAILED/INVALID_CONFIG episodes render from the stub. Best-effort, safe re-save.
- **xray**: delete `_start_background_loading` / `_load_all` and the `_bg_loading_done` /
  `_bg_gen` coordination (and the `threading` import). The live timer is active iff an
  experiment is loaded and not yet complete (`should_poll`). Net −50 lines in `xray.py`,
  and the daemon-thread/generation-counter concurrency is gone.

## Tests

- New: a FAILED episode persists `summary_stats` to its metadata stub.
- Existing xray refresh/status tests + the stale-flip smoke updated for the now-synchronous
  load — all green.

## Merge notes

- **Stacked on #440** (live status-only refresh). The diff shows #440's commit until it
  merges; combine the `refresh_experiment` edits if merging out of order.
- **Supersedes #379's xray `_load_all` step-eviction** (that code is removed here). #379's
  `exp_runner` driver-memory clear and `max_steps` stats fix are independent and still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
