### PR TITLE
fix(investigator): repair-retry the verdict; loud sentinel instead of dropping it

### DIFF
--- a/scripts/smoke/investigator_verdict_retry.py
+++ b/scripts/smoke/investigator_verdict_retry.py
@@ -1,0 +1,161 @@
+"""SMOKE: end-to-end through the real `investigate_experiment` pipeline, the
+investigator never loses a finding when the model emits no usable verdict.
+
+Two scenarios, each on a minimal one-episode fixture with a pre-seeded context file
+(so the benchmark-context sub-agent doesn't run) and a scripted driver:
+
+  1. unusable-then-good  → the verdict is repaired via one no-tool re-prompt, and the
+     real verdict is persisted to episode_record.json.
+  2. always-unusable     → a LOUD sentinel finding is persisted (outcome=failure,
+     summary starts "INVESTIGATION FAILED"), never a silent empty record.
+
+    python scripts/smoke/investigator_verdict_retry.py
+
+Prints `SMOKE OK/FAIL: investigator_verdict_retry` and exits 0/1.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import msgpack
+import zstandard
+
+from cube_harness.analyze.investigator import InvestigationConfig, investigate_experiment
+from cube_harness.analyze.investigator.agent_driver import DriverResult
+from cube_harness.analyze.investigator.context import INVESTIGATION_CONTEXT_FILENAME
+from cube_harness.eval_log import EPISODE_RECORD_FILENAME, EpisodeRecord, UsageSummary
+
+PROSE_ONLY = "I walked the episode: the agent read the file but the infra then crashed. (no verdict block)"
+VALID_FINDINGS_JSON = json.dumps(
+    {
+        "analysis": "Agent ran `cat foo.py` but never attempted a fix.",
+        "outcome": "failure",
+        "summary": "Agent read the file but made no edit.",
+        "primary_blame": "model_capability",
+        "primary_blame_confidence": 4,
+        "other_blames": [],
+        "evidence": [{"step": 1, "quote": "cat foo.py"}],
+        "hypothesis": "Add an explicit edit instruction to the system prompt.",
+        "hypothesis_confidence": 3,
+    }
+)
+
+
+class _ScriptedDriver:
+    name = "scripted"
+    max_parallelism = 1
+
+    def __init__(self, outputs: list[str]) -> None:
+        self._outputs = outputs
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, **kwargs: Any) -> DriverResult:
+        text = self._outputs[min(len(self.calls), len(self._outputs) - 1)]
+        self.calls.append(kwargs)
+        return DriverResult(output_text=text, prompt_tokens=10, completion_tokens=5)
+
+    async def continue_session(self, **kwargs: Any) -> DriverResult:
+        raise NotImplementedError
+
+
+def _fail(msg: str) -> None:
+    print(f"SMOKE FAIL: investigator_verdict_retry — {msg}")
+    sys.exit(1)
+
+
+def _write_step(steps_dir: Path, name: str, payload: dict) -> None:
+    raw = msgpack.packb(payload, use_bin_type=True)
+    (steps_dir / name).write_bytes(zstandard.ZstdCompressor().compress(raw))
+
+
+def _make_episode(root: Path, trajectory_id: str) -> Path:
+    exp = root / "exp"
+    ep = exp / "episodes" / trajectory_id
+    (ep / "steps").mkdir(parents=True)
+    _write_step(
+        ep / "steps",
+        "000_obs.msgpack.zst",
+        {
+            "output": {
+                "obs": {
+                    "contents": [{"data": "Fix the bug in foo.py.", "tool_call_id": None}],
+                    "reward": None,
+                    "done": False,
+                }
+            }
+        },
+    )
+    _write_step(
+        ep / "steps",
+        "001_act.msgpack.zst",
+        {
+            "output": {
+                "actions": [{"name": "Bash", "arguments": {"command": "cat foo.py"}}],
+                "llm_calls": [],
+                "error": None,
+            }
+        },
+    )
+    record = EpisodeRecord(
+        evaluation_id="eval-1",
+        sample_id=trajectory_id.split("_ep")[0],
+        is_correct=False,
+        score=0.0,
+        num_turns=2,
+        n_agent_steps=1,
+        n_env_steps=1,
+        usage=UsageSummary(),
+        trajectory_id=trajectory_id,
+        timestamp=0.0,
+    )
+    (ep / EPISODE_RECORD_FILENAME).write_text(record.model_dump_json(indent=2))
+    (exp / INVESTIGATION_CONTEXT_FILENAME).write_text(f"# seeded\n\n```paths\nexp: {exp}\n```\n")
+    return exp
+
+
+def _investigate(exp: Path, tid: str, driver: _ScriptedDriver) -> Any:
+    results = investigate_experiment(exp, InvestigationConfig(driver=driver, ids=[tid], synthesis_model=""))
+    if tid not in results:
+        _fail(f"no result for {tid}")
+    findings, _meta = results[tid]
+    return findings
+
+
+def main() -> None:
+    tid = "task1_ep0"
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        # Scenario 1: unusable → repaired on retry.
+        exp1 = _make_episode(Path(d1), tid)
+        driver1 = _ScriptedDriver([PROSE_ONLY, VALID_FINDINGS_JSON])
+        f1 = _investigate(exp1, tid, driver1)
+        if len(driver1.calls) != 2:
+            _fail(f"repair: expected 2 driver calls (run + 1 repair), got {len(driver1.calls)}")
+        if driver1.calls[1].get("allowed_tools") != ():
+            _fail(f"repair: re-prompt should strip tools, got allowed_tools={driver1.calls[1].get('allowed_tools')!r}")
+        if f1.primary_blame.value != "model_capability":
+            _fail(f"repair: expected repaired verdict, got blame={f1.primary_blame.value}")
+        restored = EpisodeRecord.model_validate_json((exp1 / "episodes" / tid / EPISODE_RECORD_FILENAME).read_text())
+        if restored.findings is None or restored.findings.outcome.value != "failure":
+            _fail("repair: repaired verdict was not persisted to episode_record.json")
+        print(f"  scenario 1 (repair): {len(driver1.calls)} calls, blame={f1.primary_blame.value}, persisted ✓")
+
+        # Scenario 2: never usable → loud sentinel (default max_verdict_retries=2 ⇒ 3 calls).
+        exp2 = _make_episode(Path(d2), tid)
+        driver2 = _ScriptedDriver([PROSE_ONLY])
+        f2 = _investigate(exp2, tid, driver2)
+        if len(driver2.calls) != 3:
+            _fail(f"sentinel: expected 3 driver calls (run + 2 retries), got {len(driver2.calls)}")
+        if f2.outcome.value != "failure" or not f2.summary.startswith("INVESTIGATION FAILED"):
+            _fail(f"sentinel: expected loud sentinel, got outcome={f2.outcome.value} summary={f2.summary!r}")
+        if PROSE_ONLY not in f2.analysis:
+            _fail("sentinel: prose analysis was not preserved")
+        print(f"  scenario 2 (sentinel): {len(driver2.calls)} calls, summary={f2.summary[:40]!r}... ✓")
+
+    print("SMOKE OK: investigator_verdict_retry")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cube_harness/analyze/investigator/core.py
+++ b/src/cube_harness/analyze/investigator/core.py
@@ -51,7 +51,9 @@ from cube_harness.core import Trajectory
 from cube_harness.eval_log import (
     FINDINGS_SCHEMA_VERSION,
     BaseFindings,
+    BlameCategory,
     InvestigationMetadata,
+    Outcome,
 )
 
 logger = logging.getLogger(__name__)
@@ -159,6 +161,106 @@ def _validate_invariants(obj: BaseFindings) -> None:
             obj.primary_blame.value,
         )
         obj.primary_blame = obj.primary_blame.__class__("none")
+
+
+# auto-fix(450)↓
+class _UnusableVerdict(Exception):
+    """The investigator finished its analysis but emitted no parseable/complete
+    structured verdict (no JSON block, malformed JSON, or missing required fields)."""
+
+
+def _parse_findings(output_text: str, recipe: InvestigatorRecipe) -> BaseFindings:
+    """Extract + validate the structured verdict, raising `_UnusableVerdict` on any
+    parse/validation failure so the caller can re-prompt for a repaired verdict."""
+    try:
+        obj = extract_json_block(output_text)
+        findings = recipe.output_model.model_validate(obj)
+        _validate_invariants(findings)
+        return findings
+    except (ValueError, json.JSONDecodeError, ValidationError) as e:
+        raise _UnusableVerdict(str(e)) from e
+
+
+def _verdict_repair_prompt(prior_output: str, error: str) -> str:
+    """Hand the model back its own analysis + the parse error and ask only for a
+    corrected verdict — no re-investigation (the retry run passes no tools)."""
+    return (
+        "Your investigation analysis is reproduced below, but it did not end with a "
+        f"valid structured verdict (parse/validation error: {error}).\n\n"
+        "Do NOT investigate further or call any tools. Using ONLY the analysis below, "
+        "output a single fenced ```json block that fully matches the schema in the "
+        "system prompt — every required field populated, especially `outcome` and "
+        "`primary_blame` (and `evidence` when `primary_blame` is not `none`).\n\n"
+        "--- YOUR PRIOR ANALYSIS ---\n"
+        f"{prior_output}"
+    )
+
+
+def _verdict_failure_sentinel(prior_output: str, error: str) -> BaseFindings:
+    """Loud fallback when the verdict can't be repaired: an unmistakable
+    investigation-failure finding (never a silent empty/clean record) that preserves
+    the prose analysis so the spent reasoning is not lost."""
+    return BaseFindings(
+        analysis=prior_output or "(investigator produced no output)",
+        evidence=[],
+        summary=f"INVESTIGATION FAILED: no usable structured verdict after retries ({error}).",
+        outcome=Outcome("failure"),
+        primary_blame=BlameCategory("none"),
+        primary_blame_confidence=0,
+        hypothesis="Re-run the investigator: it finished analysis but never emitted a parseable verdict.",
+        hypothesis_confidence=0,
+    )
+
+
+async def _run_with_verdict_retry(
+    driver: AgentDriver,
+    recipe: InvestigatorRecipe,
+    *,
+    base_run_kwargs: dict[str, Any],
+    episode_name: str,
+) -> tuple[BaseFindings, DriverResult]:
+    """Run the investigator, then guarantee a usable structured verdict.
+
+    The model sometimes finishes a full analysis but emits no parseable / complete
+    verdict (malformed JSON, or `outcome`/`primary_blame` missing). Previously that
+    raised and the batch runner wrote an empty sidecar finding, silently losing the
+    (expensive) analysis. Re-prompt — with **no tools**, handing back the prior
+    analysis — to repair just the verdict, bounded by `recipe.max_verdict_retries`;
+    fall back to a loud sentinel finding rather than an empty record.
+    """
+    result = await driver.run(**base_run_kwargs)
+    last_error = ""
+    for attempt in range(recipe.max_verdict_retries + 1):
+        try:
+            return _parse_findings(result.output_text, recipe), result
+        except _UnusableVerdict as e:
+            last_error = str(e)
+            if attempt >= recipe.max_verdict_retries:
+                break
+            logger.warning(
+                "Investigator verdict unusable for %s (attempt %d/%d): %s — re-prompting for repair",
+                episode_name,
+                attempt + 1,
+                recipe.max_verdict_retries + 1,
+                last_error,
+            )
+            repair_kwargs = {
+                **base_run_kwargs,
+                "user_prompt": _verdict_repair_prompt(result.output_text, last_error),
+                "allowed_tools": (),  # verdict-only repair: no re-investigation
+            }
+            result = await driver.run(**repair_kwargs)
+    logger.error(
+        "Investigator could not produce a usable verdict for %s after %d attempts (%s); "
+        "recording a sentinel failure finding.",
+        episode_name,
+        recipe.max_verdict_retries + 1,
+        last_error,
+    )
+    return _verdict_failure_sentinel(result.output_text, last_error), result
+
+
+# /auto-fix(450)
 
 
 def _resolve_recipe(recipe: InvestigatorRecipe | None, model_override: str | None) -> InvestigatorRecipe:
@@ -333,7 +435,7 @@ async def _investigate_episode_impl(
         recipe.model,
     )
 
-    result = await driver.run(
+    base_run_kwargs: dict[str, Any] = dict(
         system_prompt=recipe.system_prompt,
         user_prompt=user_prompt,
         cwd=episode_dir,
@@ -344,10 +446,9 @@ async def _investigate_episode_impl(
         verbose=verbose,
         trace_mode=trace_mode,
     )
-
-    obj = extract_json_block(result.output_text)
-    findings = recipe.output_model.model_validate(obj)
-    _validate_invariants(findings)
+    findings, result = await _run_with_verdict_retry(
+        driver, recipe, base_run_kwargs=base_run_kwargs, episode_name=episode_dir.name
+    )
 
     investigation_metadata = InvestigationMetadata(
         model=recipe.model,
@@ -854,3 +955,4 @@ def write_json_report(
 #              — cold cache + n_parallel=4 over 4 episodes ⇒ generate_context_file
 #              invoked exactly once (asserts the invariant, not a reproduction).
 #   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.
+# auto-fix-note(450) {class=L1 anchor=PR#450 hash=PENDING ctx=investigator/empty-or-malformed-verdict-dropped-finding/verdict-repair-retry+loud-sentinel/tbench2:kv-store-grpc/cube-harness@ccba968e}

--- a/src/cube_harness/analyze/investigator/recipe.py
+++ b/src/cube_harness/analyze/investigator/recipe.py
@@ -61,6 +61,10 @@ class InvestigatorRecipe(TypedBaseModel):
     allowed_tools: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
     permission_mode: Literal["bypassPermissions", "ask"] = "bypassPermissions"
     audit: bool = False
+    # If the investigator finishes its analysis but emits no parseable/complete
+    # structured verdict, re-prompt it (with no tools) up to this many times to
+    # repair just the verdict before falling back to a loud sentinel finding.
+    max_verdict_retries: int = 2
 
     @field_serializer("output_model")
     def _serialize_output_model_field(self, value: type[TypedBaseModel]) -> str:

--- a/tests/test_investigator_verdict_retry.py
+++ b/tests/test_investigator_verdict_retry.py
@@ -1,0 +1,107 @@
+"""The investigator must never silently lose a finding when the model finishes its
+analysis but emits no parseable/complete structured verdict: it re-prompts (no tools)
+to repair the verdict, and falls back to a LOUD sentinel rather than an empty record."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from cube_harness.analyze.investigator.agent_driver import DriverResult
+from cube_harness.analyze.investigator.core import (
+    _parse_findings,
+    _run_with_verdict_retry,
+    _UnusableVerdict,
+    _verdict_failure_sentinel,
+)
+from cube_harness.analyze.investigator.recipe import InvestigatorRecipe
+from cube_harness.eval_log import BaseFindings
+
+# A full analysis but NO structured verdict (the kv-store-grpc failure mode).
+PROSE_ONLY = "I walked the episode. The agent built the server, then the infra crashed. (no verdict block)"
+# A valid, complete verdict.
+VALID_VERDICT = """Here is my verdict.
+```json
+{"analysis": "a", "evidence": [], "summary": "s", "outcome": "success",
+ "primary_blame": "none", "primary_blame_confidence": 0, "other_blames": [],
+ "hypothesis": "h", "hypothesis_confidence": 0}
+```"""
+
+RECIPE = InvestigatorRecipe(
+    name="t",
+    system_prompt="sys",
+    user_prompt_template="{trajectory_id}",
+    output_model=BaseFindings,
+    max_verdict_retries=2,
+)
+BASE_KWARGS: dict[str, Any] = dict(system_prompt="sys", user_prompt="orig", allowed_tools=("Read", "Bash"))
+
+
+class _ScriptedDriver:
+    """AgentDriver that returns a scripted output per `run` call (repeats the last)."""
+
+    name = "scripted"
+    max_parallelism = 1
+
+    def __init__(self, outputs: list[str]) -> None:
+        self._outputs = list(outputs)
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, **kwargs: Any) -> DriverResult:
+        text = self._outputs[min(len(self.calls), len(self._outputs) - 1)]
+        self.calls.append(kwargs)
+        return DriverResult(output_text=text, prompt_tokens=10, completion_tokens=5)
+
+    async def continue_session(self, **kwargs: Any) -> DriverResult:
+        raise NotImplementedError
+
+
+def _run(driver: _ScriptedDriver) -> BaseFindings:
+    findings, _result = asyncio.run(
+        _run_with_verdict_retry(driver, RECIPE, base_run_kwargs=dict(BASE_KWARGS), episode_name="ep0")
+    )
+    return findings
+
+
+def test_parse_findings_raises_on_unusable_verdict() -> None:
+    try:
+        _parse_findings(PROSE_ONLY, RECIPE)
+    except _UnusableVerdict:
+        pass
+    else:
+        raise AssertionError("expected _UnusableVerdict for prose with no verdict block")
+    assert _parse_findings(VALID_VERDICT, RECIPE).outcome.value == "success"
+
+
+def test_usable_verdict_first_try_does_not_retry() -> None:
+    driver = _ScriptedDriver([VALID_VERDICT])
+    findings = _run(driver)
+    assert findings.outcome.value == "success"
+    assert len(driver.calls) == 1  # no repair call
+
+
+def test_retry_repairs_unusable_verdict() -> None:
+    driver = _ScriptedDriver([PROSE_ONLY, VALID_VERDICT])
+    findings = _run(driver)
+    assert findings.outcome.value == "success"
+    assert len(driver.calls) == 2  # one repair re-prompt
+    repair = driver.calls[1]
+    assert repair["allowed_tools"] == ()  # verdict-only repair: tools stripped
+    assert "PRIOR ANALYSIS" in repair["user_prompt"] and PROSE_ONLY in repair["user_prompt"]
+
+
+def test_exhausted_retries_yield_loud_sentinel() -> None:
+    driver = _ScriptedDriver([PROSE_ONLY])  # never repairs
+    findings = _run(driver)
+    # max_verdict_retries=2 ⇒ initial + 2 repairs = 3 calls
+    assert len(driver.calls) == 3
+    assert findings.outcome.value == "failure"
+    assert findings.summary.startswith("INVESTIGATION FAILED")
+    assert PROSE_ONLY in findings.analysis  # prose preserved, not an empty record
+
+
+def test_sentinel_is_a_valid_finding() -> None:
+    sentinel = _verdict_failure_sentinel("some analysis", "boom")
+    assert isinstance(sentinel, BaseFindings)
+    assert sentinel.outcome.value == "failure"
+    assert "boom" in sentinel.summary


### PR DESCRIPTION
## Invariant violated

A finished investigation must always yield a usable, persisted verdict — or fail **loudly**. It must never silently drop the (expensive) analysis when the model emits no parseable/complete structured verdict.

## Root cause

`_investigate_episode_impl` ran the driver, then did `extract_json_block → model_validate → _validate_invariants` **with no retry**. When the model finished a full analysis but emitted no valid verdict — malformed JSON, *or* a JSON object missing required fields (`outcome`/`primary_blame`) — this raised, and the batch runner caught it and wrote an **empty sidecar `findings.json`**. The $0.40 of analysis was lost, and every downstream consumer that reads the structured fields (the coverage map, the 3-bucket rollup) saw `NO_FINDING`.

Observed on `kv-store-grpc` in the tbench2-daytona run: a $0.42 / 240s analysis with a full prose walkthrough, but `outcome=None`/`primary_blame=None` — the model finished an infra-crashed episode and never committed to a verdict.

## The fix

Wrap the run→parse in a bounded **verdict-repair retry** (`_run_with_verdict_retry`):

- The required `outcome`/`primary_blame` fields + `_validate_invariants` already define "usable" — any parse/validation failure raises `_UnusableVerdict`.
- On an unusable verdict, re-prompt **with no tools** (`allowed_tools=()`), handing the model back its own prior analysis + the specific error, asking only for a corrected `json` block. Cheap (no re-investigation), bounded by the new `recipe.max_verdict_retries` (default 2).
- If retries exhaust, write a **loud sentinel** finding (`outcome=failure`, `summary` starting `INVESTIGATION FAILED`, prose preserved) and log at ERROR — never an empty/clean record.

## Blast radius

- `recipe.py`: new `max_verdict_retries: int = 2` (additive).
- `core.py`: `_run_with_verdict_retry` + 3 small helpers; the call site swaps the bare parse for it. The happy path is unchanged (usable verdict ⇒ one run, zero retries).
- No driver/Protocol change. `continue_session`/the audit-pass fallback are untouched (a cheaper session-resume is possible now that the SDK exposes `resume`, but deferred to keep this diff in one module + avoid resume-semantics risk).

## Adversarial "opposite user"

*Could the retry mask a model that legitimately can't decide?* The repair prompt forbids re-investigation and only asks the model to commit a verdict it already reasoned toward; if it still can't, the sentinel records that honestly (failure + loud summary), which is strictly better than the prior silent empty record. *Cost?* The repair turn carries the prior analysis as context and uses no tools — far cheaper than a re-investigation, and it only fires when the first verdict was unusable.

## Class

**L1** (correct at the investigator layer; the parse/verdict path is shared by every recipe). Marker `auto-fix(PENDING)` → amended to the PR number on open.

## Test

`tests/test_investigator_verdict_retry.py` (5) — predicate raises on prose; usable-first-try doesn't retry; unusable→good repairs in 2 calls with tools stripped + prior analysis fed back; exhaustion ⇒ loud sentinel (3 calls, prose preserved); sentinel is a valid finding.

**Smoke** `scripts/smoke/investigator_verdict_retry.py` — drives the **real `investigate_experiment` pipeline** on a fixture episode with a scripted driver: scenario 1 repairs + persists the real verdict to `episode_record.json`; scenario 2 persists the loud sentinel. Prints `SMOKE OK`.

Full investigator suite (59) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
