### PR TITLE
docs(auto-fix): 'no viable band-aid -> issue-only' disposition (+ reconcile §5)

### DIFF
--- a/openspec/specs/auto-fix/spec.md
+++ b/openspec/specs/auto-fix/spec.md
@@ -33,6 +33,19 @@ run) can see what was patched, why, and where it may not generalize.
 **Nothing blocks the loop.** L2/L3 still ship a temporary PR. The human's
 queue is the `design-debt` backlog, not individual patches.
 
+**Exception — no viable band-aid (diagnosis-only).** "Ship a temp PR" assumes a
+band-aid *exists and helps*. When every candidate fix is **validated net-negative**
+(it regresses other tasks — confirm with a regression run, don't guess) or
+**infeasible** (the constraint can't be worked around at this layer), do **not**
+ship a harmful patch just to satisfy "ship something" — the `design-debt` issue is
+the sole deliverable. The issue MUST carry (a) the evidence the band-aid was tried
+and regressed / is infeasible, and (b) whether a **narrower, strictly-safe guard**
+was shippable instead — most often *fail-loud-not-silent* (surface the defect as an
+explicit error rather than a silently-wrong result); if so, ship that guard as the
+band-aid PR. "Fail loud" is almost always safe and almost always available, so true
+diagnosis-only (issue and nothing else) should be rare — reach for it only after
+ruling the safe guard out.
+
 ### When NOT to mark (proportionality)
 
 Markers exist for code that can silently rot. **Skip in-code markers** when
@@ -152,9 +165,13 @@ Degraded mode: if `gh` is unavailable when writing the marker, leave
    long-form *design* context (what makes this L2/L3; the openspec stub
    link).
 2. Write `auto-fix(N)` markers (N = issue number); open PR referencing
-   `N`. PR body has the Fix Report (same shape as L0/L1).
+   `N`. PR body has the Fix Report (same shape as L0/L1). **Skip this step
+   in the no-viable-band-aid case** (§1 exception): if every candidate fix is
+   validated net-negative or infeasible and no strictly-safe guard exists, the
+   issue alone is the deliverable — there is no PR to open.
 3. On merge: **issue stays open** (`design-debt` label). It's the backlog
-   item the human reviews. Only the PR closes.
+   item the human reviews. Only the PR closes. (No-band-aid issues simply stay
+   open with no associated PR until the design decision is made.)
 4. **Consolidation:** when a refactor promotes band-aids to permanent
    design, it deletes the marked regions + footnotes and the refactor
    PR/openspec cites `supersedes auto-fix N, M, …`; the design-debt


### PR DESCRIPTION
## What
Adds a missing disposition to the auto-fix methodology spec: **what to do when no
viable band-aid exists.**

- **§1** — new "Exception — no viable band-aid (diagnosis-only)": when every
  candidate fix is *validated net-negative* (regresses other tasks) or *infeasible*,
  don't ship a harmful patch to satisfy "ship something" — the `design-debt` issue is
  the sole deliverable, and it must carry (a) the regression/infeasibility evidence
  and (b) whether a narrower **fail-loud-not-silent** guard was shippable instead
  (and if so, ship that). Fail-loud is almost always safe + available, so true
  diagnosis-only should be rare.
- **§5** — makes the no-band-aid path explicit (skip the PR step), reconciling the
  section title ("PR-only by default; issue only for design-debt") with its body
  (which otherwise mandates a PR for every L2/L3).

## Why
Hit directly in the SWE-bench non-root investigation (#446): there is **no clean
in-place non-root fix** for root-owned package subdirs (relocate regresses editable
installs; reparent is impossible without root). The old spec would have had me ship
the regressing relocate band-aid; instead the right outcome was the design-debt
issue (#446) plus the strictly-safe fail-loud guard (#452). This codifies that
judgment so future loop runs don't ship a net-negative patch just to "ship something".

Additive living-spec edit (no behavior/code change) — no RFC folder per the
constitution's additive-change rule.
