### PR TITLE
fix(webarena): reddit rate-limit relaxation + launch healthcheck diagnostics

### DIFF
--- a/cubes/webarena-verified/src/webarena_verified_cube/resources.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/resources.py
@@ -27,6 +27,13 @@ def _script(name: str) -> str:
     return (_SCRIPTS_DIR / name).read_text()
 
 
+# Reddit rate-limit relaxation, appended to every launch path that starts the
+# reddit container (reddit alone, or all sites together). Single source so the
+# two paths can't drift; shipped inline since launch scripts are passed to the
+# infra host as strings (no sibling files at runtime).
+_REDDIT_RELAX = "\n" + _script("reddit_relax_limits.sh")
+
+
 # ── shopping_admin ────────────────────────────────────────────────────────────
 # Magento admin portal.  184 tasks.
 WEBARENA_SHOPPING_ADMIN = DockerServiceConfig(
@@ -66,7 +73,7 @@ WEBARENA_REDDIT = DockerServiceConfig(
         "reddit_ctrl": 9998,  # env-ctrl (container port 8877)
     },
     endpoint_to_site={"reddit": "reddit"},
-    launch_script=_script("reddit_launch.sh"),
+    launch_script=_script("reddit_launch.sh") + _REDDIT_RELAX,
 )
 
 # ── gitlab ────────────────────────────────────────────────────────────────────
@@ -216,5 +223,5 @@ WEBARENA_ALL = DockerServiceConfig(
         "wikipedia": "wikipedia",
         "map": "map",
     },
-    launch_script=_script("all_sites_launch.sh"),
+    launch_script=_script("all_sites_launch.sh") + _REDDIT_RELAX,
 )

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/all_sites_launch.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/all_sites_launch.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 
 echo "[launch] Starting all 6 WebArena-Verified containers …"
 
+dump_service_debug() {
+    local name="$1"
+    local container="webarena_${name}"
+    echo "[launch][debug] $name container status:"
+    docker ps -a --filter "name=${container}" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+    echo "[launch][debug] $name recent container logs:"
+    docker logs --tail 200 "${container}" 2>&1 || true
+    if [ "$name" = "wikipedia" ]; then
+        echo "[launch][debug] wikipedia /data details:"
+        docker exec webarena_wikipedia sh -lc \
+            'ls -lah /data && stat /data/wikipedia_en_all_maxi_2022-05.zim || true' 2>&1 || true
+        echo "[launch][debug] wikipedia kiwix version:"
+        docker exec webarena_wikipedia sh -lc 'kiwix-serve --version || true' 2>&1 || true
+    fi
+}
+
 # ── shopping_admin (Magento admin) ────────────────────────────────────────────
 docker run -d --name webarena_shopping_admin \
     -p 7780:80 -p 7781:8877 \
@@ -55,6 +71,7 @@ wait_healthy() {
         sleep 2
     done
     echo "ERROR: $name did not become healthy after $((max_attempts * 2))s" >&2
+    dump_service_debug "$name"
     exit 1
 }
 
@@ -75,4 +92,7 @@ echo "[launch] All 6 sites healthy"
 
 # Magento sites need extra warmup for PHP caches
 sleep 30
+
+# Reddit rate-limit relaxation is appended here from resources.py (_REDDIT_RELAX),
+# shared with reddit_launch.sh — see scripts/reddit_relax_limits.sh.
 echo "[launch] Warmup complete — ready"

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/reddit_launch.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/reddit_launch.sh
@@ -17,3 +17,6 @@ if [ "$healthy" -eq 0 ]; then
     echo "ERROR: reddit did not become healthy after 120s" >&2
     exit 1
 fi
+
+# Reddit rate-limit relaxation is appended here from resources.py (_REDDIT_RELAX),
+# shared with all_sites_launch.sh — see scripts/reddit_relax_limits.sh.

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/reddit_relax_limits.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/reddit_relax_limits.sh
@@ -1,0 +1,50 @@
+# Relax Reddit (Postmill) rate limits so the agent doesn't get throttled mid-task.
+# Shared by reddit_launch.sh and all_sites_launch.sh (injected once from
+# resources.py — see _REDDIT_RELAX). All steps are best-effort: a missing file
+# or a failed exec must not fail the launch.
+# See https://github.com/gasse/webarena-setup/commit/b4426309
+
+docker exec webarena_reddit sh -lc '
+if [ -f /srv/forum/app/DataSource/SubmissionData.php ]; then
+  sed -i \
+    -e "s/1 hour/2 minutes/g" \
+    -e "s/5 minutes/2 minutes/g" \
+    -e "s/max=3/max=50/g" \
+    -e "s/max=15/max=50/g" \
+    /srv/forum/app/DataSource/SubmissionData.php
+else
+  echo "[launch][warn] Missing /srv/forum/app/DataSource/SubmissionData.php; skipping reddit rate-limit patch"
+fi
+' || true
+
+docker exec webarena_reddit sh -lc '
+if [ -f /srv/forum/app/DataSource/CommentData.php ]; then
+  sed -i \
+    -e "s/5 minutes/2 minutes/g" \
+    -e "s/max=10/max=50/g" \
+    /srv/forum/app/DataSource/CommentData.php
+else
+  echo "[launch][warn] Missing /srv/forum/app/DataSource/CommentData.php; skipping reddit rate-limit patch"
+fi
+' || true
+
+docker exec webarena_reddit sh -lc '
+if [ -f /srv/forum/app/DataSource/UserData.php ]; then
+  sed -i \
+    -e '"'"'s/max="3"/max="50"/g'"'"' \
+    -e "s/1 hour/2 minutes/g" \
+    /srv/forum/app/DataSource/UserData.php
+else
+  echo "[launch][warn] Missing /srv/forum/app/DataSource/UserData.php; skipping reddit rate-limit patch"
+fi
+' || true
+
+docker exec webarena_reddit sh -lc '
+if [ -f /srv/forum/bin/console ]; then
+  php /srv/forum/bin/console cache:clear
+else
+  echo "[launch][warn] Missing /srv/forum/bin/console; skipping cache:clear"
+fi
+' || true
+docker exec webarena_reddit php -r "opcache_reset();" 2>/dev/null || true
+echo "[launch] Reddit rate limits relaxed"

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/wikipedia_launch.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/wikipedia_launch.sh
@@ -3,6 +3,19 @@
 # Volumes are pre-populated by VolumeSpec during provision().
 set -euo pipefail
 
+dump_wikipedia_debug() {
+    echo "[wikipedia][debug] container status:"
+    docker ps -a --filter name=webarena_wikipedia --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+    echo "[wikipedia][debug] recent container logs:"
+    docker logs --tail 200 webarena_wikipedia 2>&1 || true
+    echo "[wikipedia][debug] /data listing + file details inside container:"
+    docker exec webarena_wikipedia sh -lc \
+        'ls -lah /data && stat /data/wikipedia_en_all_maxi_2022-05.zim || true' 2>&1 || true
+    echo "[wikipedia][debug] kiwix/environment-control versions:"
+    docker exec webarena_wikipedia sh -lc \
+        'kiwix-serve --version || true; python3 -m environment_control.cli --help >/dev/null && python3 -c "import environment_control; print(environment_control.__version__)" || true' 2>&1 || true
+}
+
 docker run -d \
     --name webarena_wikipedia \
     -p 8888:8080 \
@@ -17,5 +30,6 @@ for i in $(seq 1 60); do
 done
 if [ "$healthy" -eq 0 ]; then
     echo "ERROR: wikipedia did not become healthy after 120s" >&2
+    dump_wikipedia_debug
     exit 1
 fi


### PR DESCRIPTION
- **Reddit:** relax Postmill rate limits (SubmissionData / CommentData / UserData)
  + cache clear so the agent isn't throttled mid-task. Single source in
  `scripts/reddit_relax_limits.sh`, injected into both the reddit-only and
  all-sites launch paths from `resources.py` (`_REDDIT_RELAX`) so the two can't drift.
- **Diagnostics:** on healthcheck failure, dump container status, logs, and (for
  wikipedia) `/data` + kiwix/env-control versions, to speed up triage.

> **Note:** the kiwix-serve wikipedia migration originally bundled here was split
> into #507 (it needs a volume-population fix + a faithfulness check). This PR now
> contains only the reddit + diagnostics hardening.