### PR TITLE
fix(swebench-verified): fail loud, not silent-0, when a task is unpatchable on non-root infra (#446)

### DIFF
--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from cube.container import relocate_if_readonly
 from cube.core import ActionSchema, Observation
+from cube.resource import IncompatibleInfraError
 from cube.task import STOP_ACTION, RuntimeContext, Task, TaskConfig, TaskExecutionInfo, TaskMetadata
 
 from cube.tools.terminal import ContainerTerminalTool, TerminalToolConfig
@@ -178,8 +179,56 @@ class SWEBenchVerifiedTask(Task[SWEBenchVerifiedTaskMetadata, ContainerTerminalT
         )
         self._tool = self.tool_config.model_copy(update={"working_dir": new_wd}).make(container=self._container)
 
+    # auto-fix(446)↓ fail loud, not silent-0.
+    _GOLD_TARGET_RE = re.compile(r"^\+\+\+ b/(.+)$", re.MULTILINE)
+
+    def _raise_if_unpatchable(self, working_dir: str) -> None:
+        """Raise ``IncompatibleInfraError`` if the gold patch's target files can't be
+        written after the writability normalisation in ``_build_tool``.
+
+        On non-root infra (EAI toolkit, uid 13011) some images ship root-owned package
+        subdirs (e.g. psf/requests' ``/testbed/requests/``) that ``cp/mv`` can't reparent
+        without root. Any patch — gold or agent — to a file there dies with ``git apply:
+        Permission denied``, and the task would silently score a *correct* fix 0. We probe
+        exactly the files the **gold patch** touches (the canonical fix's source paths) —
+        not the whole tree — so unrelated root-owned vendored dirs (e.g. astropy's
+        ``astropy/_erfa``) don't false-positive. If even the gold patch's targets aren't
+        writable, no agent patch to the same files can be either → surface the cube's
+        IncompatibleInfraError (terminal + non-retriable per episode.py) instead. Root
+        infras leave everything writable, so this never fires there. See #446.
+        """
+        targets = sorted(set(self._GOLD_TARGET_RE.findall(self._exec.patch or "")))
+        if not targets:
+            return
+        # A target is patchable iff its parent dir is writable (git apply unlinks+recreates
+        # via the dir) and the file itself is writable-or-absent.
+        quoted = " ".join(shlex.quote(t) for t in targets)
+        probe = (
+            f"cd {shlex.quote(working_dir)} || exit 0; for f in {quoted}; do "
+            'd=$(dirname "$f"); if [ ! -w "$d" ] || { [ -e "$f" ] && [ ! -w "$f" ]; }; then '
+            "printf '%s\\n' \"$f\"; break; fi; done"
+        )
+        blocked = self._container.exec(probe, timeout=60).stdout.strip()
+        if blocked:
+            uid = self._container.exec("id -u", timeout=15).stdout.strip()
+            raise IncompatibleInfraError(
+                f"{self.metadata.id}: gold-patch target {blocked.splitlines()[0]!r} under "
+                f"{working_dir} is not writable by the runtime user (uid {uid}) after writability "
+                f"normalisation — this image ships root-owned package dirs a non-root infra cannot "
+                f"patch (git apply would fail 'Permission denied', silently scoring a correct patch 0). "
+                f"This task needs 'container:root'; run it on a root-capable infra (daytona/local/aws). "
+                f"See cube-harness#446."
+            )
+
+    # /auto-fix(446)
+
     def reset(self) -> tuple[Observation, dict[str, Any]]:
         self.tool.reset()
+        # auto-fix(446): fail loud (IncompatibleInfraError), not silent-0, if the gold
+        # patch's target files aren't writable on this (non-root) infra. Called here —
+        # inside reset(), which the episode runs within its try/except — so the error
+        # is classified terminal & non-retriable (episode.py) rather than escaping setup.
+        self._raise_if_unpatchable(self.tool._config.working_dir)
 
         # Oracle mode: write gold patch for debug/baseline use
         if self.oracle_mode and self._exec.patch:
@@ -450,3 +499,16 @@ class SWEBenchVerifiedTaskConfig(TaskConfig[SWEBenchVerifiedTaskMetadata]):
 # === auto-fix notes ===
 # auto-fix-note(423) {class=L1 anchor=PR#423 hash=00588ac5 ctx=daytona+toolkit/swebench-verified/sphinx-doc__sphinx-8475}
 # auto-fix-note(430) {class=L1 anchor=PR#430 hash=6a2bbc39 ctx=daytona/swebench-verified/sphinx-doc__sphinx-8475/test_build_linkcheck}
+# auto-fix-note(446) {class=L2 issue=446 hash=PENDING ctx=toolkit/uid-13011/swebench-verified/psf__requests-1142}
+#   symptoms:  non-root toolkit + image with root-owned package subdir
+#              (/testbed/requests/) -> git apply "Permission denied" -> a correct
+#              patch (gold or agent) silently scores 0.
+#   invariant: a writability defect of the infra must NOT masquerade as an agent
+#              failure (reward 0). Fail loud (IncompatibleInfraError) instead.
+#   why:       band-aid — detects the unpatchable dir at _build_tool and raises the
+#              cube's IncompatibleInfraError (terminal/non-retriable). The full
+#              resolution (declare container:root vs skip vs relocate) is the
+#              design decision tracked in #446; no in-place non-root fix exists.
+#   tested:    scripts/smoke/nonroot_unpatchable_faill0ud.py (requests-1142 raises;
+#              writable tasks no-op).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/scripts/smoke/nonroot_unpatchable_faill0ud.py
+++ b/scripts/smoke/nonroot_unpatchable_faill0ud.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Smoke: non-root-unpatchable SWE-bench tasks fail loud, not silent-0 (auto-fix #446).
+
+Regression guard for the auto-fix(446) band-aid. On a non-root infra (EAI Toolkit,
+uid 13011) some SWE-bench images ship root-owned package subdirs (e.g. psf/requests'
+``/testbed/requests/``) that the writability normalisation in
+``SWEBenchVerifiedTask._build_tool`` cannot reparent without root. Any patch — gold
+or agent — to a file there dies with ``git apply: Permission denied``, and the task
+would silently score a *correct* fix 0. The band-aid raises ``IncompatibleInfraError``
+(terminal & non-retriable, episode.py) instead, scoped to the **gold patch's target
+files** so unrelated root-owned vendored dirs (e.g. astropy's ``astropy/_erfa``) do
+not false-positive.
+
+This smoke asserts, on toolkit:
+  1. ``psf__requests-1142`` (gold target ``requests/models.py`` in a root-owned dir)
+     ends ``INVALID_CONFIG`` with ``error_type == "IncompatibleInfraError"`` — NOT a
+     reward-0 completion, and NOT retried.
+  2. ``astropy__astropy-12907`` (gold target ``astropy/modeling/`` is writable, even
+     though ``astropy/_erfa`` is root-owned) resolves normally (reward 1.0) — no
+     false-positive.
+
+SKIP if ``eai`` is absent / not authed (safe in any CI).
+
+Run from the cube-harness repo root with the venv:
+    EAI_PROFILE=yul101 .venv/bin/python scripts/smoke/nonroot_unpatchable_faill0ud.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+_NAME = "nonroot_unpatchable_faill0ud"
+_BLOCKED = "psf__requests-1142"  # gold target requests/models.py — root-owned dir
+_CONTROL = "astropy__astropy-12907"  # gold target astropy/modeling/ — writable
+
+
+def banner(status: str, reason: str = "") -> int:
+    print(f"\nSMOKE {status}: {_NAME}" + (f" — {reason}" if reason else ""))
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+def main() -> int:
+    if shutil.which("eai") is None:
+        return banner("SKIP", "eai not on PATH")
+
+    # Imports after the SKIP gate so a CI box without the deps still skips cleanly.
+    from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmarkConfig
+    from swebench_verified_cube.gold_patch.agent import GoldPatchAgentConfig
+
+    from cube_harness.exp_runner import run_with_ray
+    from cube_harness.experiment import Experiment
+    from cube_harness.infra import INFRA_CONFIGS
+    from cube_harness.storage import FileStorage
+
+    if "toolkit" not in INFRA_CONFIGS:
+        return banner("SKIP", "no 'toolkit' infra configured in ~/.cube/infra.py")
+
+    tmp = Path(tempfile.mkdtemp(prefix="smoke_faill0ud_"))
+    bench = SWEBenchVerifiedBenchmarkConfig(oracle_mode=True).subset_from_list([_BLOCKED, _CONTROL])
+    exp = Experiment(
+        name=f"{_NAME}",
+        agent_config=GoldPatchAgentConfig(),
+        benchmark_config=bench,
+        infra=INFRA_CONFIGS["toolkit"],
+        max_steps=5,
+        output_dir=tmp / "run",
+    )
+    try:
+        run_with_ray(exp, n_cpus=2)
+    except Exception as exc:  # a per-episode raise must not crash the batch
+        return banner("FAIL", f"run_with_ray raised at batch level: {type(exc).__name__}: {exc}")
+
+    store = FileStorage(exp.output_dir)
+    statuses = {s.task_id: s for s in store.list_episode_statuses().values()}
+    blocked = statuses.get(_BLOCKED)
+    control = statuses.get(_CONTROL)
+    if blocked is None or control is None:
+        return banner("FAIL", f"missing episode status (blocked={blocked!r}, control={control!r})")
+
+    # 1. blocked task must fail loud (IncompatibleInfraError), terminal & non-retriable.
+    if blocked.error_type != "IncompatibleInfraError":
+        return banner(
+            "FAIL",
+            f"{_BLOCKED}: expected error_type=IncompatibleInfraError (fail loud), got "
+            f"status={blocked.status!r} error_type={blocked.error_type!r} reward={blocked.reward!r} "
+            f"— a silent reward-0 here is the bug this guards against",
+        )
+    if blocked.status != "INVALID_CONFIG":
+        return banner(
+            "FAIL", f"{_BLOCKED}: IncompatibleInfraError should be terminal INVALID_CONFIG, got {blocked.status!r}"
+        )
+    if blocked.retry_count != 0:
+        return banner("FAIL", f"{_BLOCKED}: should be non-retriable, but retry_count={blocked.retry_count}")
+
+    # 2. control task must NOT false-positive — resolves normally.
+    if not (control.status == "COMPLETED" and (control.reward or 0) >= 1.0):
+        return banner(
+            "FAIL",
+            f"{_CONTROL}: false-positive — a writable task regressed to "
+            f"status={control.status!r} reward={control.reward!r} (its gold target dir IS writable)",
+        )
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    return banner("OK", f"{_BLOCKED} → fail-loud INVALID_CONFIG/IncompatibleInfraError; {_CONTROL} → resolved 1.0")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -5,6 +5,7 @@ from typing import Callable, Self
 
 from cube.benchmark import Benchmark, RuntimeContext
 from cube.core import EnvironmentOutput, StepError, TypedBaseModel
+from cube.resource import IncompatibleInfraError
 from cube.task import TaskConfig
 from opentelemetry.trace import StatusCode
 from termcolor import colored
@@ -305,9 +306,12 @@ class Episode:
         except Exception as e:
             logger.exception(f"Error during agent run: {e}")
             # Permanent provider errors (bad model name, bad key, malformed request)
-            # will fail identically on retry — mark them terminal & non-retriable so
-            # the runner stops instead of burning the whole retry budget.
-            ep_status.status = "INVALID_CONFIG" if is_permanent_llm_error(e) else "FAILED"
+            # and infra-incompatibility (IncompatibleInfraError — e.g. a task that
+            # needs container:root on a non-root infra) will fail identically on
+            # retry — mark them terminal & non-retriable so the runner stops instead
+            # of burning the whole retry budget.
+            permanent = is_permanent_llm_error(e) or isinstance(e, IncompatibleInfraError)
+            ep_status.status = "INVALID_CONFIG" if permanent else "FAILED"
             ep_status.error_type = type(e).__name__
             ep_status.error_message = str(e)[:500]
             raise e


### PR DESCRIPTION
# Fix Report — fail loud (not silent-0) when a SWE-bench task is unpatchable on non-root infra

**Class**: L2 band-aid · **Anchor**: design-debt issue **#446**
**Context fingerprint**: `toolkit/yul101/uid-13011/swebench-verified/psf__requests-1142`

## Invariant violated
A **writability defect of the infra** must never masquerade as an agent failure
(reward 0). If a correct patch *cannot be applied* on this infra, the episode must
fail **loud and attributable**, not silently score 0.

## Root cause
On a non-root infra (EAI Toolkit pins uid 13011) some SWE-bench images ship
**root-owned package subdirs** even though `/testbed` itself is world-writable, e.g.
`/testbed/requests/` is `drwxr-xr-x root:root`. The `cp/mv` normalisation in
`SWEBenchVerifiedTask._build_tool` only fixes files whose *parent dir* is writable;
a root-owned dir can't be chmod'd/reparented/removed without root. So `git apply`
(gold **or** agent patch) to a file there dies with `Permission denied`, the
FAIL_TO_PASS test fails, and a **correct** patch silently scores 0. There is **no
clean in-place non-root fix** (relocating to `/tmp/testbed` breaks editable installs
— see #446 for the full analysis); this PR is the band-aid that stops the *silent*
part.

## The fix
1. **`task.py`** — after writability normalisation, `reset()` calls
   `_raise_if_unpatchable()`, which probes **only the gold patch's target files**
   (the canonical fix's source paths) for writability. If a target's dir isn't
   writable, raise the cube's `IncompatibleInfraError` with an actionable message
   ("needs `container:root`; run on daytona/local/aws"). Scoping to the gold
   targets — not the whole tree — avoids false-positives on unrelated root-owned
   vendored dirs (e.g. astropy's `astropy/_erfa`, which `astropy-12907`'s fix never
   touches). The check lives in `reset()` (inside the episode's try) so the error is
   caught and classified, not leaked out of setup.
2. **`episode.py`** — classify `IncompatibleInfraError` as `INVALID_CONFIG`
   (terminal **non-retriable**), alongside permanent LLM errors: it fails identically
   on retry, so retrying only burns budget.

## Why this layer
- The writability normalisation already lives in swebench `_build_tool`; the loud
  signal belongs right after it.
- `IncompatibleInfraError` is the cube's existing capability-incompatibility error
  (the same one the make-time `can_serve` gate raises) — reused, not reinvented.
- The *full* resolution (declare `container:root` statically vs skip vs relocate) is
  a design decision tracked in **#446**; this PR only converts silent-0 → loud.

## Blast radius
- `cubes/swebench-verified-cube/.../task.py` (`reset` + new `_raise_if_unpatchable`).
- `src/cube_harness/episode.py` (one classification line; affects any
  `IncompatibleInfraError`, which is the intended general behavior).
- `swebench-live-cube` has the same `_build_tool` shape — **not** touched here
  (follow-up); it would benefit from the same guard.

## Adversarial: the opposite user
*A task with an unrelated root-owned vendored dir but a writable fix target* (e.g.
`astropy-12907`: `astropy/_erfa` is root-owned, fix is in `astropy/modeling/`). An
early version that probed the whole tree **false-positived** on it. Fixed by scoping
to gold-patch targets — verified below.

## Test (smoke, validated on toolkit/yul101)
`scripts/smoke/nonroot_unpatchable_faill0ud.py` (`SMOKE OK/FAIL/SKIP`, SKIPs without `eai`):
- `psf__requests-1142` → `INVALID_CONFIG` + `error_type=IncompatibleInfraError`,
  `retry_count=0` (fail loud, non-retriable) — **was** a silent reward-0.
- `astropy__astropy-12907` → `COMPLETED` reward `1.0` (no false-positive).

Manually confirmed both outcomes on toolkit before opening this PR.
