### PR TITLE
fix(summary): exclude ungraded episodes (verifier_ran=False) from accuracy

### DIFF
--- a/scripts/experiments_report.py
+++ b/scripts/experiments_report.py
@@ -61,31 +61,39 @@ def _short_benchmark(name: str) -> str:
     return name.replace("swebench-verified-cube", "sweb-v").replace("swebench-live-cube", "sweb-live")
 
 
-def _scan_episodes(result: ExperimentResult) -> tuple[dict[str, int], list[float], float, int]:
-    """Aggregate per-status counts, rewards, cost, and context-window errors.
+def _scan_episodes(result: ExperimentResult) -> tuple[dict[str, int], list[float], float, int, int]:
+    """Aggregate per-status counts, rewards, cost, context-window errors, ungraded count.
 
     Walks via :meth:`ExperimentResult.iter_episode_statuses` so the episode set
-    (including in-flight) matches what the XRay viewer sees.
+    (including in-flight) matches what the XRay viewer sees. A completed episode
+    whose grader did not run (``reward_info.verifier_ran is False``) is excluded
+    from ``completed_rewards`` and counted in ``n_ungraded`` instead, so eval-infra
+    failures don't masquerade as graded zeros in the accuracy.
     """
     counts: dict[str, int] = {}
     completed_rewards: list[float] = []
     total_cost = 0.0
     ctx_errors = 0
+    n_ungraded = 0
 
     for es in result.iter_episode_statuses():
         counts[es.status] = counts.get(es.status, 0) + 1
         if es.error_type and "ContextWindow" in es.error_type:
             ctx_errors += 1
-        if es.status in _DONE_STATUSES and es.reward is not None:
-            completed_rewards.append(float(es.reward))
-        # Cost lives in episode_record.json, not status.json.
         ep_dir = result._dir / "episodes" / f"{es.task_id}_ep{es.episode_id}"
+        if es.status in _DONE_STATUSES and es.reward is not None:
+            reward_info = _load_json(ep_dir / "episode.metadata.json").get("reward_info", {})
+            if reward_info.get("verifier_ran", True) is False:
+                n_ungraded += 1
+            else:
+                completed_rewards.append(float(es.reward))
+        # Cost lives in episode_record.json, not status.json.
         total_cost += _load_json(ep_dir / "episode_record.json").get("usage", {}).get("total_cost_usd", 0.0)
 
-    return counts, completed_rewards, total_cost, ctx_errors
+    return counts, completed_rewards, total_cost, ctx_errors, n_ungraded
 
 
-def _format_episode_breakdown(counts: dict[str, int], ctx_errors: int) -> tuple[str, int]:
+def _format_episode_breakdown(counts: dict[str, int], ctx_errors: int, n_ungraded: int = 0) -> tuple[str, int]:
     """Return ("done/total status icons", n_total) for the table row.
 
     Uses ``STATUS_ICONS`` from ``episode_status`` — same canonical icon set the
@@ -105,6 +113,8 @@ def _format_episode_breakdown(counts: dict[str, int], ctx_errors: int) -> tuple[
         parts.append(" ".join(error_parts))
     if ctx_errors:
         parts.append(f"{ctx_errors}ctx")
+    if n_ungraded:
+        parts.append(f"{n_ungraded}ung")
     return " ".join(parts), n_total
 
 
@@ -127,12 +137,12 @@ def _parse_experiment(exp_dir: Path) -> dict | None:
         return None
 
     result = ExperimentResult(exp_dir)
-    counts, rewards, total_cost, ctx_errors = _scan_episodes(result)
+    counts, rewards, total_cost, ctx_errors, n_ungraded = _scan_episodes(result)
     if not counts:
         return None
 
     ts = record.get("evaluation_timestamp", 0)
-    breakdown, _ = _format_episode_breakdown(counts, ctx_errors)
+    breakdown, _ = _format_episode_breakdown(counts, ctx_errors, n_ungraded)
 
     return {
         "date": datetime.fromtimestamp(ts).strftime("%m-%d %H:%M") if ts else "?",

--- a/scripts/smoke/verifier_ran_scoring.py
+++ b/scripts/smoke/verifier_ran_scoring.py
@@ -1,0 +1,91 @@
+"""SMOKE: a completed-but-ungraded episode (reward_info.verifier_ran is False) is
+excluded from accuracy — not counted as a graded zero — on BOTH score paths:
+the live ``FileStorage.update_experiment_summary`` and the ``experiments_report``
+``_scan_episodes`` table path.
+
+Builds a synthetic experiment with three completed episodes — a graded pass (1.0),
+a graded fail (0.0), and an ungraded one (verifier didn't run) — and asserts the
+mean is 0.5 over the two GRADED episodes (not 1/3 over all three), with the
+ungraded one surfaced separately.
+
+    python scripts/smoke/verifier_ran_scoring.py
+
+Prints `SMOKE OK/FAIL: verifier_ran_scoring` and exits 0/1.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from cube_harness.core import Trajectory
+from cube_harness.episode_status import EpisodeStatus
+from cube_harness.storage import FileStorage
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from experiments_report import _scan_episodes  # noqa: E402
+
+from cube_harness.results import ExperimentResult  # noqa: E402
+
+# (task_id, reward, verifier_ran)
+EPISODES = [
+    ("graded_pass", 1.0, True),
+    ("graded_fail", 0.0, True),
+    ("ungraded", 0.0, False),  # verifier never ran → must NOT count as a graded 0
+]
+EXPECTED_AVG = 0.5  # mean(1.0, 0.0) over the two graded episodes
+EXPECTED_UNGRADED = 1
+
+
+def _fail(msg: str) -> None:
+    print(f"SMOKE FAIL: verifier_ran_scoring — {msg}")
+    sys.exit(1)
+
+
+def _check_live_summary(root: Path) -> None:
+    storage = FileStorage(root)
+    for tid, reward, verifier_ran in EPISODES:
+        traj = Trajectory(
+            id=f"{tid}_ep0",
+            metadata={"task_id": tid, "agent_name": "A"},
+            reward_info={"reward": reward, "verifier_ran": verifier_ran},
+            summary_stats={"final_reward": reward},
+        )
+        storage.update_experiment_summary(traj)
+    summary = json.loads((root / "experiment_summary.json").read_text())
+    if summary["n_ungraded"] != EXPECTED_UNGRADED:
+        _fail(f"live: n_ungraded={summary['n_ungraded']} != {EXPECTED_UNGRADED}")
+    if summary["avg_reward"] != EXPECTED_AVG:
+        _fail(f"live: avg_reward={summary['avg_reward']} != {EXPECTED_AVG} (ungraded leaked into accuracy?)")
+    print(f"  live summary: avg_reward={summary['avg_reward']} n_ungraded={summary['n_ungraded']} ✓")
+
+
+def _check_report_path(root: Path) -> None:
+    storage = FileStorage(root)
+    for tid, reward, verifier_ran in EPISODES:
+        ep_dir = root / "episodes" / f"{tid}_ep0"
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        storage.write_episode_status(
+            f"{tid}_ep0",
+            EpisodeStatus(status="COMPLETED", task_id=tid, episode_id=0, started_at=1.0, reward=reward),
+        )
+        (ep_dir / "episode.metadata.json").write_text(
+            json.dumps({"reward_info": {"reward": reward, "verifier_ran": verifier_ran}})
+        )
+    _counts, rewards, _cost, _ctx, n_ungraded = _scan_episodes(ExperimentResult(root))
+    if n_ungraded != EXPECTED_UNGRADED:
+        _fail(f"report: n_ungraded={n_ungraded} != {EXPECTED_UNGRADED}")
+    if len(rewards) != 2 or sum(rewards) / len(rewards) != EXPECTED_AVG:
+        _fail(f"report: graded rewards={rewards} (mean != {EXPECTED_AVG}; ungraded leaked in?)")
+    print(f"  report path: graded_rewards={rewards} mean={sum(rewards) / len(rewards)} n_ungraded={n_ungraded} ✓")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as live_root, tempfile.TemporaryDirectory() as report_root:
+        _check_live_summary(Path(live_root))
+        _check_report_path(Path(report_root))
+    print("SMOKE OK: verifier_ran_scoring")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -473,19 +473,33 @@ class FileStorage:
                     for step in trajectory.steps
                     if isinstance(step.output, AgentOutput)
                 )
+                # auto-fix(449)↓
+                # `verifier_ran is False` ⇒ the episode completed but the grader never
+                # produced a gradeable result (e.g. eval-time deps failed to install).
+                # Absent ⇒ assume graded, so cubes that don't set it are unaffected.
+                # Consumes the flag #444 added; previously `total_reward += final_reward`
+                # ran unconditionally, scoring an ungraded episode as a graded 0.
+                verifier_ran = (trajectory.reward_info or {}).get("verifier_ran", True)
 
                 summary.n_episodes += 1
                 if has_error:
                     summary.n_errored += 1
+                elif not verifier_ran:
+                    # Completed-but-ungraded: count completion, but keep it out of the
+                    # accuracy numerator/denominator rather than scoring it a graded 0.
+                    summary.n_completed += 1
+                    summary.n_ungraded += 1
                 else:
                     summary.n_completed += 1
-                summary.total_reward += stats.get("final_reward", 0.0)
+                    summary.total_reward += stats.get("final_reward", 0.0)
                 summary.total_prompt_tokens += stats.get("prompt_tokens", 0)
                 summary.total_completion_tokens += stats.get("completion_tokens", 0)
                 summary.total_cost += stats.get("cost", 0.0)
 
-                if summary.n_completed > 0:
-                    summary.avg_reward = round(summary.total_reward / summary.n_completed, 4)
+                n_graded = summary.n_completed - summary.n_ungraded
+                if n_graded > 0:
+                    summary.avg_reward = round(summary.total_reward / n_graded, 4)
+                # /auto-fix(449)
                 summary.updated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
                 tmp_path = summary_path.with_suffix(".tmp")
@@ -584,3 +598,7 @@ class FileStorage:
             if status is not None:
                 result[ep_dir.name] = status
         return result
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(449) {class=L1 anchor=PR#449 hash=PENDING ctx=summary/avg_reward-counted-verifier_ran=False-as-graded-0/consumes-444-flag/tbench2:pytorch-model-cli+sam-cell-seg/cube-harness@ccba968e}

--- a/src/cube_harness/summary.py
+++ b/src/cube_harness/summary.py
@@ -43,6 +43,10 @@ class ExperimentSummary(BaseModel):
     n_episodes: int = 0
     n_completed: int = 0
     n_errored: int = 0
+    # Subset of n_completed whose grader did not run (reward_info.verifier_ran is False):
+    # the episode finished but produced no gradeable result, so it is excluded from
+    # avg_reward rather than counted as a graded 0.
+    n_ungraded: int = 0
     total_reward: float = 0.0
     total_prompt_tokens: int = 0
     total_completion_tokens: int = 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1621,3 +1621,41 @@ class TestInjectEpisodeStatus:
         stubs = storage.load_missing_trajectory_stubs()
         stub = next(s for s in stubs if s.id == "task_1_ep0")
         assert stub.metadata.get("_episode_status") == "QUEUED"
+
+
+class TestExperimentSummaryVerifierRan:
+    """avg_reward must exclude completed-but-ungraded episodes (reward_info.verifier_ran
+    is False) instead of counting them as graded zeros — and stay backward-compatible
+    for cubes/episodes that never set the flag."""
+
+    def _traj(self, idx: int, reward: float, reward_info: dict) -> Trajectory:
+        return Trajectory(
+            id=f"task_{idx}_ep0",
+            metadata={"task_id": f"task_{idx}", "agent_name": "A"},
+            reward_info=reward_info,
+            summary_stats={"final_reward": reward},
+        )
+
+    def test_ungraded_excluded_from_avg_reward(self, tmp_dir: Path) -> None:
+        storage = FileStorage(tmp_dir)
+        # graded pass, graded fail, ungraded (verifier didn't run)
+        storage.update_experiment_summary(self._traj(1, 1.0, {"reward": 1.0, "verifier_ran": True}))
+        storage.update_experiment_summary(self._traj(2, 0.0, {"reward": 0.0, "verifier_ran": True}))
+        storage.update_experiment_summary(self._traj(3, 0.0, {"reward": 0.0, "verifier_ran": False}))
+
+        summary = json.loads((tmp_dir / "experiment_summary.json").read_text())
+        assert summary["n_episodes"] == 3
+        assert summary["n_completed"] == 3
+        assert summary["n_ungraded"] == 1
+        # mean over the 2 GRADED episodes (1.0, 0.0) == 0.5 — NOT 1/3 over all completed.
+        assert summary["avg_reward"] == 0.5
+
+    def test_absent_verifier_ran_defaults_to_graded(self, tmp_dir: Path) -> None:
+        storage = FileStorage(tmp_dir)
+        # No verifier_ran key (e.g. a cube that doesn't set it) → counted as graded.
+        storage.update_experiment_summary(self._traj(1, 1.0, {"reward": 1.0}))
+        storage.update_experiment_summary(self._traj(2, 0.0, {"reward": 0.0}))
+
+        summary = json.loads((tmp_dir / "experiment_summary.json").read_text())
+        assert summary["n_ungraded"] == 0
+        assert summary["avg_reward"] == 0.5


### PR DESCRIPTION
## Invariant violated

A benchmark's accuracy must be a mean over episodes the grader actually **graded**. An episode that completed but whose verifier never ran (eval-time deps failed to install, etc.) is *ungraded* — it must be excluded from accuracy, not counted as a graded `reward=0`.

## Root cause

#444 added `reward_info.verifier_ran` (False when the verifier produced no gradeable result) — but **nothing consumed it**. Both score paths counted a completed-but-ungraded episode as a graded zero:

- **Live summary** (`storage.update_experiment_summary`): `total_reward += final_reward` ran unconditionally, and `avg_reward = total_reward / n_completed` — so an ungraded `reward=0` dragged the mean down.
- **Report** (`experiments_report._scan_episodes`): every `status in _DONE_STATUSES and reward is not None` entered `completed_rewards`.

Concrete case from the tbench2-daytona run: **pytorch-model-cli** — the agent's solution was *correct*, but the verifier's heavy deps didn't install (`verifier_ran=False`, `reward=0`, `status=COMPLETED`), so it was scored a graded 0. (`sam-cell-seg` same.) Note this is distinct from `ContainerExecError`/FAILED episodes, which are already excluded via `reward=None`.

## The fix

Consume the flag #444 produced; `verifier_ran` absent ⇒ assume graded (cubes that don't set it are unaffected).

- **`summary.py`**: add `n_ungraded` (subset of `n_completed` whose grader didn't run).
- **`storage.py`**: a completed episode with `verifier_ran is False` increments `n_completed` + `n_ungraded` but **not** `total_reward`; `avg_reward = total_reward / (n_completed − n_ungraded)`. This also closes the latent numerator/denominator inconsistency (`total_reward` now only sums graded-completed episodes).
- **`experiments_report.py`**: such episodes are excluded from `completed_rewards` and surfaced as `Nung` in the episode breakdown, so a shrunken accuracy denominator is visible rather than silent.

## Blast radius

`n_completed` keeps its meaning ("not errored"); its only consumer was the `avg_reward` line, which now uses the graded subset. Cubes that never set `verifier_ran` see identical numbers (default True). No contract change, single repo.

## Adversarial "opposite user"

*Does this let a benchmark hide failures by marking things ungraded?* No — `verifier_ran` is set by the cube's `evaluate()` and means "the grader didn't produce a result," which is an eval-infra condition, not an agent outcome; ungraded episodes are reported (`n_ungraded` / `Nung`), not dropped silently. *Does excluding them inflate accuracy?* It removes spurious zeros from episodes that were never graded; the count is surfaced so the denominator shrink is auditable.

## Class

**L1** (correct at the summary layer; both score paths share the `verifier_ran` source). Marker `auto-fix(PENDING)` → amended to the PR number on open. Completes `auto-fix(444)`.

## Test

`tests/test_storage.py::TestExperimentSummaryVerifierRan` — graded-pass + graded-fail + ungraded ⇒ `avg_reward=0.5` (over the 2 graded), `n_ungraded=1`; and absent-flag ⇒ all graded (backward compat).

**Smoke** `scripts/smoke/verifier_ran_scoring.py` — builds a synthetic experiment and asserts BOTH the live summary and the report `_scan_episodes` exclude the ungraded episode (mean 0.5, not 1/3). Prints `SMOKE OK`.

Full `test_storage.py` (103) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
