### PR TITLE
fix(eval_log): coerce sample_id to str for integer task_ids

### DIFF
--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -559,7 +559,7 @@ class EpisodeRecord(TypedBaseModel):
         task_config: Any | None = None,
     ) -> "EpisodeRecord":
         """Assemble an EpisodeRecord from a completed trajectory."""
-        sample_id = trajectory.metadata.get("task_id", "")
+        sample_id = str(trajectory.metadata.get("task_id", ""))
         action_schemas: list[dict] = trajectory.metadata.get("action_schemas", [])
         tool_names = _extract_tool_names(action_schemas)
 


### PR DESCRIPTION
Some benchmarks (e.g. WebArena) use integer task IDs. EpisodeRecord.sample_id is typed as str, so coerce at the assignment site to avoid type mismatches downstream.

One-line fix in EpisodeRecord.from_trajectory.