### PR TITLE
fix(exp_runner): time out QUEUED orphans so a dead Ray worker can't hang the run

### DIFF
--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -40,6 +40,9 @@ _CLEANUP_GRACE_TIMEOUT_S: float = 30.0
 DEFAULT_STEP_TIMEOUT_S: float = 9000.0
 DEFAULT_SETUP_TIMEOUT_S: float = 4 * DEFAULT_STEP_TIMEOUT_S  # container scheduling can queue
 DEFAULT_CANCEL_GRACE_S: float = 120.0
+# A driver-pre-claimed episode that Ray never picks up (worker died / unschedulable)
+# is failed after this long in QUEUED so it can't hang the poll loop indefinitely.
+DEFAULT_ORPHAN_THRESHOLD_S: float = 3600.0
 
 # How often the driver updates experiment_status.json in Ray mode.
 _EXP_HEARTBEAT_INTERVAL_S: float = 30.0
@@ -285,7 +288,7 @@ def run_with_ray(
     step_timeout_s: float = DEFAULT_STEP_TIMEOUT_S,
     setup_timeout_s: float = DEFAULT_SETUP_TIMEOUT_S,
     cancel_grace_s: float = DEFAULT_CANCEL_GRACE_S,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
@@ -451,6 +454,7 @@ def _run_with_ray_impl(
                 step_timeout_s=step_timeout_s,
                 setup_timeout_s=setup_timeout_s,
                 cancel_grace_s=cancel_grace_s,
+                orphan_threshold_s=orphan_threshold_s,
                 exp_status=exp_status,
                 exp_status_path=exp_status_path,
             )
@@ -478,6 +482,7 @@ def _poll_ray(
     step_timeout_s: float,
     setup_timeout_s: float,
     cancel_grace_s: float,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     exp_status: ExperimentStatus,
     exp_status_path: Path,
 ) -> ExpResult:
@@ -520,6 +525,7 @@ def _poll_ray(
             step_timeout_s=step_timeout_s,
             setup_timeout_s=setup_timeout_s,
             cancel_grace_s=cancel_grace_s,
+            orphan_threshold_s=orphan_threshold_s,
         )
 
         # Heartbeat experiment_status.json so XRay knows this driver is alive.
@@ -552,23 +558,53 @@ def _kill_stale_workers(
     step_timeout_s: float,
     setup_timeout_s: float,
     cancel_grace_s: float,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
 ) -> None:
-    """Read each active episode's status.json; force-kill workers with stale heartbeats.
+    """Read each active episode's status.json; force-kill stalled/orphaned workers.
 
-    Uses a phase-aware budget: episodes still in setup (current_step == 0) are given
-    `setup_timeout_s`; episodes that have entered the agent loop get the full `step_timeout_s`.
-    This lets setup hangs (container boot, env reset) be detected quickly without
-    shortening the budget for legitimate long-running agent steps.
+    Two stall classes are handled so the poll loop can't hang on a ref forever:
+    - **RUNNING** with a stale heartbeat — phase-aware budget: episodes still in setup
+      (current_step == 0) get `setup_timeout_s`, episodes in the agent loop get the full
+      `step_timeout_s`. Detects setup hangs (container boot, env reset) quickly without
+      shortening the budget for legitimate long-running agent steps.
+    - **QUEUED** past `orphan_threshold_s` — Ray never picked the episode up (worker died
+      or the task is unschedulable). There's no heartbeat to age, so the wait is bounded
+      from `started_at`. Without this a stuck-QUEUED ref keeps `episodes_in_progress`
+      non-empty forever and hangs the poll loop.
     """
     now = time.time()
     to_remove: list[ray.ObjectRef] = []
     for ref in list(episodes_in_progress):
         traj_id = ref_to_traj_id[ref]
         status = storage.read_episode_status(traj_id)
-        # QUEUED → episode hasn't been picked up by a Ray worker yet (no heartbeat to check).
-        # The orphan threshold path in the STALE sweep handles a never-picked-up QUEUED.
-        if status is None or status.status != "RUNNING" or status.last_heartbeat_at is None:
+        if status is None:
             continue
+        # auto-fix(445)↓
+        # QUEUED orphan: never picked up by a worker (no heartbeat). Bound from started_at.
+        if status.status != "RUNNING" or status.last_heartbeat_at is None:
+            if status.status == "QUEUED" and now - status.started_at > orphan_threshold_s:
+                logger.error(
+                    f"Episode {traj_id} stuck QUEUED for {now - status.started_at:.0f}s "
+                    f"(>{orphan_threshold_s:.0f}s) — Ray never picked it up; force killing"
+                )
+                try:
+                    ray.cancel(ref, force=True)
+                except Exception:
+                    logger.exception(f"ray.cancel failed for {traj_id}")
+                # Re-read: a worker may have picked it up between our read and the cancel.
+                fresh = storage.read_episode_status(traj_id)
+                if fresh is not None and fresh.status != "QUEUED":
+                    to_remove.append(ref)
+                    continue
+                status.status = "CANCELLED"
+                status.ended_at = now
+                status.error_type = "OrphanedInQueue"
+                status.error_message = f"never picked up by a Ray worker within {orphan_threshold_s:.0f}s"
+                storage.write_episode_status(traj_id, status)
+                results.failures[traj_id] = status.error_message
+                to_remove.append(ref)
+            continue
+        # /auto-fix(445)
         age = now - status.last_heartbeat_at
         budget = setup_timeout_s if status.current_step == 0 else step_timeout_s
         if age <= budget + cancel_grace_s:
@@ -607,7 +643,7 @@ def run_sequentially(
     *,
     step_timeout_s: float = DEFAULT_STEP_TIMEOUT_S,
     cancel_grace_s: float = DEFAULT_CANCEL_GRACE_S,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
@@ -755,3 +791,7 @@ def _run_sequentially_impl(
         )
         exp.print_stats(results)
         return results
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(445) {class=L1 anchor=PR#445 hash=PENDING ctx=ray-runner/queued-orphan-timeout/orphan_threshold_s-was-plumbed-but-never-consumed/cube-harness@0c3861ca}

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -968,3 +968,129 @@ class TestKillStaleWorkersRaceGuard:
         # Recorded as a failure.
         assert traj_id in results.failures
         assert fake_ref not in episodes_in_progress
+
+
+class TestKillStaleWorkersQueuedOrphan:
+    """Unit tests for the QUEUED-orphan timeout in _kill_stale_workers.
+
+    A driver-pre-claimed episode that Ray never picks up (worker died /
+    unschedulable) has no heartbeat to age; it is failed after `orphan_threshold_s`
+    from `started_at` so a stuck-QUEUED ref can't keep the poll loop alive forever.
+    Regression for the prove-plus-comm stall (dead Ray worker stranded its task).
+    """
+
+    def _queued_status(self, task_id: str, started_age: float) -> EpisodeStatus:
+        return EpisodeStatus(
+            status="QUEUED",
+            task_id=task_id,
+            episode_id=0,
+            started_at=time.time() - started_age,
+            last_heartbeat_at=None,  # never picked up by a worker
+            current_step=0,
+            retry_count=0,
+        )
+
+    def test_orphaned_queued_past_threshold_is_cancelled(self, tmp_dir) -> None:
+        storage = FileStorage(tmp_dir)
+        traj_id = "task_orphan_ep0"
+        queued = self._queued_status("task_orphan", started_age=7200)  # 2h in QUEUED
+
+        fake_ref = MagicMock()
+        ref_to_traj_id = {fake_ref: traj_id}
+        results = ExpResult(exp_id="test", tasks_num=1)
+        episodes_in_progress = [fake_ref]
+
+        with (
+            patch("cube_harness.exp_runner.ray.cancel") as mock_cancel,
+            patch.object(storage, "read_episode_status", side_effect=[queued, queued]),
+            patch.object(storage, "write_episode_status") as mock_write,
+        ):
+            _kill_stale_workers(
+                episodes_in_progress,
+                ref_to_traj_id,
+                storage,
+                results,
+                step_timeout_s=1.0,
+                setup_timeout_s=1.0,
+                cancel_grace_s=1.0,
+                orphan_threshold_s=3600.0,
+            )
+
+        mock_cancel.assert_called_once_with(fake_ref, force=True)
+        assert mock_write.call_count == 1
+        written: EpisodeStatus = mock_write.call_args[0][1]
+        assert written.status == "CANCELLED"
+        assert written.error_type == "OrphanedInQueue"
+        assert traj_id in results.failures
+        assert fake_ref not in episodes_in_progress
+
+    def test_fresh_queued_is_left_alone(self, tmp_dir) -> None:
+        storage = FileStorage(tmp_dir)
+        traj_id = "task_fresh_ep0"
+        queued = self._queued_status("task_fresh", started_age=30)  # only 30s in QUEUED
+
+        fake_ref = MagicMock()
+        ref_to_traj_id = {fake_ref: traj_id}
+        results = ExpResult(exp_id="test", tasks_num=1)
+        episodes_in_progress = [fake_ref]
+
+        with (
+            patch("cube_harness.exp_runner.ray.cancel") as mock_cancel,
+            patch.object(storage, "read_episode_status", side_effect=[queued]),
+            patch.object(storage, "write_episode_status") as mock_write,
+        ):
+            _kill_stale_workers(
+                episodes_in_progress,
+                ref_to_traj_id,
+                storage,
+                results,
+                step_timeout_s=1.0,
+                setup_timeout_s=1.0,
+                cancel_grace_s=1.0,
+                orphan_threshold_s=3600.0,
+            )
+
+        mock_cancel.assert_not_called()
+        mock_write.assert_not_called()
+        assert traj_id not in results.failures
+        assert fake_ref in episodes_in_progress
+
+    def test_queued_picked_up_during_race_not_clobbered(self, tmp_dir) -> None:
+        """QUEUED (orphan) → worker grabs it (RUNNING) between read and cancel → no clobber."""
+        storage = FileStorage(tmp_dir)
+        traj_id = "task_race_ep0"
+        queued = self._queued_status("task_race", started_age=7200)
+        running = EpisodeStatus(
+            status="RUNNING",
+            task_id="task_race",
+            episode_id=0,
+            started_at=time.time() - 7200,
+            last_heartbeat_at=time.time(),
+            current_step=1,
+        )
+
+        fake_ref = MagicMock()
+        ref_to_traj_id = {fake_ref: traj_id}
+        results = ExpResult(exp_id="test", tasks_num=1)
+        episodes_in_progress = [fake_ref]
+
+        with (
+            patch("cube_harness.exp_runner.ray.cancel"),
+            patch.object(storage, "read_episode_status", side_effect=[queued, running]),
+            patch.object(storage, "write_episode_status") as mock_write,
+        ):
+            _kill_stale_workers(
+                episodes_in_progress,
+                ref_to_traj_id,
+                storage,
+                results,
+                step_timeout_s=1.0,
+                setup_timeout_s=1.0,
+                cancel_grace_s=1.0,
+                orphan_threshold_s=3600.0,
+            )
+
+        # Did not clobber the now-RUNNING status.
+        mock_write.assert_not_called()
+        assert traj_id not in results.failures
+        assert fake_ref not in episodes_in_progress


### PR DESCRIPTION
## Invariant violated

`run_with_ray` must always make progress toward termination: every submitted episode ends in a terminal status (COMPLETED / FAILED / CANCELLED / …) within a bounded time, so `_poll_ray`'s `while len(episodes_in_progress) > 0` loop cannot spin forever.

## Root cause

`orphan_threshold_s` (default 3600s) is declared on `run_with_ray`, `_run_with_ray_impl`, the sequential variants, and threaded param→param — but in the **Ray live loop it is never consumed**. `_kill_stale_workers` only times out **RUNNING** tasks with a stale heartbeat; it explicitly skips QUEUED:

```python
if status is None or status.status != "RUNNING" or status.last_heartbeat_at is None:
    continue  # comment claimed "the STALE sweep handles a never-picked-up QUEUED"
```

That claimed path doesn't exist in the live loop — `sweep_stale_statuses` (which *does* use `orphan_threshold_s` for QUEUED) only runs at round start/end over on-disk statuses; it never shrinks the live `episodes_in_progress` ref set. So an episode stuck in **QUEUED** — Ray never picked it up because a worker died or the task was unschedulable — keeps `episodes_in_progress` non-empty **forever**, hanging the run.

**Observed:** during an 89-task daytona run, a Ray worker died (a `FileNotFoundError` on a rotated worker `.out` while Ray formatted a task error), `prove-plus-comm` stayed `QUEUED` with `last_heartbeat_at=None`, and the run froze at 64/66 (cost flat, no progress) until manually killed.

## Why this fix / why this layer

- The orphan-queue timeout was **designed but never wired in** — the param + the `_kill_stale_workers` comment both reference it. This completes the intended behavior with the smallest change.
- Detection belongs in `_kill_stale_workers` (the live loop's mechanism): it's the only place that holds the Ray refs and can `ray.cancel` + remove them so the loop can finish. Marking a status STALE on disk (what `sweep_stale_statuses` does) wouldn't shrink the live ref set.
- QUEUED has no heartbeat, so the wait is bounded from `started_at` — mirroring `sweep_stale_statuses`'s existing QUEUED-orphan rule for consistency.

## Blast radius

- `src/cube_harness/exp_runner.py`: `DEFAULT_ORPHAN_THRESHOLD_S` const; `orphan_threshold_s` threaded into `_poll_ray` + its `_kill_stale_workers` call; QUEUED-orphan branch in `_kill_stale_workers`. RUNNING-stale path unchanged.
- Affects **every Ray-mode experiment** (harness-wide robustness); no behavior change for runs without stuck-QUEUED episodes.
- Existing `_kill_stale_workers` callers/tests unaffected (new param defaults to `DEFAULT_ORPHAN_THRESHOLD_S`).

## Adversarial "opposite user"

Could this kill a legitimately long-queued episode (e.g. slow container scheduling on a busy cluster)? The threshold is 3600s (1h) by default, well beyond normal scheduling latency, and tunable. Could it race a worker that grabs the task just as we cancel? The branch re-reads the status after `ray.cancel` and does **not** clobber a status that has left QUEUED (now RUNNING/terminal) — same guard the RUNNING-stale path uses. A cancelled orphan is recorded as a retriable failure, so retry-enabled runs re-attempt it.

## Class

**L1** (correct; touches the shared Ray runner hot path). Marker `auto-fix(PENDING)` → amended to the PR number on open.

## Test

`tests/test_experiment.py::TestKillStaleWorkersQueuedOrphan` (3 cases):
- QUEUED past `orphan_threshold_s` → `ray.cancel(force=True)`, status CANCELLED / `OrphanedInQueue`, recorded as failure, ref removed.
- fresh QUEUED (30s) → left alone (no cancel, no write, still in-progress).
- QUEUED→RUNNING race (worker grabs it between read and cancel) → status not clobbered, ref removed for the loop.

Full `test_experiment.py` (44) + `test_exp_runner_lifecycle.py` + `test_retry_integration.py` (the end-to-end Ray retry test exercising `_poll_ray`/`_kill_stale_workers`) all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
