### PR TITLE
fix(terminalbench2): run the verifier with its full timeout (bash_unlimited)

### DIFF
--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/task.py
@@ -202,10 +202,18 @@ class TerminalBench2Task(Task[TerminalBench2TaskMetadata, ContainerTerminalTool]
 
         # Run test.sh → pytest → writes reward.txt in the logs-verifier dir.
         # Tool's working_dir is already set (may be /tmp/app after relocation).
-        output = self.tool.bash(
+        # auto-fix(447)↓
+        # Use bash_unlimited (not the agent-facing bash): the trusted verifier must
+        # run with its full `max_test_timeout_sec` (up to 7200s for some tasks) and
+        # un-truncated output. The agent-facing bash clamps every call to the tool's
+        # `max_timeout` (900s, an abuse guard for the *agent*) and truncates output —
+        # which silently killed the verifier at 900s for the 20 tasks whose
+        # max_test_timeout_sec exceeds 900 (e.g. reshard-c4-data=3600, sam-cell-seg=7200).
+        output = self.tool.bash_unlimited(
             f"export HOME=/tmp/fakehome && bash {self._tests_dir}/test.sh",
             timeout=self._exec.max_test_timeout_sec,
         )
+        # /auto-fix(447)
         test_results = self._parse_pytest_output(output)
 
         # Read reward written by test.sh
@@ -517,3 +525,4 @@ class TerminalBench2TaskConfig(TaskConfig[TerminalBench2TaskMetadata]):
 # === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
 # auto-fix-note(418) {class=L1 anchor=PR#418 hash=PENDING ctx=toolkit/eai-yul101/runtime-uid-13011/tbench2:configure-git-webserver+nginx-request-logging+sqlite-with-gcov/cube-harness@1e67efdb}
 # auto-fix-note(420) {class=L1 anchor=PR#420 hash=PENDING ctx=toolkit/eai-yul101/cube_assets:stale-uv<0.4/tbench2:fix-git+nginx-request-logging+sqlite-with-gcov/cube-harness@1e67efdb}
+# auto-fix-note(447) {class=L1 anchor=PR#447 hash=PENDING ctx=daytona+all-infra/verifier-clamped-to-agent-max_timeout-900/tbench2:reshard-c4-data+sam-cell-seg+20-tasks-over-900s/cube-harness@0c3861ca}

--- a/cubes/terminalbench2-cube/tests/test_verifier_timeout.py
+++ b/cubes/terminalbench2-cube/tests/test_verifier_timeout.py
@@ -1,0 +1,52 @@
+"""Pins the verifier-timeout invariant in `TerminalBench2Task.evaluate`.
+
+The verifier is trusted infra and must run with its full `max_test_timeout_sec`
+(up to 7200s for some tasks). The agent-facing `bash` clamps every call to the
+tool's `max_timeout` (900s abuse guard) and truncates output — which silently
+killed the verifier at 900s for the 20 tasks whose `max_test_timeout_sec` exceeds
+900 (e.g. reshard-c4-data=3600, sam-cell-seg=7200). `evaluate` must run test.sh
+via `bash_unlimited`, which skips the clamp and truncation.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+from cube.tools.terminal import ContainerTerminalTool, TerminalToolConfig
+
+from terminalbench2_cube.task import TerminalBench2Task
+
+
+def _tool_with_cap() -> tuple[ContainerTerminalTool, MagicMock]:
+    container = MagicMock()
+    container.exec.return_value = MagicMock(stdout="ok", stderr="", exit_code=0, duration_seconds=1.0)
+    tool = ContainerTerminalTool(config=TerminalToolConfig(working_dir="/app", max_timeout=900), container=container)
+    return tool, container
+
+
+def test_bash_clamps_but_bash_unlimited_does_not() -> None:
+    """The behavioral property the fix relies on: bash clamps to max_timeout (900),
+    bash_unlimited passes the full timeout through to the container."""
+    tool, container = _tool_with_cap()
+
+    tool.bash("echo x", timeout=3600)
+    assert container.exec.call_args.kwargs["timeout"] == 900  # agent-facing: clamped
+
+    container.exec.reset_mock()
+    tool.bash_unlimited("echo x", timeout=3600)
+    assert container.exec.call_args.kwargs["timeout"] == 3600  # verifier-facing: uncapped
+
+
+def test_evaluate_runs_verifier_via_bash_unlimited() -> None:
+    """Regression guard: evaluate() must run the test.sh verifier via bash_unlimited
+    (not the clamped/truncated agent-facing bash)."""
+    src = inspect.getsource(TerminalBench2Task.evaluate)
+    # the verifier RUN (bash <tests>/test.sh) goes through bash_unlimited...
+    assert "bash_unlimited(" in src
+    # ...and is NOT run through the clamped agent-facing bash. (chmod/mkdir on the
+    # test path are quick commands and may legitimately use bash — exclude them.)
+    for line in src.splitlines():
+        runs_testsh = "bash " in line and "test.sh" in line  # actually executing the script
+        if runs_testsh and "self.tool.bash(" in line and "chmod" not in line and "mkdir" not in line:
+            raise AssertionError(f"verifier test.sh must use bash_unlimited, not bash: {line.strip()}")


### PR DESCRIPTION
## Invariant violated

The terminalbench2 verifier (`test.sh`) must run with the timeout the task declares (`max_test_timeout_sec`, up to 7200s) — it's trusted infra, not an agent action subject to the agent's abuse-prevention timeout cap.

## Root cause

`evaluate()` ran the verifier via the **agent-facing** `self.tool.bash(...)`:

```python
output = self.tool.bash(f"... bash {tests}/test.sh", timeout=self._exec.max_test_timeout_sec)
```

`ContainerTerminalTool.bash` clamps every call to the tool's `max_timeout` (terminalbench2 sets it to **900s** — an abuse guard so the *agent* can't request arbitrarily long commands) **and** truncates output to `max_output_bytes`:

```python
if self._config.max_timeout is not None:
    timeout = min(timeout, self._config.max_timeout)   # 3600 -> 900
```

So for every task whose `max_test_timeout_sec > 900`, the verifier was silently `SIGTERM`'d at 900s regardless of the declared budget — a spurious eval failure that looks like a task/agent failure.

**Blast radius — 20 of 89 tasks** declare `max_test_timeout_sec > 900`: reshard-c4-data, train-fasttext, video-processing, mteb-leaderboard, portfolio-optimization, regex-chess, winning-avg-corewars (3600); sam-cell-seg (7200); schemelike-metacircular-eval (2400); large-scale-text-editing (1200); + 10 at 1800. Found via the full-run Investigator (e.g. reshard-c4-data: *"evaluation timed out after 900[s]… the mismatch between ContainerTerminalTool's max_timeout=900 and max_test_timeout_sec=3600 is the root cause"*).

## Why this fix / why this layer

`bash_unlimited` already exists for exactly this — its docstring: *"Like `bash()` but without output truncation — for internal harness use only. Use this in `evaluate()` / `apply_patch()` where the caller needs the full output."* It calls `container.exec` directly, bypassing both the `max_timeout` clamp and truncation. The one-line switch restores the invariant without weakening the agent-facing cap (agents still can't exceed 900s).

## Blast radius (code)

- `cubes/terminalbench2-cube/src/terminalbench2_cube/task.py`: `evaluate()` test.sh run `bash` → `bash_unlimited`. The other `evaluate()` bash calls (mkdir/chmod/uv-preinstall/reward-read) are short (<900s) and correctly stay on `bash`.
- No change to `ContainerTerminalTool`; the agent action surface is untouched.

## Adversarial "opposite user"

Does dropping truncation risk huge outputs? `bash_unlimited` is the method designed for this and is already used by other cubes' `evaluate()`/`apply_patch()`; the verifier output is parsed (reward.txt / pytest summary), and the previously-truncated install logs were the cause of *other* parse failures, not a feature. Does removing the cap let a malicious test.sh run forever? No — `max_test_timeout_sec` (the task's own declared bound) still caps it, and the `timeout Ns` wrapper inside `container.exec` enforces it.

## Class

**L1** (correct; the verifier path is shared by all terminalbench2 tasks). Marker `auto-fix(PENDING)` → amended to the PR number on open.

## Test

`tests/test_verifier_timeout.py` (2):
- `test_bash_clamps_but_bash_unlimited_does_not`: with `max_timeout=900`, `bash(timeout=3600)` reaches `container.exec` with **900**; `bash_unlimited(timeout=3600)` reaches it with **3600** — the exact property the fix relies on.
- `test_evaluate_runs_verifier_via_bash_unlimited`: regression guard that `evaluate()` runs test.sh via `bash_unlimited`, not the clamped `bash`.

Full terminalbench2 suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
