### PR TITLE
fix(agents): handle malformed tool call JSON without crashing

### DIFF
--- a/src/cube_harness/agents/legacy_generic_agent.py
+++ b/src/cube_harness/agents/legacy_generic_agent.py
@@ -1224,7 +1224,7 @@ class GenericAgent(Agent):
                     ans_dict["thoughts"] = text_response.strip()
 
                 # Parse actions from tool calls
-                actions = parse_actions(llm_response.message)
+                actions, _ = parse_actions(llm_response.message)
                 if actions:
                     # Return first action (multiaction not supported in legacy agent)
                     ans_dict["actions"] = actions

--- a/src/cube_harness/agents/react.py
+++ b/src/cube_harness/agents/react.py
@@ -99,7 +99,8 @@ class ReactAgent(Agent):
         self.history.append(llm_output)
         self._actions_cnt += 1
         llm_call = LLMCall(llm_config=self.config.llm_config, prompt=prompt, output=llm_output, usage=usage)
-        return AgentOutput(actions=parse_actions(llm_output), llm_calls=[llm_call])
+        actions, decode_error = parse_actions(llm_output)
+        return AgentOutput(actions=actions, llm_calls=[llm_call], error=decode_error)
 
     def choose_steps_to_render(self, history: list[dict | Message]) -> list[dict | Message]:
         """Select which parts of history to include in the prompt based on length."""

--- a/src/cube_harness/utils.py
+++ b/src/cube_harness/utils.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import re
 
 from bs4 import BeautifulSoup
-from cube.core import Action
+from cube.core import Action, StepError
 from litellm import Message
+
+logger = logging.getLogger(__name__)
 
 
 def prune_html(html):
@@ -31,7 +34,7 @@ def prune_html(html):
     return html
 
 
-def parse_actions(llm_output: Message) -> list[Action]:
+def parse_actions(llm_output: Message) -> tuple[list[Action], StepError | None]:
     actions = []
     if hasattr(llm_output, "tool_calls") and llm_output.tool_calls:
         for tc in llm_output.tool_calls:
@@ -39,9 +42,10 @@ def parse_actions(llm_output: Message) -> list[Action]:
             if isinstance(arguments, str):
                 try:
                     arguments = json.loads(arguments)
-                except json.JSONDecodeError:
-                    raise ValueError(f"Invalid JSON arguments in tool call: {arguments}")
+                except json.JSONDecodeError as e:
+                    logger.warning("Malformed tool call arguments for %s: %s", tc.function.name, arguments[:200])
+                    return [], StepError.from_exception(e)
             if tc.function.name is None:
                 raise ValueError("Tool call must have a function name.")
             actions.append(Action(id=tc.id, name=tc.function.name, arguments=arguments))
-    return actions
+    return actions, None


### PR DESCRIPTION
parse_actions() now returns (actions, StepError | None) instead of raising ValueError on malformed JSON arguments. The error is logged as a warning and propagated through AgentOutput.error so the episode can continue or terminate gracefully.
