### PR TITLE
fix(terminalbench2): grade from CTRF report + flag verifier-only failures

### DIFF
--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
@@ -2,6 +2,7 @@
 
 import base64
 import io
+import json
 import logging
 import re
 import shlex
@@ -19,6 +20,10 @@ from cube.tools.terminal import ContainerTerminalTool, TerminalToolConfig
 from terminalbench2_cube.pytest_parser import PytestParser
 
 logger = logging.getLogger(__name__)
+
+# CTRF statuses that count as a pass, mirroring PytestParser's mapping
+# (skipped / xfail are treated as passed).
+_CTRF_PASS_STATUSES = frozenset({"passed", "skipped", "xfail"})
 
 
 class TerminalBench2TaskMetadata(TaskMetadata):
@@ -214,7 +219,14 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
             timeout=self._exec.max_test_timeout_sec,
         )
         # /auto-fix(447)
-        test_results = self._parse_pytest_output(output)
+
+        # Prefer the structured CTRF report the upstream test.sh writes
+        # (`pytest --ctrf <verifier>/ctrf.json`) over regex-parsing stdout: the
+        # report survives the heavy eval-time `apt`/`uvx` install logs that
+        # routinely truncate pytest's summary out of the captured stdout, and it
+        # is immune to pytest text-format drift.
+        ctrf_raw = self.tool.bash(f"cat {self._logs_verifier_dir}/ctrf.json 2>/dev/null || true")
+        test_results, verifier_ran = self._parse_verifier_results(ctrf_raw, output)
 
         # Read reward written by test.sh
         reward_output = self.tool.bash(f"cat {self._logs_verifier_dir}/reward.txt 2>/dev/null || echo 0")
@@ -224,12 +236,25 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
             reward = 0.0
 
         n_passed = sum(1 for r in test_results.values() if r == "passed")
+        total = len(test_results)
+        if not verifier_ran:
+            logger.warning(
+                "%s: verifier produced no gradeable result (deps/collection failed); "
+                "reward=%s is an eval artifact, not a graded failure",
+                self.metadata.id,
+                reward,
+            )
         return reward, {
             "done": True,
             "passed": n_passed,
-            "total": len(test_results),
-            "all_passed": len(test_results) > 0 and n_passed == len(test_results),
+            "total": total,
+            "all_passed": total > 0 and n_passed == total,
             "test_results": test_results,
+            # False => the verifier itself produced no gradeable result (deps
+            # wouldn't install / tests didn't collect). reward=0 is then an
+            # infra/eval artifact, NOT evidence the solution is wrong — callers
+            # should separate it from a genuine graded 0 (don't count against the model).
+            "verifier_ran": verifier_ran,
             "output_preview": output[:1000] if output else "",
         }
 
@@ -461,8 +486,45 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
             self._task_path = None
         super().close()
 
+    # auto-fix(444)↓
+    def _parse_verifier_results(self, ctrf_raw: str, stdout: str) -> tuple[dict[str, str], bool]:
+        """Resolve per-test results and whether the verifier actually graded.
+
+        Returns ``(test_results, verifier_ran)``. Prefers the structured CTRF
+        JSON report (``pytest --ctrf``); falls back to stdout heuristics only
+        when no report was written.
+
+        ``verifier_ran`` is **False** when the verifier produced no gradeable
+        result: no CTRF file *and* no parseable stdout, or a CTRF report with
+        zero collected tests. That means the verifier's own setup/collection
+        failed (eval-time deps wouldn't install, test import error) rather than
+        the agent's solution being wrong — a `reward=0` in that case is an
+        infra/eval artifact, not a graded failure.
+        """
+        ctrf_raw = (ctrf_raw or "").strip()
+        if ctrf_raw:
+            try:
+                tests = json.loads(ctrf_raw).get("results", {}).get("tests", [])
+            except (ValueError, TypeError, AttributeError):
+                logger.warning("Could not parse CTRF report; falling back to stdout parsing")
+            else:
+                results = {
+                    (t.get("name") or f"test_{i}"): ("passed" if t.get("status") in _CTRF_PASS_STATUSES else "failed")
+                    for i, t in enumerate(tests)
+                }
+                # CTRF written with >=1 collected test => a real graded result.
+                # CTRF written with 0 tests => pytest ran but collected nothing
+                # (collection/setup failure) => not gradeable.
+                return results, bool(results)
+
+        results = self._parse_pytest_output(stdout)
+        return results, bool(results)
+
+    # /auto-fix(444)
+
     def _parse_pytest_output(self, output: str) -> dict[str, str]:
-        """Parse pytest output, falling back to regex heuristics."""
+        """Parse pytest stdout, falling back to regex heuristics. Used only when
+        no CTRF report is available (see _parse_verifier_results)."""
         try:
             return {name: status.value for name, status in PytestParser().parse(output).items()}
         except ValueError:
@@ -526,3 +588,4 @@ class TerminalBench2TaskConfig(TaskConfig[TerminalBench2TaskMetadata]):
 # auto-fix-note(418) {class=L1 anchor=PR#418 hash=PENDING ctx=toolkit/eai-yul101/runtime-uid-13011/tbench2:configure-git-webserver+nginx-request-logging+sqlite-with-gcov/cube-harness@1e67efdb}
 # auto-fix-note(420) {class=L1 anchor=PR#420 hash=PENDING ctx=toolkit/eai-yul101/cube_assets:stale-uv<0.4/tbench2:fix-git+nginx-request-logging+sqlite-with-gcov/cube-harness@1e67efdb}
 # auto-fix-note(447) {class=L1 anchor=PR#447 hash=PENDING ctx=daytona+all-infra/verifier-clamped-to-agent-max_timeout-900/tbench2:reshard-c4-data+sam-cell-seg+20-tasks-over-900s/cube-harness@0c3861ca}
+# auto-fix-note(444) {class=L1 anchor=PR#444 hash=PENDING ctx=daytona/heavy-eval-deps/tbench2:pytorch-model-cli+sam-cell-seg+mcmc-sampling-stan/cube-harness@0c3861ca}

--- a/cubes/terminalbench2-cube/tests/test_verifier_parsing.py
+++ b/cubes/terminalbench2-cube/tests/test_verifier_parsing.py
@@ -1,0 +1,78 @@
+"""Pins the verifier-result resolution invariant in `TerminalBench2Task`.
+
+The upstream `test.sh` writes a structured CTRF report (`pytest --ctrf`). We
+prefer it over regex-parsing stdout because heavy eval-time `apt`/`uvx`
+installs routinely truncate pytest's text summary out of the captured stdout
+(observed on pytorch-model-cli / sam-cell-seg / mcmc-sampling-stan, where even
+the *reference* solution scored total=0). `verifier_ran` distinguishes a real
+graded result from a verifier that never produced one (deps wouldn't install /
+tests didn't collect) — so a `reward=0` of the latter kind isn't conflated with
+a genuine graded failure.
+"""
+
+from __future__ import annotations
+
+import json
+
+from terminalbench2_cube.task import TerminalBench2Task
+
+
+def _bare_task() -> TerminalBench2Task:
+    """A method-only TerminalBench2Task: `_parse_verifier_results` uses no
+    instance state, so `__new__` (no Pydantic init / container) suffices."""
+    return TerminalBench2Task.__new__(TerminalBench2Task)
+
+
+def test_ctrf_with_tests_is_graded_and_marks_ran() -> None:
+    ctrf = json.dumps(
+        {
+            "results": {
+                "tests": [
+                    {"name": "test_a", "status": "passed"},
+                    {"name": "test_b", "status": "failed"},
+                    {"name": "test_c", "status": "skipped"},  # skipped counts as pass
+                ]
+            }
+        }
+    )
+    results, ran = _bare_task()._parse_verifier_results(ctrf, "stdout ignored when CTRF present")
+    assert ran is True
+    assert results == {"test_a": "passed", "test_b": "failed", "test_c": "passed"}
+
+
+def test_ctrf_zero_tests_marks_not_ran() -> None:
+    """mcmc-sampling-stan case: pytest ran but collected 0 tests (setup failed)."""
+    ctrf = json.dumps({"results": {"summary": {"tests": 0}, "tests": []}})
+    results, ran = _bare_task()._parse_verifier_results(ctrf, "apt/uvx logs, no pytest summary")
+    assert results == {}
+    assert ran is False
+
+
+def test_ctrf_survives_truncated_stdout() -> None:
+    """The whole point: a valid CTRF report grades correctly even when stdout
+    is just the (truncated) install log with no pytest summary."""
+    ctrf = json.dumps({"results": {"tests": [{"name": "t1", "status": "passed"}]}})
+    truncated_stdout = "Get:1 http://deb.debian.org/debian ... Building dependency tree ..."
+    results, ran = _bare_task()._parse_verifier_results(ctrf, truncated_stdout)
+    assert ran is True
+    assert results == {"t1": "passed"}
+
+
+def test_no_ctrf_falls_back_to_stdout() -> None:
+    results, ran = _bare_task()._parse_verifier_results("", "===== 3 passed, 1 failed in 2.1s =====")
+    assert ran is True
+    assert sum(1 for v in results.values() if v == "passed") == 3
+
+
+def test_no_ctrf_no_results_marks_not_ran() -> None:
+    """sam-cell-seg case: install failed before pytest → no CTRF, no parseable stdout."""
+    stdout = "ERROR: No matching distribution found for torch==2.5.1+cpu"
+    results, ran = _bare_task()._parse_verifier_results("", stdout)
+    assert results == {}
+    assert ran is False
+
+
+def test_malformed_ctrf_falls_back_to_stdout() -> None:
+    results, ran = _bare_task()._parse_verifier_results("{not valid json", "===== 5 passed in 1s =====")
+    assert ran is True
+    assert sum(1 for v in results.values() if v == "passed") == 5


### PR DESCRIPTION
## Invariant violated

A terminalbench2 episode's reward must reflect **the agent's solution**, and `evaluate()`'s reported `passed`/`total` must reflect **what the verifier actually graded** — not whether the verifier's own setup happened to survive being captured on stdout.

## Root cause

Every upstream `test.sh` runs `pytest --ctrf <verifier>/ctrf.json` — it writes a **structured CTRF JSON report** and a numeric `reward.txt`. `evaluate()` read `reward.txt` for the reward but reconstructed `passed`/`total` by **regex-parsing pytest's stdout text**. Two failure modes followed, both confirmed on Daytona with the **reference** solutions (oracle mode):

- **Truncation.** Heavy eval-time installs (`apt-get install ffmpeg`, `uvx -w torch …`) emit tens of KB to stdout (pytorch-model-cli: 77 KB). pytest's summary is pushed out of the captured window → stdout parse yields `total=0` even when pytest passed.
- **Verifier-setup failure conflated with a graded fail.** When the verifier's deps don't install (`No matching distribution found for torch==2.5.1+cpu` for sam-cell-seg; rstan/CRAN for mcmc-sampling-stan), pytest never grades — but `reward.txt` is still `0` (the `else` branch), so the episode looks like a normal `reward=0` graded failure. The reference solutions all scored 0 this way.

## Why this fix / why this layer

- **Parse the CTRF report the verifier already writes**, falling back to stdout only when it's absent — it's immune to stdout truncation and pytest text-format drift, and it's the verifier's own machine-readable output (consistent with already trusting its `reward.txt`).
- **`verifier_ran` is the clean discriminator**: CTRF written with ≥1 collected test ⇒ a real grade; CTRF absent, or present with 0 collected tests, ⇒ the verifier never produced a gradeable result. Emitting it in `evaluate()`'s `info` lets downstream (summary/Investigator/reporting) stop counting eval/infra failures against the model — the wrapper-faithfulness property.
- **Layer:** entirely within the cube's `evaluate()`. Additive `info` key (no contract change); `_parse_pytest_output` retained as the fallback.

## Blast radius

- `cubes/terminalbench2-cube/src/terminalbench2_cube/task.py`: `evaluate()` (parse path + new `info` key + a warning), new `_parse_verifier_results`, module const `_CTRF_PASS_STATUSES`.
- New consumers of `info["verifier_ran"]` are opt-in; nothing currently keys on it.
- `grep -rn "verifier_ran\|_parse_pytest_output" cubes/ src/` (on this branch): only the cube + its new test.

## Adversarial "opposite user"

A reviewer worried this hides real failures: it does **not** change `reward` (still from `reward.txt`); it only adds a distinguishing signal and makes `passed`/`total` accurate. Could an agent fake a green CTRF? It can't — the file is written by the upstream `pytest --ctrf` invocation inside `test.sh`, which the agent doesn't control. Could a task legitimately have 0 tests? terminalbench2 tasks always ship tests; `tests:0` means collection failed (a verifier/infra problem), which is exactly what `verifier_ran=False` should flag.

## Registry lookup

Nearby `auto-fix` notes in this file: `auto-fix-note(418)` (non-root `/app` relocation) and `auto-fix-note(420)` (stale uv). Both are `ctx=toolkit/…`; this one is `ctx=daytona/heavy-eval-deps/…` — orthogonal area (verifier result parsing vs container setup). No overlap.

## Class

**L1** (correct; touches the cube's shared `evaluate()` path, used by every terminalbench2 task). Marker `auto-fix(PENDING)` → amended to the PR number on open.

## Test

- `tests/test_verifier_parsing.py` (6 cases): CTRF with mixed pass/fail/skipped → graded + `verifier_ran=True`; CTRF `tests:0` → `({}, False)`; **CTRF grades correctly despite truncated stdout**; no-CTRF + parseable stdout → fallback + `True`; no-CTRF + install-error stdout → `({}, False)`; malformed CTRF → stdout fallback.
- End-to-end (oracle reference solutions, Daytona): `fix-git` → reward=1.0, real tests graded, no warning; `mcmc-sampling-stan` & `sam-cell-seg` → `verifier_ran=False` warning. Witness: `fix-git=1.0/graded  mcmc=0.0/verifier_ran=False  sam=0.0/verifier_ran=False`.

## Follow-ups (not in this PR)

- **Summary layer:** exclude `verifier_ran=False` episodes from the accuracy denominator (report an `infra/verifier-error` rate separately) — the harness-level half of wrapper-faithfulness.
- **Upstream task images:** pre-stage the heavy verifier deps (torch wheels, rstan) so these tasks become *scorable* on Daytona, rather than only correctly *flagged* as unscorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
