### PR TITLE
fix(swebench-verified): require container:root for root-owned-subdir tasks (#446)

### DIFF
--- a/cubes/swebench-verified-cube/scripts/create_task_metadata.py
+++ b/cubes/swebench-verified-cube/scripts/create_task_metadata.py
@@ -34,7 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from cube.resource import ContainerConfig
 from datasets import load_dataset
 
-from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmarkConfig, _DATASET_NAME
+from swebench_verified_cube.benchmark import TASKS_REQUIRING_ROOT, SWEBenchVerifiedBenchmarkConfig, _DATASET_NAME
 from swebench_verified_cube.task import SWEBenchVerifiedTaskMetadata
 
 logger = logging.getLogger(__name__)
@@ -77,6 +77,10 @@ def _build_task_metadata(rows: list[dict[str, Any]]) -> dict[str, SWEBenchVerifi
                 cpu_cores=2.0,
                 ram_gb=4.0,
                 disk_gb=10.0,
+                # A few images ship a root-owned package subdir a non-root infra can't patch
+                # (silent score=0); declaring container:root makes such infras incompatible
+                # at make(). See TASKS_REQUIRING_ROOT / cube-harness#446.
+                requires={"container:root"} if iid in TASKS_REQUIRING_ROOT else set(),
             ),
             repo=row["repo"],
             base_commit=row["base_commit"],

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/benchmark.py
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/benchmark.py
@@ -157,3 +157,40 @@ class SWEBenchVerifiedBenchmarkConfig(BenchmarkConfig[SWEBenchVerifiedTaskMetada
                 tool_config=self.tool_config,
                 oracle_mode=self.oracle_mode,
             )
+
+
+# ---------------------------------------------------------------------------
+# Tasks that require a root container (cube-harness#446)
+# ---------------------------------------------------------------------------
+
+# SWE-bench images are built ``USER root``. Most tasks run fine on a non-root infra,
+# but a few ship a root-owned, non-writable package subdir (e.g. ``/testbed/requests/``)
+# even when ``/testbed`` itself is world-writable. A non-root runtime user (the EAI
+# toolkit pins uid 13011) cannot make those files writable by any non-root means
+# (can't chmod/chown — not owner; can't rename or rm the dir — needs write on the dir),
+# so ``git apply`` of the gold patch — or any agent edit — dies with "Permission denied"
+# and a *correct* fix silently scores 0. Declaring ``container:root`` makes a non-root
+# infra report these tasks incompatible at ``BenchmarkConfig.make()`` (raises
+# ``IncompatibleInfraError`` — no spend, no silent 0); root-capable infras
+# (daytona/local/aws/azure) run them normally. Relocating the testbed is NOT a fix —
+# it regresses editable-installed repos (the import resolves to the unpatched original);
+# see cube-harness#446 and the closed #443/#205.
+#
+# Identified by the gold-patch differential (toolkit-fail + daytona-root-pass). Runtime
+# detection of the same condition is additionally covered by the fail-loud probe in
+# ``SWEBenchVerifiedTask.reset()`` (#452), which protects untagged tasks and ``force`` runs.
+#
+# This is the single source of truth: ``scripts/create_task_metadata.py`` imports it and
+# stamps ``requires={"container:root"}`` into the ``container_config`` of these tasks in the
+# generated ``task_metadata.json`` (mirrors terminalbench2 #435). The capability gate reads
+# ``container_config.requirements()`` from that metadata at ``make()`` — no runtime patching.
+TASKS_REQUIRING_ROOT: frozenset[str] = frozenset(
+    {
+        "psf__requests-1142",
+        "psf__requests-1766",
+        "psf__requests-1921",
+        "psf__requests-2931",
+        "psf__requests-5414",
+        "psf__requests-6028",
+    }
+)

--- a/cubes/swebench-verified-cube/src/swebench_verified_cube/task_metadata.json
+++ b/cubes/swebench-verified-cube/src/swebench_verified_cube/task_metadata.json
@@ -5811,6 +5811,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
@@ -5851,6 +5854,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
@@ -5871,6 +5877,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
@@ -5911,6 +5920,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
@@ -5931,6 +5943,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",
@@ -5951,6 +5966,9 @@
       "gpu": false,
       "disk_gb": 10.0,
       "ports": null,
+      "requires": [
+        "container:root"
+      ],
       "_type": "cube.resource.ContainerConfig"
     },
     "repo": "psf/requests",

--- a/cubes/swebench-verified-cube/tests/test_benchmark.py
+++ b/cubes/swebench-verified-cube/tests/test_benchmark.py
@@ -5,10 +5,13 @@ serialization round-trip).
 
 from __future__ import annotations
 
+import pytest
+
 from cube.benchmark import BenchmarkConfig
+from cube.resource import IncompatibleInfraError, InfraConfig, ResourceConfig, ResourceHandle
 from cube.task import TaskExecutionInfo
 
-from swebench_verified_cube.benchmark import SWEBenchVerifiedBenchmarkConfig
+from swebench_verified_cube.benchmark import TASKS_REQUIRING_ROOT, SWEBenchVerifiedBenchmarkConfig
 from swebench_verified_cube.debug import _TASK_ACTIONS, get_debug_benchmark
 from swebench_verified_cube.task import (
     SWEBenchVerifiedExecutionInfo,
@@ -92,3 +95,59 @@ def test_execution_info_roundtrip():
     assert restored.problem_statement == "test issue"
     assert restored.fail_to_pass == ["test_a", "test_b"]
     assert restored.eval_timeout == 1800  # default preserved
+
+
+# --- container:root requirement (cube-harness#446) ---------------------------
+
+
+class _FakeInfra(InfraConfig):
+    """Minimal InfraConfig stub for capability-gate tests; declares a capability set."""
+
+    caps: set[str] = set()
+
+    def fingerprint(self) -> str:
+        return "fake"
+
+    def capabilities(self) -> set[str]:
+        return self.caps
+
+    def provision(self, resource: ResourceConfig) -> None: ...
+
+    def launch(self, resource: ResourceConfig) -> ResourceHandle:
+        raise NotImplementedError
+
+    def list_active(self, run_id: str | None = None) -> list[ResourceHandle]:
+        return []
+
+    def cleanup(self, run_id: str) -> None: ...
+
+    def cleanup_stale(self, max_age_seconds: int | None = None) -> list[str]:
+        return []
+
+
+def test_root_tasks_declare_container_root():
+    """The known root-only tasks carry the container:root requirement; ordinary tasks don't."""
+    cfg = SWEBenchVerifiedBenchmarkConfig()
+    assert len(TASKS_REQUIRING_ROOT) == 6
+    for task_id in TASKS_REQUIRING_ROOT:
+        cc = cfg.task_metadata[task_id].container_config
+        assert cc is not None and "container:root" in cc.requirements(), task_id
+    control = cfg.task_metadata["astropy__astropy-12907"].container_config
+    assert control is not None and "container:root" not in control.requirements()
+
+
+def test_nonroot_infra_refuses_root_task_but_serves_others():
+    """A non-root infra is gated off a root-only task, runs ordinary ones, and a root
+    infra serves both. ``on_incompatible='force'`` bypasses the gate (→ #452 net)."""
+    nonroot = _FakeInfra(caps={"docker", "network:egress"})
+    rooted = _FakeInfra(caps={"docker", "network:egress", "container:root"})
+
+    root_task = SWEBenchVerifiedBenchmarkConfig().subset_from_list(["psf__requests-1142"])
+    with pytest.raises(IncompatibleInfraError):
+        root_task._gate_infra_compatibility(nonroot)
+    root_task._gate_infra_compatibility(rooted)  # root infra serves it — no raise
+
+    ordinary = SWEBenchVerifiedBenchmarkConfig().subset_from_list(["astropy__astropy-12907"])
+    ordinary._gate_infra_compatibility(nonroot)  # ordinary task is fine non-root — no raise
+
+    _FakeInfra(caps={"docker"}, on_incompatible="force")  # force is a valid escape hatch


### PR DESCRIPTION
## What

Declares `container:root` on the **6 `psf/requests` tasks** whose SWE-bench image ships a root-owned, non-writable package subdir (`/testbed/requests/`). On a non-root infra (EAI toolkit, uid 13011) `git apply` of the gold patch — or any agent edit — dies with *Permission denied*, so a **correct fix silently scores 0**. Surfaced by the gold-patch oracle (toolkit-fail + Daytona-root-pass differential).

## Mechanism (mirrors terminalbench2 #435)

- `TASKS_REQUIRING_ROOT` in `benchmark.py` is the **single source of truth**.
- `scripts/create_task_metadata.py` imports it and stamps `requires={"container:root"}` into those tasks' `container_config` — so the requirement lives **in the generated `task_metadata.json`** (committed here) and **survives regeneration**. No runtime metadata patching.
- The existing capability gate (#191/#204) then makes a non-root infra report them incompatible at `BenchmarkConfig.make()`: **`make(toolkit)` raises `IncompatibleInfraError`** pre-flight (no spend, no silent 0). Root-capable infras (daytona/local/aws/azure) run them; a subset excluding the 6 still runs on toolkit; `on_incompatible="force"` bypasses the gate → then **#452**'s runtime fail-loud probe catches the same condition at `reset()`.

## Why not relocate

Relocating the testbed regresses editable-installed repos (patch lands in `/tmp`, `import` resolves to the unpatched original; matplotlib → `ImportPathMismatchError`). Already closed as #443 / cube-standard #205. See #446.

## Tests

`tests/test_benchmark.py`: the 6 carry `container:root` (loaded from the json; a control task does not); a fake non-root infra is gated off a root task, serves ordinary tasks, and a root infra serves both. 8 passed.

Resolves the **#446** design decision (option 1). cube-harness-only — gate + `container:root` token already in cube-standard dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
