### PR TITLE
refactor(episode): stream trajectory steps to disk (stop accumulating in RAM)

### DIFF
--- a/openspec/changes/stream-trajectory-steps/deltas.md
+++ b/openspec/changes/stream-trajectory-steps/deltas.md
@@ -1,0 +1,32 @@
+# Deltas
+
+## episode/spec.md
+
+### MODIFIED
+- **Main loop:** each step is streamed (`save_step` + `SummaryProcessor.on_step`, indexed by
+  a counter) and **not** appended to `Trajectory.steps`; the list stays empty throughout.
+  `summary_stats` comes from `SummaryProcessor.summary_stats(...)`; `final_reward` from the
+  last `EnvironmentOutput` (`reward_info`).
+- **`Episode.run() -> Trajectory`** returns a step-less trajectory (metadata + `summary_stats`
+  + `reward_info`). Step content is loaded lazily from disk via `storage.load_trajectory`.
+- **Invariant 1** strengthened: steps are persisted incrementally **and never accumulated in
+  memory** — the returned/worker-returned trajectory carries no steps.
+
+### REMOVED
+- `_compute_summary_stats(traj)` — subsumed by `SummaryProcessor.summary_stats(...)`.
+- Gotcha "`_compute_summary_stats` walks the full trajectory; for very long trajectories this
+  can be slow" — no longer applicable (stats are accumulated incrementally).
+
+## core/spec.md
+
+### MODIFIED
+- `Trajectory.steps` is a lazy, on-disk-backed view, **not** an in-memory accumulator. A
+  trajectory produced by the runner has `steps == []`; use `summary_stats` / `reward_info`
+  for aggregates and `FileStorage.load_trajectory(id)` to materialize step content.
+
+## storage/spec.md
+
+### MODIFIED
+- `SummaryProcessor` is the authoritative source of per-episode `summary_stats` (accumulated
+  incrementally as steps stream in); it now also tracks cached / cache-creation tokens and
+  the first step `error_type`, and exposes `summary_stats(...)`, `has_error`, `final_reward`.

--- a/openspec/changes/stream-trajectory-steps/proposal.md
+++ b/openspec/changes/stream-trajectory-steps/proposal.md
@@ -1,0 +1,47 @@
+# Stream trajectory steps to disk (stop accumulating them in RAM)
+
+## Why
+
+The episode loop builds the full `Trajectory.steps` list in memory, then at episode end
+re-writes it (`save_trajectory`) and re-summarizes it (`_compute_summary_stats`). Ray
+workers return the full trajectory to the driver, which holds **every** episode's steps at
+once. On image-heavy benchmarks (OSWorld, web) a single trajectory is 15–400 MB, so the
+driver balloons to ~20 GB over a run — and hundreds of GB of screenshots are serialized over
+the Ray object store for nothing, since the steps are already on disk.
+
+Nothing in the agent↔env loop reads the accumulated steps: `agent.step(obs)` gets only the
+current observation. The step list is a persistence/reporting byproduct, and both consumers
+already stream — `storage.save_step` writes each step incrementally and `SummaryProcessor`
+accumulates stats per step. Full step *content* is only needed by xray/investigator, which
+load it from disk on demand.
+
+## What
+
+- `SummaryProcessor` becomes the single source of `summary_stats` (adds cached /
+  cache-creation tokens and the first step `error_type`; exposes `summary_stats(...)`,
+  `has_error`, `final_reward`).
+- The episode loop streams each step (`save_step` + `SummaryProcessor.on_step` via a counter)
+  and **stops retaining `Trajectory.steps`**. The returned `Trajectory` carries metadata +
+  `summary_stats` + `reward_info`, with `steps == []`; step content loads lazily via
+  `storage.load_trajectory`.
+- `_compute_summary_stats` is removed (subsumed by `SummaryProcessor`); the redundant
+  end-of-run re-write and re-summary are gone.
+- `EpisodeRecord.from_trajectory`, `Experiment.print_stats`, and the Ray completion log read
+  `summary_stats`/`reward_info` instead of walking `steps`.
+
+Net: driver/worker RAM is flat regardless of step size, and the pointless Ray serialization
+of screenshots is eliminated.
+
+## Breaking change
+
+`Episode.run()` / `run_with_ray` / `run_sequentially` now return **step-less** trajectories.
+Callers needing step content must `FileStorage(output_dir).load_trajectory(id)`. No in-repo
+consumer relied on the returned steps (xray already loads from disk); the eval-log
+`EpisodeRecord` is a summary record and no longer reads steps.
+
+## Alternatives considered
+
+- **Clear steps after `print_stats`** (band-aid): frees driver RAM but still serializes and
+  ships every screenshot over Ray. Rejected — treats the symptom, not the cause.
+- **Keep `_compute_summary_stats`, just clear before return:** keeps the redundant double
+  summary and the per-worker full materialization. Rejected.

--- a/openspec/specs/core/spec.md
+++ b/openspec/specs/core/spec.md
@@ -37,17 +37,22 @@ A step is either the environment's output (obs/reward/done/info) or the agent's 
 ```python
 class Trajectory(TypedBaseModel):
     id: str                                # usually f"{task_id}_ep{episode_id}"
-    steps: list[TrajectoryStep] = []
+    steps: list[TrajectoryStep] = []       # lazy/on-disk view; EMPTY on a runner-produced traj
     metadata: dict = {}                    # task_id, agent_name, info dump
     start_time: float | None = None
     end_time: float | None = None
     reward_info: dict = {}                 # final reward + info dict
-    summary_stats: dict | None = None      # computed by _compute_summary_stats
+    summary_stats: dict | None = None      # streamed by SummaryProcessor (the aggregate source)
 
-    def last_env_step(self) -> EnvironmentOutput  # raises if none present
+    def last_env_step(self) -> EnvironmentOutput  # raises if none present (needs steps loaded)
     @property n_agent_steps: int
     @property n_env_steps: int
 ```
+
+A `Trajectory` returned by `Episode.run()` / the runners carries metadata + `summary_stats`
++ `reward_info` but **no steps** (they stream to disk during the run). Use `summary_stats` /
+`reward_info` for aggregates; call `FileStorage.load_trajectory(id)` to materialize step
+content (xray/investigator do this on demand).
 
 ### `ActionSpace`
 ```python

--- a/openspec/specs/episode/spec.md
+++ b/openspec/specs/episode/spec.md
@@ -46,16 +46,20 @@ class Episode:
     # If benchmark provided, forwards runtime_context and container_backend.
 
     def run(self) -> Trajectory
-    # Main loop. Creates the task via task_config.make(...), runs reset → step*, persists
-    # every step incrementally, closes the task in finally.
+    # Main loop. Creates the task via task_config.make(...), runs reset → step*, streams
+    # every step to disk (never retained in memory), closes the task in finally. The
+    # returned Trajectory carries metadata + summary_stats + reward_info with steps == [];
+    # load step content lazily via storage.load_trajectory(id).
 
     allow_overwrite: bool = False   # when True, archives existing trajectory before saving
 ```
 
-### `_compute_summary_stats(traj) -> dict` (module-level)
-Computed at end-of-episode and stored in `Trajectory.summary_stats`. Includes
+### `summary_stats`
+`Trajectory.summary_stats` is accumulated incrementally by `SummaryProcessor`
+(`cube_harness.summary`) as steps stream in, then written at end-of-episode. Includes
 `n_env_steps`, `n_agent_steps`, `total_actions`, `total_llm_calls`, token counts,
-`cost`, `duration`, `final_reward`.
+`cost`, `duration`, `final_reward`, `error_type`. It is the only per-episode aggregate the
+runner needs — no end-of-run walk over the steps.
 
 ## Main loop semantics
 
@@ -72,19 +76,22 @@ Computed at end-of-episode and stored in `Trajectory.summary_stats`. Includes
      not abort the run on transient I/O errors).
    - `agent.step(obs)` → `AgentOutput`
      - On exception: save the failed agent step, re-raise (trajectory is preserved)
-   - Append agent step to trajectory + save incrementally
+   - Stream the agent step to disk (`save_step` + `SummaryProcessor.on_step`); not retained
    - If empty actions and no error → log and break
    - `step_fn(agent_output.actions)` → `EnvironmentOutput`
      - On exception: save failed env step (with prior obs), re-raise
-   - Append env step + save
+   - Stream the env step to disk; not retained in memory
 7. `finally`: call `task.close()` and `tracer.shutdown()`
-8. Compute `summary_stats`, persist final trajectory, return
+8. Take `summary_stats` from `SummaryProcessor`, persist final metadata, return the
+   step-less trajectory
 
 Final episode status is `OK` if `final_reward > 0`, else `ERROR` (sets OTel span status).
 
 ## Invariants
 
-1. Every step is persisted incrementally — no in-memory-only state that can be lost.
+1. Every step is persisted incrementally **and never accumulated in memory** — the returned
+   Trajectory (including the one a Ray worker returns) carries no steps, only metadata +
+   summary_stats + reward_info. Load step content via `storage.load_trajectory(id)`.
 2. `task.close()` is always called (finally block), even on exceptions.
 3. Agent and env exceptions are caught, written as a step with `error` populated, then
    re-raised. Callers see the exception; the trajectory remains on disk.
@@ -125,7 +132,7 @@ loadable but no longer written.
   `run()` so long-lived resources are owned by the worker, not the scheduler.
 - Ray workers share `benchmark._runtime_context` by reference — treat it as
   read-only after `setup()` returns (see cube-standard benchmark spec).
-- `_compute_summary_stats` walks the full trajectory; for very long trajectories
-  (thousands of steps) this can be slow. Currently acceptable; revisit if needed.
+- `summary_stats` is accumulated incrementally by `SummaryProcessor` as steps stream in, so
+  it stays O(1) per step regardless of trajectory length — no end-of-run walk.
 - Episode timeouts are enforced by `run_with_ray` at the scheduler level, not inside
   the episode. Sequential runs have no timeout.

--- a/scripts/smoke/streaming_trajectory.py
+++ b/scripts/smoke/streaming_trajectory.py
@@ -32,8 +32,8 @@ from cube.tool import Tool, ToolConfig, tool_action
 
 from cube_harness.agent import Agent, AgentConfig
 from cube_harness.core import AgentOutput
-from cube_harness.exp_runner import run_sequentially
-from cube_harness.experiment import Experiment
+from cube_harness.exp_runner import run_sequentially, run_with_ray
+from cube_harness.experiment import Experiment, ExpResult
 from cube_harness.storage import FileStorage
 
 NAME = "streaming_trajectory"
@@ -110,47 +110,66 @@ def _fail(msg: str) -> int:
     return 1
 
 
+def _check(label: str, exp: Experiment, result: ExpResult) -> int:
+    """Assert the streaming contract for one runner's output. Returns 0 on success."""
+    storage = FileStorage(exp.output_dir)
+    if len(result.trajectories) != N_TASKS:
+        return _fail(f"[{label}] expected {N_TASKS} trajectories, got {len(result.trajectories)}")
+
+    for traj_id, traj in result.trajectories.items():
+        # 1. Returned trajectory is step-less but summarised (nothing accumulated in RAM).
+        if traj.steps:
+            return _fail(f"[{label}] {traj_id}: returned trajectory still holds {len(traj.steps)} steps in RAM")
+        if not traj.summary_stats:
+            return _fail(f"[{label}] {traj_id}: summary_stats missing on returned trajectory")
+        if (traj.reward_info or {}).get("reward") != 1.0:
+            return _fail(f"[{label}] {traj_id}: reward_info missing/wrong: {traj.reward_info}")
+
+        # 2. Steps are fully persisted and reload from disk.
+        loaded = storage.load_trajectory(traj_id)
+        if len(loaded.steps) < 2:
+            return _fail(f"[{label}] {traj_id}: expected >=2 persisted steps, got {len(loaded.steps)}")
+        if loaded.summary_stats != traj.summary_stats:
+            return _fail(f"[{label}] {traj_id}: summary_stats changed across disk round-trip")
+
+    # 3. Stats + eval-log export work off summary_stats (would raise/return 0 if broken).
+    exp.print_stats(result)
+    eval_log = exp.export_eval_log()
+    if len(eval_log.episodes) != N_TASKS:
+        return _fail(f"[{label}] eval-log has {len(eval_log.episodes)} episodes, expected {N_TASKS}")
+    if not all(ep.num_turns >= 2 and ep.score == 1.0 for ep in eval_log.episodes):
+        return _fail(f"[{label}] eval-log records have wrong num_turns/score (not derived from summary_stats)")
+
+    print(f"  ✓ [{label}] {N_TASKS} step-less returns; steps + summary on disk; eval-log derived from summary")
+    return 0
+
+
+def _experiment(output_dir: Path) -> Experiment:
+    return Experiment(
+        name="stream_smoke",
+        output_dir=output_dir,
+        agent_config=_MockAgentConfig(),
+        benchmark_config=_SmokeBenchmarkConfig(),
+        max_steps=2,
+    )
+
+
 def main() -> int:
     tmp = tempfile.mkdtemp(prefix="streaming_traj_")
     try:
-        exp = Experiment(
-            name="stream_smoke",
-            output_dir=Path(tmp) / "exp",
-            agent_config=_MockAgentConfig(),
-            benchmark_config=_SmokeBenchmarkConfig(),
-            max_steps=2,
-        )
-        result = run_sequentially(exp)
-        storage = FileStorage(exp.output_dir)
+        # Sequential: in-process runner (driver == worker).
+        exp_seq = _experiment(Path(tmp) / "seq")
+        rc = _check("sequential", exp_seq, run_sequentially(exp_seq))
+        if rc:
+            return rc
 
-        if len(result.trajectories) != N_TASKS:
-            return _fail(f"expected {N_TASKS} trajectories, got {len(result.trajectories)}")
+        # Ray: the parallel runner — the path where the ~20 GB driver accumulation
+        # manifested (workers return trajectories to the driver via the object store).
+        exp_ray = _experiment(Path(tmp) / "ray")
+        rc = _check("ray", exp_ray, run_with_ray(exp_ray, n_cpus=2))
+        if rc:
+            return rc
 
-        for traj_id, traj in result.trajectories.items():
-            # 1. Returned trajectory is step-less but summarised.
-            if traj.steps:
-                return _fail(f"{traj_id}: returned trajectory still holds {len(traj.steps)} steps in RAM")
-            if not traj.summary_stats:
-                return _fail(f"{traj_id}: summary_stats missing on returned trajectory")
-            if (traj.reward_info or {}).get("reward") != 1.0:
-                return _fail(f"{traj_id}: reward_info missing/wrong: {traj.reward_info}")
-
-            # 2. Steps are fully persisted and reload from disk.
-            loaded = storage.load_trajectory(traj_id)
-            if len(loaded.steps) < 2:
-                return _fail(f"{traj_id}: expected >=2 persisted steps, got {len(loaded.steps)}")
-            if loaded.summary_stats != traj.summary_stats:
-                return _fail(f"{traj_id}: summary_stats changed across disk round-trip")
-
-        # 3. Stats + eval-log export work off summary_stats (would raise/return 0 if broken).
-        exp.print_stats(result)
-        eval_log = exp.export_eval_log()
-        if len(eval_log.episodes) != N_TASKS:
-            return _fail(f"eval-log has {len(eval_log.episodes)} episodes, expected {N_TASKS}")
-        if not all(ep.num_turns >= 2 and ep.score == 1.0 for ep in eval_log.episodes):
-            return _fail("eval-log records have wrong num_turns/score (not derived from summary_stats)")
-
-        print(f"  ✓ {N_TASKS} trajectories returned step-less; steps + summary on disk; eval-log derived from summary")
         print(f"SMOKE OK: {NAME}")
         return 0
     finally:

--- a/scripts/smoke/streaming_trajectory.py
+++ b/scripts/smoke/streaming_trajectory.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SMOKE: the runner streams steps to disk and returns step-less trajectories.
+
+Runs a small deterministic mock-cube experiment through the real sequential runner and
+verifies the streaming contract end-to-end:
+
+  - every trajectory in ExpResult.trajectories has steps == [] (nothing accumulated in the
+    driver — this is the OSWorld ~20 GB fix);
+  - summary_stats and reward_info are populated on those step-less trajectories;
+  - the steps are fully persisted and reload from disk via FileStorage.load_trajectory;
+  - print_stats and the eval-log export work off summary_stats (no len(steps)/last_env_step).
+
+The Ray path returns whatever Episode.run() returns (the same step-less trajectory), so the
+sequential path exercises the same contract without Ray-worker pickling of __main__ classes.
+
+Run:
+    .venv/bin/python scripts/smoke/streaming_trajectory.py
+
+Prints SMOKE OK|FAIL: streaming_trajectory  (exit 0|1).
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
+from cube.core import Action, Observation
+from cube.task import Task, TaskConfig, TaskMetadata
+from cube.tool import Tool, ToolConfig, tool_action
+
+from cube_harness.agent import Agent, AgentConfig
+from cube_harness.core import AgentOutput
+from cube_harness.exp_runner import run_sequentially
+from cube_harness.experiment import Experiment
+from cube_harness.storage import FileStorage
+
+NAME = "streaming_trajectory"
+N_TASKS = 4
+
+
+class _NoopTool(Tool):
+    @tool_action
+    def click(self, element_id: str) -> str:
+        """Click an element.
+
+        Args:
+            element_id: The element to click.
+        """
+        return f"clicked {element_id}"
+
+
+class _NoopToolConfig(ToolConfig):
+    def make(self, container: object = None) -> _NoopTool:
+        _ = container
+        return _NoopTool()
+
+
+class _MockTask(Task):
+    def reset(self) -> tuple[Observation, dict]:
+        return Observation.from_text("smoke task goal"), {}
+
+    def evaluate(self, obs: Observation | None = None) -> tuple[float, dict]:
+        _ = obs
+        return 1.0, {"success": True}
+
+
+class _MockTaskConfig(TaskConfig):
+    def make(self, runtime_context: object = None) -> _MockTask:
+        _ = runtime_context
+        return _MockTask(metadata=TaskMetadata(id=self.task_id), tool_config=self.tool_config or _NoopToolConfig())
+
+
+class _MockBenchmark(Benchmark):
+    def _setup(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _SmokeBenchmarkConfig(BenchmarkConfig):
+    benchmark_metadata = BenchmarkMetadata(name="stream-smoke", version="0.1.0", description="streaming smoke")
+    task_metadata = {f"smoke_task_{i}": TaskMetadata(id=f"smoke_task_{i}") for i in range(N_TASKS)}
+    task_config_class = _MockTaskConfig
+    benchmark_class = _MockBenchmark
+
+
+class _MockAgentConfig(AgentConfig):
+    def make(self, action_set: object = None, **kwargs: object) -> "Agent":
+        _ = action_set, kwargs
+        return _MockAgent(config=self)
+
+
+class _MockAgent(Agent):
+    name = "StreamSmokeAgent"
+    description = "Submits final_step immediately — deterministic, no LLM."
+    input_content_types = ["text"]
+    output_content_types = ["action"]
+
+    def step(self, obs: Observation) -> AgentOutput:
+        _ = obs
+        return AgentOutput(actions=[Action(name="final_step", arguments={})])
+
+
+def _fail(msg: str) -> int:
+    print(f"  ✗ {msg}")
+    print(f"SMOKE FAIL: {NAME}")
+    return 1
+
+
+def main() -> int:
+    tmp = tempfile.mkdtemp(prefix="streaming_traj_")
+    try:
+        exp = Experiment(
+            name="stream_smoke",
+            output_dir=Path(tmp) / "exp",
+            agent_config=_MockAgentConfig(),
+            benchmark_config=_SmokeBenchmarkConfig(),
+            max_steps=2,
+        )
+        result = run_sequentially(exp)
+        storage = FileStorage(exp.output_dir)
+
+        if len(result.trajectories) != N_TASKS:
+            return _fail(f"expected {N_TASKS} trajectories, got {len(result.trajectories)}")
+
+        for traj_id, traj in result.trajectories.items():
+            # 1. Returned trajectory is step-less but summarised.
+            if traj.steps:
+                return _fail(f"{traj_id}: returned trajectory still holds {len(traj.steps)} steps in RAM")
+            if not traj.summary_stats:
+                return _fail(f"{traj_id}: summary_stats missing on returned trajectory")
+            if (traj.reward_info or {}).get("reward") != 1.0:
+                return _fail(f"{traj_id}: reward_info missing/wrong: {traj.reward_info}")
+
+            # 2. Steps are fully persisted and reload from disk.
+            loaded = storage.load_trajectory(traj_id)
+            if len(loaded.steps) < 2:
+                return _fail(f"{traj_id}: expected >=2 persisted steps, got {len(loaded.steps)}")
+            if loaded.summary_stats != traj.summary_stats:
+                return _fail(f"{traj_id}: summary_stats changed across disk round-trip")
+
+        # 3. Stats + eval-log export work off summary_stats (would raise/return 0 if broken).
+        exp.print_stats(result)
+        eval_log = exp.export_eval_log()
+        if len(eval_log.episodes) != N_TASKS:
+            return _fail(f"eval-log has {len(eval_log.episodes)} episodes, expected {N_TASKS}")
+        if not all(ep.num_turns >= 2 and ep.score == 1.0 for ep in eval_log.episodes):
+            return _fail("eval-log records have wrong num_turns/score (not derived from summary_stats)")
+
+        print(f"  ✓ {N_TASKS} trajectories returned step-less; steps + summary on disk; eval-log derived from summary")
+        print(f"SMOKE OK: {NAME}")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -169,6 +169,8 @@ class Episode:
         ep_status = self._open_status(trajectory_id)
 
         trajectory: Trajectory | None = None
+        summary_proc: SummaryProcessor | None = None
+        step_idx = 0
         try:
             with tracer.episode(task_id, experiment=self.config.exp_name) as episode_span:
                 start_time = ep_status.started_at
@@ -176,7 +178,6 @@ class Episode:
                 agent_name = self.config.agent_config.agent_name
                 trajectory = Trajectory(
                     id=trajectory_id,
-                    steps=[TrajectoryStep(output=env_output, start_time=start_time, end_time=time.time())],
                     metadata={
                         "task_id": task_id,
                         "agent_name": agent_name,
@@ -186,13 +187,25 @@ class Episode:
                     },
                     start_time=start_time,
                 )
+                # Steps stream to disk and are never retained in memory: the returned
+                # Trajectory carries metadata + summary_stats only (steps load lazily from
+                # disk via storage.load_trajectory). Keeps driver and worker RAM flat on
+                # image-heavy benchmarks; stats come from the streaming SummaryProcessor.
                 self.storage.save_trajectory(trajectory, allow_overwrite=self.allow_overwrite)
                 ep_dir = self.storage._episode_dir(trajectory.id)
                 (ep_dir / "episode_config.json").write_text(
                     self.config.model_dump_json(indent=2, serialize_as_any=True)
                 )
                 summary_proc = SummaryProcessor(ep_dir)
-                summary_proc.on_step(0, trajectory.steps[0])
+
+                def _record(step: TrajectoryStep) -> None:
+                    """Persist one step to disk and fold it into the running summary."""
+                    nonlocal step_idx
+                    self.storage.save_step(step, trajectory.id, step_idx)
+                    summary_proc.on_step(step_idx, step)
+                    step_idx += 1
+
+                _record(TrajectoryStep(output=env_output, start_time=start_time, end_time=time.time()))
                 logger.info(colored(f"Episode started — done={env_output.done} reward={env_output.reward}", "blue"))
                 turns = 0
                 while not env_output.done and turns < self.config.max_steps:
@@ -213,18 +226,12 @@ class Episode:
                         except Exception as e:
                             logger.exception(f"Error in agent.step() at turn {turns}: {e}")
                             agent_output = AgentOutput(error=StepError.from_exception(e))
-                            agent_step = TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time())
-                            self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
-                            summary_proc.on_step(len(trajectory.steps), agent_step)
-                            trajectory.steps.append(agent_step)
+                            _record(TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time()))
                             ep_status.had_step_errors = True
                             raise e
 
                         self.log_agent_output(turns, agent_output)
-                        agent_step = TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time())
-                        self.storage.save_step(agent_step, trajectory.id, len(trajectory.steps))
-                        summary_proc.on_step(len(trajectory.steps), agent_step)
-                        trajectory.steps.append(agent_step)
+                        _record(TrajectoryStep(output=agent_output, start_time=ts, end_time=time.time()))
                         if agent_output.error is not None:
                             ep_status.had_step_errors = True
 
@@ -238,10 +245,7 @@ class Episode:
                         except Exception as e:
                             logger.exception(f"Error in step() at turn {turns}: {e}")
                             env_output = EnvironmentOutput(obs=env_output.obs, error=StepError.from_exception(e))
-                            env_step = TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time())
-                            self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
-                            summary_proc.on_step(len(trajectory.steps), env_step)
-                            trajectory.steps.append(env_step)
+                            _record(TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time()))
                             ep_status.had_step_errors = True
                             raise e
 
@@ -250,10 +254,7 @@ class Episode:
                                 f"Turn {turns} Env output: done={env_output.done} reward={env_output.reward}", "blue"
                             )
                         )
-                        env_step = TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time())
-                        self.storage.save_step(env_step, trajectory.id, len(trajectory.steps))
-                        summary_proc.on_step(len(trajectory.steps), env_step)
-                        trajectory.steps.append(env_step)
+                        _record(TrajectoryStep(output=env_output, start_time=env_ts, end_time=time.time()))
                         if env_output.error is not None:
                             ep_status.had_step_errors = True
                         span.set_attribute("done", env_output.done)
@@ -262,8 +263,8 @@ class Episode:
                 # Loop exited without `done=True` — either max_steps fired or the agent
                 # gave up. cube's task.step only calls evaluate() when done or
                 # validate_per_step, so we'd otherwise return reward=0.0. Force one
-                # final evaluation and save it as a synthetic env step so the
-                # trajectory's last_env_step carries the real reward.
+                # final evaluation and record it as a synthetic env step so the recorded
+                # reward (reward_info / summary_stats) is real.
                 max_steps_reached = turns >= self.config.max_steps and not env_output.done
                 if not env_output.done:
                     try:
@@ -276,15 +277,14 @@ class Episode:
                             info={**env_output.info, **forced_info},
                             error=env_output.error,
                         )
-                        forced_step = TrajectoryStep(output=env_output, start_time=eval_ts, end_time=time.time())
-                        self.storage.save_step(forced_step, trajectory.id, len(trajectory.steps))
-                        summary_proc.on_step(len(trajectory.steps), forced_step)
-                        trajectory.steps.append(forced_step)
+                        _record(TrajectoryStep(output=env_output, start_time=eval_ts, end_time=time.time()))
                     except Exception:
                         logger.exception("Final evaluate() raised; trajectory keeps last step's reward")
                 trajectory.end_time = time.time()
                 trajectory.reward_info = {"reward": env_output.reward, "done": env_output.done, **env_output.info}
-                trajectory.summary_stats = _compute_summary_stats(trajectory)
+                trajectory.summary_stats = summary_proc.summary_stats(
+                    duration=trajectory.end_time - start_time, final_reward=env_output.reward
+                )
                 self.storage.save_trajectory(trajectory)
                 summary_proc.on_episode_complete(trajectory, self.storage)
                 try:
@@ -297,9 +297,8 @@ class Episode:
                 except Exception:
                     logger.warning("Failed to write episode record", exc_info=True)
                 logger.info(colored(f"Episode completed in {turns} turns, reward: {env_output.reward}", "blue"))
-                final_reward = trajectory.last_env_step().reward
-                ep_status.reward = final_reward
-                status = StatusCode.OK if final_reward > 0 else StatusCode.ERROR
+                ep_status.reward = env_output.reward
+                status = StatusCode.OK if env_output.reward > 0 else StatusCode.ERROR
                 episode_span.set_status(status)
             ep_status.status = "MAX_STEPS_REACHED" if max_steps_reached else "COMPLETED"
         except Exception as e:
@@ -317,9 +316,13 @@ class Episode:
             # step/token/cost stats without loading any steps — which is what makes the
             # background bulk-loader unnecessary. Best-effort: never mask the real error,
             # and save_trajectory is a safe re-save (the id is already in _saved_ids).
-            if trajectory is not None and not trajectory.summary_stats:
+            if trajectory is not None and summary_proc is not None and not trajectory.summary_stats:
                 try:
-                    trajectory.summary_stats = _compute_summary_stats(trajectory)
+                    end = trajectory.end_time or time.time()
+                    trajectory.summary_stats = summary_proc.summary_stats(
+                        duration=end - (trajectory.start_time or end),
+                        final_reward=summary_proc.final_reward,
+                    )
                     self.storage.save_trajectory(trajectory)
                 except Exception:
                     logger.exception("Failed to persist summary_stats on terminal path")
@@ -344,57 +347,3 @@ class Episode:
                     logger.info(colored(f"Turn {turns} LLM Thinking Block: {block}", "cyan"))
         actions_summary = [a.name for a in agent_output.actions] if agent_output.actions else []
         logger.info(colored(f"Turn {turns} Agent output: actions={actions_summary}", "magenta"))
-
-
-def _compute_summary_stats(traj: Trajectory) -> dict:
-    n_env_steps = 0
-    n_agent_steps = 0
-    total_actions = 0
-    total_llm_calls = 0
-    prompt_tokens = 0
-    completion_tokens = 0
-    cached_tokens = 0
-    cache_creation_tokens = 0
-    cost = 0.0
-
-    for step in traj.steps:
-        if isinstance(step.output, EnvironmentOutput):
-            n_env_steps += 1
-        elif isinstance(step.output, AgentOutput):
-            n_agent_steps += 1
-            total_actions += len(step.output.actions)
-            total_llm_calls += len(step.output.llm_calls)
-            for llm_call in step.output.llm_calls:
-                if llm_call.usage:
-                    prompt_tokens += llm_call.usage.prompt_tokens
-                    completion_tokens += llm_call.usage.completion_tokens
-                    cached_tokens += llm_call.usage.cached_tokens
-                    cache_creation_tokens += llm_call.usage.cache_creation_tokens
-                    cost += llm_call.usage.cost
-
-    duration = None
-    if traj.start_time is not None and traj.end_time is not None:
-        duration = traj.end_time - traj.start_time
-
-    final_reward = 0.0
-    if traj.reward_info:
-        final_reward = traj.reward_info.get("reward", 0.0)
-    else:
-        for step in reversed(traj.steps):
-            if isinstance(step.output, EnvironmentOutput):
-                final_reward = step.output.reward
-                break
-
-    return {
-        "n_env_steps": n_env_steps,
-        "n_agent_steps": n_agent_steps,
-        "total_actions": total_actions,
-        "total_llm_calls": total_llm_calls,
-        "duration": duration,
-        "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
-        "cached_tokens": cached_tokens,
-        "cache_creation_tokens": cache_creation_tokens,
-        "cost": cost,
-        "final_reward": final_reward,
-    }

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -563,9 +563,10 @@ class EpisodeRecord(TypedBaseModel):
         action_schemas: list[dict] = trajectory.metadata.get("action_schemas", [])
         tool_names = _extract_tool_names(action_schemas)
 
-        last_env = trajectory.last_env_step()
-        score = last_env.reward
         stats = trajectory.summary_stats or {}
+        # Steps are streamed to disk and not retained in memory after a run, so derive
+        # everything from the summary_stats / reward_info the episode loop populated.
+        score = (trajectory.reward_info or {}).get("reward", stats.get("final_reward", 0.0))
 
         wall_time_s: float | None = None
         if trajectory.start_time is not None and trajectory.end_time is not None:
@@ -593,10 +594,10 @@ class EpisodeRecord(TypedBaseModel):
             tool_names=tool_names,
             is_correct=score > 0,
             score=score,
-            error=_extract_error_type(trajectory),
-            num_turns=len(trajectory.steps),
-            n_agent_steps=stats.get("n_agent_steps", trajectory.n_agent_steps),
-            n_env_steps=stats.get("n_env_steps", trajectory.n_env_steps),
+            error=stats.get("error_type"),
+            num_turns=stats.get("n_env_steps", 0) + stats.get("n_agent_steps", 0),
+            n_agent_steps=stats.get("n_agent_steps", 0),
+            n_env_steps=stats.get("n_env_steps", 0),
             wall_time_s=wall_time_s,
             usage=UsageSummary.from_summary_stats(stats),
             trajectory_id=trajectory.id,

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -504,12 +504,15 @@ def _poll_ray(
             traj_id = ref_to_traj_id[task_ref]
             try:
                 traj: Trajectory = ray.get(task_ref, timeout=step_timeout_s + cancel_grace_s)
+                # traj carries summary_stats but no steps (streamed to disk on the worker).
+                _stats = traj.summary_stats or {}
+                _n_agent, _n_env = _stats.get("n_agent_steps", 0), _stats.get("n_env_steps", 0)
                 logger.info(
                     "Completed trajectory %s with %d steps (%d agent steps, %d environment steps)",
                     traj_id,
-                    len(traj.steps),
-                    traj.n_agent_steps,
-                    traj.n_env_steps,
+                    _n_agent + _n_env,
+                    _n_agent,
+                    _n_env,
                 )
                 results.trajectories[traj_id] = traj
             except Exception as e:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -245,13 +245,16 @@ class Experiment(TypedBaseModel):
             logger.info("No trajectories to compute stats")
             return
 
-        total_steps = sum(len(trajectory.steps) for trajectory in results.trajectories.values())
+        # Trajectories returned by the runner carry summary_stats + reward_info but no
+        # steps (streamed to disk), so read counts/reward from those, not len(steps).
+        def _step_count(stats: dict | None) -> int:
+            stats = stats or {}
+            return stats.get("n_env_steps", 0) + stats.get("n_agent_steps", 0)
+
+        total_steps = sum(_step_count(t.summary_stats) for t in results.trajectories.values())
         avg_steps = total_steps / len(results.trajectories)
 
-        rewards = []
-        for traj in results.trajectories.values():
-            rewards.append(traj.last_env_step().reward)
-
+        rewards = [(t.reward_info or {}).get("reward", 0.0) for t in results.trajectories.values()]
         accuracy = sum(rewards) / len(rewards) if rewards else 0.0
 
         logger.info(f"Experiment '{self.name}' stats:")

--- a/src/cube_harness/summary.py
+++ b/src/cube_harness/summary.py
@@ -61,9 +61,12 @@ class SummaryProcessor:
         self._total_llm_calls = 0
         self._prompt_tokens = 0
         self._completion_tokens = 0
+        self._cached_tokens = 0
+        self._cache_creation_tokens = 0
         self._cost_usd = 0.0
         self._reward = 0.0
         self._done = False
+        self._error_type: str | None = None
 
     def _build_entry(self, turn: int, status: EpisodeStatus) -> StepSummary:
         return StepSummary(
@@ -87,6 +90,12 @@ class SummaryProcessor:
             f.write(entry.model_dump_json() + "\n")
 
     def on_step(self, step_num: int, step: TrajectoryStep) -> None:
+        # Capture the first step-level error so EpisodeRecord can report it without
+        # re-walking the (now un-retained) step list.
+        err = getattr(step.output, "error", None)
+        if err is not None and self._error_type is None:
+            self._error_type = err.error_type
+
         if isinstance(step.output, AgentOutput):
             self._n_agent_steps += 1
             self._total_actions += len(step.output.actions)
@@ -95,6 +104,8 @@ class SummaryProcessor:
                 if llm_call.usage:
                     self._prompt_tokens += llm_call.usage.prompt_tokens
                     self._completion_tokens += llm_call.usage.completion_tokens
+                    self._cached_tokens += llm_call.usage.cached_tokens
+                    self._cache_creation_tokens += llm_call.usage.cache_creation_tokens
                     self._cost_usd += llm_call.usage.cost
         elif isinstance(step.output, EnvironmentOutput):
             self._n_env_steps += 1
@@ -103,8 +114,34 @@ class SummaryProcessor:
 
         self._append(self._build_entry(step_num, EpisodeStatus.RUNNING))
 
+    @property
+    def has_error(self) -> bool:
+        return self._error_type is not None
+
+    @property
+    def final_reward(self) -> float:
+        """Reward of the most recent environment step (the trajectory's final reward)."""
+        return self._reward
+
+    def summary_stats(self, *, duration: float | None, final_reward: float) -> dict:
+        """Final per-episode stats, accumulated incrementally — the single source of
+        truth (replaces the old end-of-run walk over ``trajectory.steps``)."""
+        return {
+            "n_env_steps": self._n_env_steps,
+            "n_agent_steps": self._n_agent_steps,
+            "total_actions": self._total_actions,
+            "total_llm_calls": self._total_llm_calls,
+            "duration": duration,
+            "prompt_tokens": self._prompt_tokens,
+            "completion_tokens": self._completion_tokens,
+            "cached_tokens": self._cached_tokens,
+            "cache_creation_tokens": self._cache_creation_tokens,
+            "cost": self._cost_usd,
+            "final_reward": final_reward,
+            "error_type": self._error_type,
+        }
+
     def on_episode_complete(self, trajectory: Trajectory, storage: "FileStorage") -> None:
-        has_error = any(isinstance(s.output, AgentOutput) and s.output.error is not None for s in trajectory.steps)
-        status = EpisodeStatus.FAILED if has_error else EpisodeStatus.DONE
+        status = EpisodeStatus.FAILED if self.has_error else EpisodeStatus.DONE
         self._append(self._build_entry(-1, status))
         storage.update_experiment_summary(trajectory)

--- a/tests/test_cube_episode.py
+++ b/tests/test_cube_episode.py
@@ -78,23 +78,51 @@ class TestCubeEpisode:
             trajectory = episode.run()
 
         assert trajectory.metadata["task_id"] == mock_cube_task_config.task_id
-        assert len(trajectory.steps) == 3
+        # Steps stream to disk; load the persisted trajectory to inspect step structure.
+        loaded = episode.storage.load_trajectory(trajectory.id)
+        assert len(loaded.steps) == 3
 
-        initial_env_step = trajectory.steps[0].output
+        initial_env_step = loaded.steps[0].output
         assert isinstance(initial_env_step, EnvironmentOutput)
         assert initial_env_step.done is False
 
-        agent_step = trajectory.steps[1].output
+        agent_step = loaded.steps[1].output
         assert isinstance(agent_step, AgentOutput)
         assert agent_step.actions[0].name == "final_step"
 
-        final_env_step = trajectory.last_env_step()
+        final_env_step = loaded.last_env_step()
         assert final_env_step.done is True
         assert final_env_step.reward == 1.0
 
         assert "profiling" in trajectory.reward_info
         trajectory.reward_info.pop("profiling")  # ignore profiling info for this test
         assert trajectory.reward_info == {"reward": 1.0, "done": True, "success": True}
+
+    def test_run_streams_steps_to_disk_and_returns_step_less(self, tmp_dir, mock_agent_config, mock_cube_task_config):
+        """Contract: the loop streams steps to disk; the returned Trajectory carries
+        metadata + summary_stats + reward_info but NO steps (loaded lazily from disk).
+        This is what keeps driver/worker RAM flat on image-heavy benchmarks."""
+        episode = Episode(
+            id=0,
+            output_dir=tmp_dir,
+            agent_config=mock_agent_config,
+            task_config=mock_cube_task_config,
+            exp_name="cube_test",
+            max_steps=5,
+            storage=None,
+            runtime_context=None,
+        )
+        trajectory = episode.run()
+
+        # Returned trajectory is step-less but fully summarised.
+        assert trajectory.steps == []
+        assert trajectory.summary_stats["n_env_steps"] >= 1
+        assert trajectory.reward_info["reward"] == 1.0
+
+        # Steps are fully persisted and reload from disk; summary survives the round-trip.
+        loaded = episode.storage.load_trajectory(trajectory.id)
+        assert len(loaded.steps) == 3
+        assert loaded.summary_stats == trajectory.summary_stats
 
     def test_failed_episode_persists_summary_stats(self, tmp_dir, mock_cube_task_config):
         """A FAILED episode must persist summary_stats to its metadata stub, so the XRay

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -56,8 +56,9 @@ class TestEpisode:
 
         assert isinstance(trajectory, Trajectory)
         assert "task_id" in trajectory.metadata
-        # Should have initial env output + agent output + final env output
-        assert len(trajectory.steps) >= 2
+        # Steps stream to disk; the returned trajectory carries metadata + summary only.
+        loaded = mock_episode.storage.load_trajectory(trajectory.id)
+        assert len(loaded.steps) >= 2  # initial env output + agent output + final env output
 
     def test_episode_run_saves_trajectory(self, mock_episode, tmp_dir):
         """Test Episode run saves trajectory files."""
@@ -130,9 +131,8 @@ class TestEpisode:
 
         trajectory = episode.run()
 
-        # Should have stopped at max_steps
-        agent_steps = sum(1 for step in trajectory.steps if isinstance(step.output, AgentOutput))
-        assert agent_steps <= 3
+        # Should have stopped at max_steps (steps stream to disk; read the streamed count)
+        assert trajectory.summary_stats["n_agent_steps"] <= 3
 
     def test_episode_run_stops_on_done(self, tmp_dir, mock_agent_config, mock_cube_task_config):
         """Test Episode run stops when done=True."""
@@ -147,8 +147,7 @@ class TestEpisode:
         trajectory = episode.run()
 
         # Should stop before max_steps because agent returns final_step
-        last_env_step = trajectory.last_env_step()
-        assert last_env_step.done is True
+        assert trajectory.reward_info["done"] is True
 
     def test_storage_save_trajectory_creates_directory(self, mock_episode, tmp_dir):
         """Test save_trajectory creates episode directory."""

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from cube.core import Content, EnvironmentOutput, Observation, StepError
+from cube.core import Content, EnvironmentOutput, Observation
 
 from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
 from cube_harness.eval_log import (
@@ -20,7 +20,6 @@ from cube_harness.eval_log import (
     InvestigatorLLMConfig,
     UsageSummary,
     Verifier,
-    _extract_error_type,
     _extract_llm_model,
     _extract_tool_names,
     _to_github_url,
@@ -126,29 +125,20 @@ def test_extract_tool_names_skips_tools_without_name() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _extract_error_type
+# error_type (sourced from summary_stats, populated by the streaming SummaryProcessor)
 # ---------------------------------------------------------------------------
 
 
-def test_extract_error_type_clean_trajectory() -> None:
-    traj = _trajectory(reward=1.0)
-    assert _extract_error_type(traj) is None
+def test_episode_record_error_none_for_clean_trajectory() -> None:
+    record = EpisodeRecord.from_trajectory(_trajectory(reward=1.0), evaluation_id="abc123")
+    assert record.error is None
 
 
-def test_extract_error_type_from_agent_output() -> None:
+def test_episode_record_error_from_summary_stats() -> None:
     traj = _trajectory(reward=0.0)
-    err = StepError(error_type="ValueError", exception_str="bad value", stack_trace="")
-    traj.steps.insert(1, TrajectoryStep(output=AgentOutput(error=err), start_time=101.0, end_time=101.5))
-    assert _extract_error_type(traj) == "ValueError"
-
-
-def test_extract_error_type_returns_first_error() -> None:
-    traj = _trajectory(reward=0.0)
-    err1 = StepError(error_type="TimeoutError", exception_str="timeout", stack_trace="")
-    err2 = StepError(error_type="ValueError", exception_str="bad", stack_trace="")
-    traj.steps.insert(1, TrajectoryStep(output=AgentOutput(error=err1), start_time=101.0, end_time=101.5))
-    traj.steps.insert(2, TrajectoryStep(output=AgentOutput(error=err2), start_time=101.5, end_time=102.0))
-    assert _extract_error_type(traj) == "TimeoutError"
+    traj.summary_stats["error_type"] = "ValueError"
+    record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
+    assert record.error == "ValueError"
 
 
 # ---------------------------------------------------------------------------
@@ -358,7 +348,8 @@ def test_episode_record_wall_time() -> None:
 def test_episode_record_num_turns() -> None:
     traj = _trajectory(reward=1.0, n_agent_steps=3)
     record = EpisodeRecord.from_trajectory(traj, evaluation_id="abc123")
-    assert record.num_turns == len(traj.steps)
+    # num_turns derives from the streamed summary_stats (n_env + n_agent), not len(steps).
+    assert record.num_turns == traj.summary_stats["n_env_steps"] + traj.summary_stats["n_agent_steps"]
     assert record.n_agent_steps == 3
 
 

--- a/tests/test_retry_integration.py
+++ b/tests/test_retry_integration.py
@@ -449,9 +449,10 @@ def test_max_steps_terminates_with_forced_eval(tmp_dir: Path) -> None:
     assert final.reward == 1.0  # from the forced evaluate call (DebugCubeTask returns 1.0)
     assert _archive_count(tmp_dir, traj_id) == 0  # no retries
 
-    # The aggregated trajectory got a real reward, not 0.0.
+    # The aggregated trajectory got a real reward, not 0.0. Steps stream to disk, so the
+    # returned trajectory exposes the reward via reward_info, not last_env_step().
     assert traj_id in result.trajectories
-    assert result.trajectories[traj_id].last_env_step().reward == 1.0
+    assert result.trajectories[traj_id].reward_info["reward"] == 1.0
 
     # MAX_STEPS_REACHED is not retriable: a fresh resume returns nothing.
     exp.resume = True


### PR DESCRIPTION
## Summary

Fixes the trajectory-memory problem **at the root**: the episode loop no longer accumulates
`Trajectory.steps` in RAM. Steps stream to disk as they're produced, and `Episode.run()` /
`run_with_ray` / `run_sequentially` return **step-less** trajectories (metadata +
`summary_stats` + `reward_info`).

### Why

The loop built the full step list in memory, re-wrote it (`save_trajectory`) and re-summarised
it (`_compute_summary_stats`) at the end, and Ray workers shipped the whole trajectory back to
the driver — which held **every** episode's steps at once (~20 GB on OSWorld) and serialised
hundreds of GB of screenshots over the Ray object store for nothing (they're already on disk).

Nothing in the agent↔env loop reads the accumulated steps — `agent.step(obs)` gets only the
current observation. The list was a persistence/reporting byproduct, and both consumers already
stream (`storage.save_step`, `SummaryProcessor`). Full step *content* is only needed by
xray/investigator, which load it from disk on demand.

### Changes

- **`SummaryProcessor`** is the single source of `summary_stats` (adds cached / cache-creation
  tokens + first step `error_type`; exposes `summary_stats()`, `has_error`, `final_reward`).
- **Episode loop** streams each step (`save_step` + `on_step`, indexed by a counter) and stops
  retaining `Trajectory.steps`.
- **Removed** `_compute_summary_stats` (subsumed) → no redundant end-of-run re-write/re-summary.
- `EpisodeRecord.from_trajectory`, `print_stats`, and the Ray completion log read
  `summary_stats`/`reward_info` instead of walking steps.

Net: driver/worker RAM is flat regardless of step size, and the pointless Ray serialisation is
gone.

### Breaking change

Callers needing step content must `FileStorage(output_dir).load_trajectory(id)`. No in-repo
consumer relied on the returned steps (xray already loads from disk; `EpisodeRecord` is a
summary record). This is the **root-cause** version of #379's `exp_runner` step-clear — if this
lands, drop that hunk from #379 (its `max_steps` stats + xray eviction parts remain).

### Tests / verification

- Spec: `openspec/changes/stream-trajectory-steps/` (proposal + deltas); `episode`/`core` specs synced.
- Tests load steps from disk / assert on `summary_stats`; new contract test
  `test_run_streams_steps_to_disk_and_returns_step_less`; the failure path persists `summary_stats`.
- Smoke `scripts/smoke/streaming_trajectory.py`: real sequential run → asserts step-less returns +
  steps on disk + eval-log derived from summary. Green.
- Full fast suite: **939 passed, 3 skipped**; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
