### PR TITLE
fix(genny): route finished model to stop action in format-error retry

### DIFF
--- a/src/cube_harness/agents/genny.py
+++ b/src/cube_harness/agents/genny.py
@@ -620,7 +620,23 @@ class Genny(Agent):
             )
             messages = list(messages) + [
                 response.message,
-                {"role": "user", "content": "No tool calls found. Every response MUST include at least one tool call."},
+                # auto-fix(448)↓
+                # A model that believes it is finished emits a no-tool-call (text)
+                # response. The old correction ("every response MUST include a tool
+                # call") drove it to satisfy the rule with a no-op (e.g. `echo 'tool
+                # call included'`) instead of ending — burning the rest of the budget
+                # in a degenerate echo loop (observed on filter-js-from-html,
+                # schemelike-metacircular-eval, sam-cell-seg, reshard-c4-data). Route a
+                # finished model to the STOP action instead, and discourage no-ops.
+                {
+                    "role": "user",
+                    "content": (
+                        f"No tool calls found. If the task is already complete, call "
+                        f"`{STOP_ACTION.name}` to finish. Otherwise every response must include at "
+                        f"least one tool call that makes real progress — do not emit no-op commands."
+                    ),
+                },
+                # /auto-fix(448)
             ]
             prompt = Prompt(messages=messages, tools=self._api_tools)
             response = self.llm(prompt)
@@ -669,3 +685,7 @@ class Genny(Agent):
         if final_prompt:
             messages.append({"role": "user", "content": final_prompt})
         return messages
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(448) {class=L1 anchor=PR#448 hash=PENDING ctx=daytona/azure-gpt-5.4-mini/genny-swe/tbench2:filter-js-from-html+schemelike-metacircular-eval+sam-cell-seg+reshard-c4-data:format-error-correction-drove-degenerate-echo-loop/cube-harness@0c3861ca}

--- a/tests/test_genny_prompts.py
+++ b/tests/test_genny_prompts.py
@@ -692,6 +692,22 @@ class TestFormatErrorPromptShape:
         assert _role(retry_msgs[-1]) == "user"
         assert "No tool calls found" in _content(retry_msgs[-1])
 
+    def test_correction_routes_finished_model_to_stop_action(self) -> None:
+        """A finished model emits a no-tool-call response; the correction must route it
+        to the STOP action (final_step) and discourage no-ops — otherwise the model
+        satisfies 'must include a tool call' with echo no-ops and burns the budget in a
+        degenerate loop (filter-js-from-html, schemelike-metacircular-eval, ...)."""
+        from cube.task import STOP_ACTION
+
+        agent = _make_agent(max_format_errors=1)
+        cap = CapturingLLM(responses=[_text_response("the task is complete"), _tool_response()])
+        agent.llm = cap
+        agent.step(Observation.from_text("goal"))
+
+        correction = _content(cap.calls[1].messages[-1])
+        assert STOP_ACTION.name in correction  # tells a finished model how to end
+        assert "no-op" in correction.lower()  # discourages the echo loop
+
     def test_retry_prompt_has_original_response_before_correction(self) -> None:
         """The empty response is inserted before the correction message."""
         no_tool = _text_response("I will think about it")


### PR DESCRIPTION
## Invariant violated

When a Genny agent believes the task is finished it must be able to **end the
episode**. A model that signals completion in prose (no tool call) should be
routed to the stop action — not coerced into emitting a no-op tool call just to
satisfy a formatting rule.

## Root cause

Genny's format-error retry loop ([`genny.py`](src/cube_harness/agents/genny.py))
fires when a response has no tool calls. The old correction message was:

```
No tool calls found. Every response MUST include at least one tool call.
```

The `swe` system prompt never mentions the stop action (`final_step`). So when a
model decided it was done and wrote a prose "the task is complete" turn, the
correction gave it no way out: the only rule it knew was "emit a tool call." It
complied with the *letter* of the rule by emitting a no-op — `echo 'Tool call
included.'`, a trivial `read_file`, etc. — which produced no new information, so
the next turn it again believed itself done, got the same correction, and looped.
The result is a **degenerate echo loop** that burns the entire remaining step/token
budget after the task was effectively over.

Confirmed by decoding `schemelike-metacircular-eval_ep77`: turns 173–199 are all
`echo 'Tool call included.'` / trivial reads with `correction_in_prompt=True` every
turn. The Investigator independently flagged the same pathology
(`primary_blame=agent_scaffolding`) on four full-run tasks: **filter-js-from-html,
schemelike-metacircular-eval, sam-cell-seg, reshard-c4-data**.

## Why this fix / why this layer

The correction message is the *only* place the loop tells the model what to do when
it emits no tool call — so it's the correct layer to also tell it how to *finish*.
The new message keeps the original instruction (so a genuinely-mid-task model still
gets nudged to act) and adds the missing exit + an explicit no-op deterrent:

```
No tool calls found. If the task is already complete, call `final_step` to finish.
Otherwise every response must include at least one tool call that makes real
progress — do not emit no-op commands.
```

`final_step` is `STOP_ACTION.name`, so the message stays correct if the stop
action is ever renamed. This is the minimal change that restores the invariant; it
does not touch the system prompt, the action space, or the loop control flow.

## Blast radius

- [`src/cube_harness/agents/genny.py`](src/cube_harness/agents/genny.py): the
  format-error correction message (one `messages` entry). Affects every Genny run
  that hits a no-tool-call turn — which is exactly the population that was looping.
- No change to `STOP_ACTION`, the action space, `max_format_errors`, or the step loop.

## Adversarial "opposite user"

*Won't this make models stop too early?* The message is conditional — "**if** the
task is already complete" — and only fires after the model already emitted zero tool
calls (i.e. it already wasn't making progress). A mid-task model still receives the
"every response must include a tool call that makes real progress" instruction. The
change strictly adds an exit that previously didn't exist; it doesn't lower the bar
for continuing.

*Does routing to `final_step` mask a real capability failure?* No — the loop was
already a failure (zero progress, wasted budget). Ending cleanly instead of echoing
gives the Investigator a truthful `model_capability` / `almost` signal instead of a
misleading 40-turn `agent_scaffolding` artifact, and stops burning budget on a
finished episode.

## Class

**L1** (correct at the agent layer; the correction loop is shared by all Genny
runs). Marker `auto-fix(PENDING)` → amended to the PR number on open.

## Test

`tests/test_genny_prompts.py`:
- `test_correction_routes_finished_model_to_stop_action`: a model that emits a
  prose "the task is complete" turn gets a correction that names `final_step` and
  forbids no-ops, then can stop. Asserts `STOP_ACTION.name in correction` and
  `"no-op" in correction.lower()`.
- The pre-existing `test_retry_prompt_contains_correction_message` still passes —
  the `"No tool calls found"` prefix is preserved.

Full genny suite (`test_genny.py` + `test_genny_prompts.py`, 141 tests) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
