### PR TITLE
fix(investigator): build context map once before parallel fan-out

### DIFF
--- a/src/cube_harness/analyze/investigator/core.py
+++ b/src/cube_harness/analyze/investigator/core.py
@@ -600,6 +600,23 @@ async def _investigate_experiment_async(
     semaphore = asyncio.Semaphore(n_parallel)
     primary_results: dict[str, tuple[BaseFindings, InvestigationMetadata]] = {}
 
+    # auto-fix(451)↓
+    # Build the shared investigation-context map exactly once, before fanning
+    # out. `_ensure_context_file` is check-then-act; with a cold cache and
+    # n_parallel>1, every episode worker would otherwise see "not cached" and
+    # invoke the (Opus) benchmark-context-agent for the *same* file — N
+    # concurrent builds, N-1 wasted (the costliest call in the batch). A single
+    # awaited pre-build makes every per-episode call an idempotent cache hit.
+    # Best-effort: on failure, fall back to the per-episode build (status quo).
+    try:
+        _view = _load_experiment_view(experiment_dir / "experiment_config.json")
+        await _ensure_context_file(
+            experiment_dir, driver, context_dir=context_dir, benchmark_dotted=_view.benchmark_dotted
+        )
+    except Exception as e:  # noqa: BLE001 — pre-warm must never break the batch
+        logger.warning("Context-map pre-build skipped (%s); per-episode build will run.", e)
+    # /auto-fix(451)
+
     async def _one(ref: EpisodeRef, seed_index: int) -> None:
         async with semaphore:
             try:
@@ -816,4 +833,24 @@ def write_json_report(
 #   tested:    tests/test_investigator.py — a hanging fake driver is
 #              bounded; the batch records nothing for it and completes the
 #              rest (asserts the invariant, not a reproduction).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.
+# auto-fix-note(451) {class=L1 issue=451 hash=PENDING ctx=macos-arm64/claude-sonnet-4-6/cube-harness@ccba968e}
+#   symptoms:  Auto-CUBE swebench-live-daytona-r0, Round 1 investigation
+#              (ch-investigate run --n-parallel 4, cold --context-dir cache):
+#              all 4 episode workers logged "investigation_context not cached
+#              — invoking benchmark-context-agent" for the *same* file and 4
+#              Opus context-map builds completed (4 "wrote" log lines),
+#              inflating batch cost ~4x (the map is the costliest single call).
+#   invariant: the benchmark-context-agent (Opus codebase map) runs at most
+#              once per (session, benchmark) per batch, regardless of
+#              n_parallel — never once-per-worker on a cold cache.
+#   why:       `_ensure_context_file` is check-then-act with no lock and was
+#              called only inside each parallel episode worker; cold cache +
+#              n_parallel>1 ⇒ all workers see "not cached" and each builds.
+#              Fix hoists one awaited pre-build above the semaphore fan-out in
+#              `_investigate_experiment_async` (right layer: the batch runner
+#              owns shared-resource init); per-episode calls become cache hits.
+#   tested:    tests/test_investigator.py::test_context_map_built_once_under_parallelism
+#              — cold cache + n_parallel=4 over 4 episodes ⇒ generate_context_file
+#              invoked exactly once (asserts the invariant, not a reproduction).
 #   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -1063,6 +1063,45 @@ def test_investigate_experiment_injects_full_context_markdown(tmp_path: Path) ->
     assert "cubes/foo/task.py:evaluate is the reward function" in user_prompt, "key-location pointer not injected"
 
 
+def test_context_map_built_once_under_parallelism(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """auto-fix: cold context cache + n_parallel>1 must build the (Opus) context
+    map exactly once, not once per worker.
+
+    Asserts the invariant, not the reproduction: with 4 episodes and n_parallel=4
+    over a cold session-keyed cache, the benchmark-context-agent
+    (`generate_context_file`) is invoked exactly once. Before the fix, all 4
+    parallel episode workers raced on the check-then-act and each built it.
+    """
+    import cube_harness.analyze.investigator.core as inv_core
+
+    # 4 real episodes (with steps) so every parallel worker reaches _ensure_context_file.
+    exp = tmp_path / "exp"
+    for i in range(4):
+        exp, _ = _make_episode_dir(tmp_path, f"task{i}_ep0")
+
+    # context_dir set => session-keyed cache (cold), independent of the per-episode
+    # seed _make_episode_dir writes into the experiment dir.
+    session = tmp_path / "session"
+    session.mkdir()
+
+    calls = {"n": 0}
+
+    async def _counting_generate(experiment_dir: Path, *, driver: Any, out_path: Path, **_: Any) -> Path:
+        calls["n"] += 1
+        out_path.write_text("# ctx\n\n```paths\n```\n")
+        return out_path
+
+    monkeypatch.setattr(inv_core, "generate_context_file", _counting_generate)
+
+    driver = _FakeDriver(output_text=f"```json\n{_VALID_FINDINGS_JSON}\n```")
+    investigate_experiment(
+        exp,
+        InvestigationConfig(driver=driver, n_parallel=4, context_dir=session, synthesis_model=""),
+    )
+
+    assert calls["n"] == 1, f"context map built {calls['n']}x under n_parallel=4; expected exactly once"
+
+
 # ---------------------------------------------------------------------------
 # CLI smoke (subcommand dispatch only — no real LLM calls)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Fix Report — auto-fix(451)

**Class**: L1  ·  **Anchor**: `PR#451`
**Context fingerprint**: `daytona/macos-arm64/claude-sonnet-4-6/cube-harness@ccba968e`

## Invariant violated
The benchmark-context-agent (the Opus codebase-map build) must run **at most once** per (session, benchmark) per batch, regardless of `--n-parallel` — never once per worker on a cold cache.

## Root cause
`_ensure_context_file` is a check-then-act with no lock (`if path.exists(): return; else: await generate_context_file(...)`), and it was called **only from inside each parallel episode worker** (`_investigate_episode_impl`). The batch runner `_investigate_experiment_async` fans those workers out under `asyncio.Semaphore(n_parallel)`. With a cold `--context-dir` cache and `n_parallel > 1`, all N workers start, all evaluate `path.exists()` as `False` before any build finishes writing, and all N invoke the Opus benchmark-context-agent for the *same* file. Last writer wins; N−1 builds are wasted — and the context map is the single most expensive call in the batch.

Surfaced by Auto-CUBE `swebench-live-daytona-r0`, round-1 investigation (`ch-investigate run --n-parallel 4`, cold cache): the log shows 4 concurrent `"investigation_context not cached — invoking benchmark-context-agent"` lines and 4 `"benchmark-context-agent wrote …"` completions for the identical path, inflating that run's investigation cost (~$5.11) roughly 4× on the map.

## Why this fix / why this layer
- Hoist a single **awaited** `_ensure_context_file` into `_investigate_experiment_async` *before* the semaphore fan-out, so the cache is warm before any worker checks it; per-episode calls then short-circuit on `path.exists()`.
- Right layer: the batch runner owns shared-resource initialization (it already owns parallelism + the "one episode can't stall the batch" guard, auto-fix(409)). The per-episode helper stays unchanged and idempotent.
- Best-effort (`try/except` + warning): a pre-build failure falls back to the prior per-episode behavior, so the fix can never make a batch *fail* that previously ran.

## Blast radius
```
$ git grep -n '_ensure_context_file' origin/dev -- 'src/**/*.py'
src/cube_harness/analyze/investigator/core.py:231:async def _ensure_context_file(
src/cube_harness/analyze/investigator/core.py:285:    context_path = await _ensure_context_file(   # per-episode (unchanged)
```
One existing call site (per-episode); this PR adds one serialized pre-build call. The single-shot `init-context` CLI path (`cli.py:204 generate_context_file`) is not parallel and is unaffected.

## Adversarial: the opposite user
A caller running `n_parallel=1` or with a warm cache: the pre-build is one extra `path.exists()` check (warm) or the same single build it would have done anyway (cold) — no behavior change, no extra cost. A caller whose `experiment_config.json` is missing/unreadable: `_load_experiment_view` already tolerates this (returns `benchmark_dotted=None`, matching the per-episode resolution), and the `try/except` degrades to status-quo per-episode build.

## Registry lookup
- `auto-fix-note(409)` in the same file (`core.py`, `ctx=macos-arm64/claude-sonnet-4-6/cube-harness@5ca4e565`) — per-episode timeout guard in the same batch runner (`_investigate_experiment_async`/`_one`). This is the **2nd** auto-fix in this batch-runner area; a 3rd would trip the refactor-proposal threshold (the batch runner's shared-state/lifecycle management).

## Test
- `tests/test_investigator.py::test_context_map_built_once_under_parallelism` — 4 real episodes, cold session-keyed cache, `n_parallel=4`; spies `generate_context_file` and asserts it is invoked **exactly once** (the invariant), not that any task succeeds. Witness: pre-fix this race produced up to 4 invocations; post-fix it is 1.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Auto-CUBE auto-fix.

