### PR TITLE
fix(swebench-verified): relocate when root-owned subdirs block non-root patching

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -170,12 +170,30 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
             f" 2>/dev/null || true",
             timeout=120,
         )
+        # auto-fix(443)↓ root-owned non-writable SUBDIRS defeat the in-place cp/mv
+        # (it needs a writable parent) and the top-dir `test -w` probe misses them.
+        # The cp/mv ownership trick above only fixes files whose PARENT dir is
+        # writable (mv unlinks the original via the writable parent). Images that
+        # ship root-owned, non-writable SUBDIRECTORIES (e.g. psf/requests'
+        # /testbed/requests/) leave .py files unpatchable on a non-root runtime —
+        # and `test -w /testbed` (top dir only) misses it, so relocate never fires
+        # and every patch/edit dies with "Permission denied". Detect any leftover
+        # non-writable .py file and force a relocate to a fully runtime-user-owned
+        # /tmp/testbed copy. Root-running infras leave nothing non-writable here, so
+        # this never triggers for them.
+        leftover = self._container.exec(
+            f"find {self.tool_config.working_dir} -not -path '*/.git/*' -name '*.py' ! -writable -print -quit 2>/dev/null || true",
+            timeout=60,
+        )
+        force_relocate = bool(leftover.stdout.strip())
         new_wd = relocate_if_readonly(
             self._container,
             self.tool_config.working_dir,
             "/tmp/testbed",
             extra_setup="git config --global --add safe.directory /tmp/testbed",
+            force=force_relocate,
         )
+        # /auto-fix(443)
         self._tool = self.tool_config.model_copy(update={"working_dir": new_wd}).make(container=self._container)
 
     def reset(self) -> tuple[Observation, dict[str, Any]]:
@@ -450,3 +468,13 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
 # === auto-fix notes ===
 # auto-fix-note(423) {class=L1 anchor=PR#423 hash=00588ac5 ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}
 # auto-fix-note(430) {class=L1 anchor=PR#430 hash=6a2bbc39 ctx=daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck}
+# auto-fix-note(443) {class=L1 anchor=PR#443 hash=PENDING ctx=toolkit/uid-13011/swebench-verified/psf__requests-1142}
+#   symptoms:  non-root toolkit — root-owned /testbed/requests/ subdir; in-place
+#              cp/mv can't reparent files in a dir it doesn't own, top-dir `test -w`
+#              probe misses it, so gold patch + agent edits hit Permission denied.
+#   invariant: every .py the agent/eval must patch is writable before tool build.
+#   why:       relocate to a fully runtime-user-owned /tmp/testbed (cube-standard
+#              relocate_if_readonly force=, PR#205); only fires when non-writable
+#              .py remain, so writable-tree tasks are unchanged (no regression).
+#   tested:    psf/requests gold patch 0/6 -> 6/6 on toolkit; 1142/1724 verified 0->1.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.


### PR DESCRIPTION
# Fix Report — SWE-bench Verified patchable on non-root infra

**Class**: L1 (cube setup path; uses a new cube-standard primitive) · **Anchor**: this PR
**Context fingerprint**: `toolkit/yul101/uid-13011/GoldPatchAgent+genny/swebench-verified@dev`
**Depends-on**: cube-standard/auto-fix/relocate-readonly-force

## Invariant violated
On a non-root infra, **every source file the agent or the evaluator must patch
must be writable by the runtime user** before the tool is built. Otherwise a
correct patch — gold or agent-authored — cannot be applied.

## Root cause
SWE-bench images are built `USER root` with a root-owned `/testbed`. `_build_tool`
normalises writability for the non-root case (EAI toolkit pins uid 13011) with
an in-place `cp "$1" "$1.tmp" && mv "$1.tmp" "$1"` over non-writable `.py`. That
trick only works when the file's **parent directory is writable** (the `mv`
unlinks the original via the writable parent). Images that ship root-owned,
**non-writable subdirectories** (`psf/requests` → `/testbed/requests/`) defeat
it: the `mv` fails and the failure is swallowed by `2>/dev/null || true`. The
trailing relocate probe is `test -w /testbed` (top dir only) — `/testbed` itself
is writable, so it never relocates. Result: `requests/models.py` stays root-owned
read-only and **every** `git apply` dies:

```
error: unable to write file 'requests/models.py' mode 100644: Permission denied
patch: **** Can't create temporary file requests/models.py.* : Permission denied  [exit_code: 2]
```

This is invisible to scoring — it presents as the task simply "not solved".

## Evidence (gold-patch differential, oracle = $0 LLM, deterministic)
500-task gold-patch validation on toolkit surfaced 15 non-resolving tasks. Daytona
(root) control + this fix split them:

| group | toolkit (old) | daytona/root | toolkit + this fix |
|---|---|---|---|
| `psf/requests` × 6 | **FAIL (perm denied)** | pass | **PASS (6/6)** |
| `matplotlib-23314` | fail | pass | still fails — `ImportPathMismatchError` after relocate (lib/-layout editable; see Limitation) |
| 8 others (astropy×3, django, pylint, sphinx, sympy×2) | fail | **fail** | n/a (eval-brittle, not root — separate issue) |

`psf__requests-1142` and `-1724` directly verified 0.0 → 1.0 on toolkit with the fix.

## Why this fix / why this layer
- The writability normalisation lives in swebench `_build_tool`; the relocate
  primitive lives in cube-standard (the `force=` knob, paired PR).
- Files in root-owned dirs **cannot** be made writable in place without root
  (can't reparent inside a dir you don't own) → the only non-root escape is a
  fully runtime-user-owned copy. `relocate_if_readonly(force=True)` provides it.
- Triggered **only** when non-writable `.py` remain after the cp/mv pass, so the
  9/10 already-passing tasks (writable trees) keep the in-place path → no regression.

## Blast radius
- `cubes/swebench-verified-cube/.../task.py:_build_tool` only.
- `swebench-live-cube` has the **identical** `_build_tool` and the same latent
  bug — intentionally not touched here; follow-up to apply the same change.

## Adversarial: the opposite user — and a known limitation
*Repos installed editable from `/testbed` — does relocating to `/tmp/testbed`
make the eval import the unpatched original?* For **flat-layout** repos (package
at repo root, e.g. `requests/`), no: `python -m pytest` runs from the working
dir, putting `/tmp/testbed` on `sys.path[0]`, so the relocated (patched) copy is
imported. Confirmed: all 6 requests tasks pass; both genny haiku & gpt-5.4-mini
also solve `requests-1142` on toolkit after the fix.

**Limitation (disclosed):** for **`lib/`- or `src/`-layout repos that are
editable-installed pointing at `/testbed`** (e.g. `matplotlib`), the relocate
introduces a *different* failure: pytest resolves the same module at both
`/testbed/...` (installed egg-link) and `/tmp/testbed/...` (cwd) →
`ImportPathMismatchError`. So this fix **resolves flat-layout repos and only
changes the failure mode (perm-denied → import-mismatch) for lib/-layout
editable repos** — those fundamentally need root (a non-root reinstall into the
root-owned conda env is impossible), or a follow-up (`--import-mode=importlib`,
or in-place dir-reparent that keeps `/testbed`). Tracked as a follow-up.

**No regression:** relocate fires *only* when non-writable `.py` remain after the
cp/mv pass, i.e. only on tasks that were **already failing** on non-root infra.
Currently-passing tasks (writable trees) keep the in-place path, unchanged.

## Test
- `psf__requests-*` gold patch on toolkit (uid 13011): 0/6 → 6/6 resolved.
- Non-triggering tasks (writable `/testbed`) keep the in-place path, scores unchanged.
