### PR TITLE
fix(workarena): seed generator, task class loading, infeasible tool key

### DIFF
--- a/cubes/workarena/scripts/generate_task_metadata.py
+++ b/cubes/workarena/scripts/generate_task_metadata.py
@@ -25,6 +25,7 @@ import logging
 from pathlib import Path
 
 from browsergym.workarena import get_all_tasks_agents
+from browsergym.workarena.tasks.compositional import ALL_COMPOSITIONAL_TASKS_L2, ALL_COMPOSITIONAL_TASKS_L3
 
 import workarena_cube
 from workarena_cube.task import WorkArenaTaskMetadata
@@ -34,18 +35,35 @@ logger = logging.getLogger(__name__)
 assert workarena_cube.__file__ is not None
 _DEFAULT_OUTPUT = Path(workarena_cube.__file__).parent / "task_metadata.json"
 
+_N_HUMAN_CURRICULUM_SEEDS = 5
+
+
+def _human_curriculum_ids(level: str) -> set[str]:
+    """Return the union of human-curriculum task IDs across several meta_seeds.
+
+    get_all_tasks_agents(is_agent_curriculum=False) varies slightly by meta_seed,
+    so we union over a small range to get a stable superset.
+    """
+    ids: set[str] = set()
+    for seed in range(_N_HUMAN_CURRICULUM_SEEDS):
+        for task_class, _ in get_all_tasks_agents(filter=level, meta_seed=seed, n_seed_l1=1, is_agent_curriculum=False):
+            ids.add(task_class.get_task_id())
+    return ids
+
 
 def _build_task_metadata() -> dict[str, WorkArenaTaskMetadata]:
     """Enumerate all WorkArena task types and build typed metadata.
 
-    Calls get_all_tasks_agents for L1, L2 agent superset, and L3 agent superset,
-    then marks which tasks are in the human evaluation curriculum.
-    Uses n_seed_l1=1 and meta_seed=0 — seeds are irrelevant here; only the
-    task classes are needed.
+    L1: uses get_all_tasks_agents (fixed list, seed-independent).
+    L2/L3: enumerates from ALL_COMPOSITIONAL_TASKS_L2/L3 — the full canonical
+    class lists baked into browsergym-workarena. This is seed-independent, unlike
+    get_all_tasks_agents(is_agent_curriculum=True) which returns different subsets
+    for different meta_seeds. Human-curriculum membership is the union across
+    several meta_seeds for stability.
     """
     metadata: dict[str, WorkArenaTaskMetadata] = {}
 
-    # L1 — no curriculum concept
+    # L1 — fixed list, no curriculum concept
     for task_class, _ in get_all_tasks_agents(filter="l1", meta_seed=0, n_seed_l1=1):
         task_id = task_class.get_task_id()
         if task_id not in metadata:
@@ -56,13 +74,14 @@ def _build_task_metadata() -> dict[str, WorkArenaTaskMetadata]:
                 task_class_path=f"{task_class.__module__}.{task_class.__qualname__}",
             )
 
-    # L2 and L3 — agent curriculum is the superset; mark human curriculum tasks
-    for level in ("l2", "l3"):
-        human_ids: set[str] = {
-            task_class.get_task_id()
-            for task_class, _ in get_all_tasks_agents(filter=level, meta_seed=0, n_seed_l1=1, is_agent_curriculum=False)
-        }
-        for task_class, _ in get_all_tasks_agents(filter=level, meta_seed=0, n_seed_l1=1, is_agent_curriculum=True):
+    # L2 and L3 — enumerate from the full canonical lists (seed-independent)
+    all_classes: dict[str, list[type]] = {
+        "l2": list(ALL_COMPOSITIONAL_TASKS_L2),
+        "l3": list(ALL_COMPOSITIONAL_TASKS_L3),
+    }
+    for level, task_classes in all_classes.items():
+        human_ids = _human_curriculum_ids(level)
+        for task_class in task_classes:
             task_id = task_class.get_task_id()
             if task_id not in metadata:
                 metadata[task_id] = WorkArenaTaskMetadata(

--- a/cubes/workarena/src/workarena_cube/benchmark.py
+++ b/cubes/workarena/src/workarena_cube/benchmark.py
@@ -15,43 +15,40 @@ logger = logging.getLogger(__name__)
 
 
 class WorkArenaSeedGenerator(AbstractSeedGenerator):
-    """Generates seeds for WorkArena tasks by delegating to get_all_tasks_agents().
+    """Generates seeds for WorkArena tasks.
 
-    Covers all three levels (l1, l2, l3) so it works naturally with any subset
-    produced by named_subset() or subset_from_glob().
+    L1: uses get_all_tasks_agents to obtain n_seeds_l1 seeds per task type,
+    matching WorkArena's original evaluation protocol.
 
-    Seeds are derived from WorkArena's own RNG (seeded by meta_seed) to maintain
-    compatibility with the original benchmark's evaluation protocol.
-
-    Lazily loads on first call and caches {task_id: [seeds]} for the lifetime
-    of this generator.
+    L2/L3: assigns meta_seed to every task type so that all task types in
+    task_metadata.json run exactly once, independent of the curriculum subset
+    returned by get_all_tasks_agents (which varies with meta_seed).
     """
 
     meta_seed: int = 42
     n_seeds_l1: int = 10
-    is_agent_curriculum: bool = True
 
-    _cache: dict[str, list[int]] | None = PrivateAttr(default=None)
+    _l1_cache: dict[str, list[int]] | None = PrivateAttr(default=None)
 
-    def _ensure_loaded(self) -> None:
-        if self._cache is not None:
+    def _ensure_l1_loaded(self) -> None:
+        if self._l1_cache is not None:
             return
         cache: dict[str, list[int]] = {}
-        for level in ("l1", "l2", "l3"):
-            for task_class, seed in get_all_tasks_agents(
-                filter=level,
-                meta_seed=self.meta_seed,
-                n_seed_l1=self.n_seeds_l1,
-                is_agent_curriculum=self.is_agent_curriculum,
-            ):
-                task_id = task_class.get_task_id()
-                cache.setdefault(task_id, []).append(seed)
-        self._cache = cache
+        for task_class, seed in get_all_tasks_agents(
+            filter="l1",
+            meta_seed=self.meta_seed,
+            n_seed_l1=self.n_seeds_l1,
+        ):
+            task_id = task_class.get_task_id()
+            cache.setdefault(task_id, []).append(seed)
+        self._l1_cache = cache
 
     def __call__(self, task_metadata: TaskMetadata) -> list[int]:
-        self._ensure_loaded()
-        assert self._cache
-        return self._cache.get(task_metadata.id, [])
+        self._ensure_l1_loaded()
+        assert self._l1_cache is not None
+        if task_metadata.id in self._l1_cache:
+            return self._l1_cache[task_metadata.id]
+        return [self.meta_seed]
 
 
 class WorkArenaBenchmark(Benchmark["WorkArenaBenchmarkConfig"]):
@@ -102,14 +99,13 @@ class WorkArenaBenchmarkConfig(BenchmarkConfig[WorkArenaTaskMetadata]):
             "l2": ("level", "l2"),
             "l3": ("level", "l3"),
         },
-        num_tasks=333,
+        num_tasks=715,
     )
     task_config_class: ClassVar[type[TaskConfig]] = WorkArenaTaskConfig
     benchmark_class: ClassVar[type[Benchmark]] = WorkArenaBenchmark
 
     meta_seed: int = 42
     n_seeds_l1: int = 10
-    is_agent_curriculum: bool = True
 
     @model_validator(mode="after")
     def _init_seed_generator(self) -> Self:
@@ -118,6 +114,5 @@ class WorkArenaBenchmarkConfig(BenchmarkConfig[WorkArenaTaskMetadata]):
             self.seed_generator = WorkArenaSeedGenerator(
                 meta_seed=self.meta_seed,
                 n_seeds_l1=self.n_seeds_l1,
-                is_agent_curriculum=self.is_agent_curriculum,
             )
         return self

--- a/cubes/workarena/src/workarena_cube/task_metadata.json
+++ b/cubes/workarena/src/workarena_cube/task_metadata.json
@@ -5,11 +5,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.dashboard.MultiChartValueRetrievalTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.multi-chart-min-max-retrieval",
@@ -17,11 +16,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.dashboard.MultiChartMinMaxRetrievalTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.single-chart-value-retrieval",
@@ -29,11 +27,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.dashboard.SingleChartValueRetrievalTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.single-chart-min-max-retrieval",
@@ -41,11 +38,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.dashboard.SingleChartMinMaxRetrievalTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.create-change-request",
@@ -53,11 +49,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.form.CreateChangeRequestTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.create-incident",
@@ -65,11 +60,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.form.CreateIncidentTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.create-hardware-asset",
@@ -77,11 +71,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.form.CreateHardwareAssetTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.create-problem",
@@ -89,11 +82,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.form.CreateProblemTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.create-user",
@@ -101,11 +93,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.form.CreateUserTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.knowledge-base-search",
@@ -113,11 +104,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.knowledge.KnowledgeBaseSearchTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-asset-list",
@@ -125,11 +115,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterAssetListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-change-request-list",
@@ -137,11 +126,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterChangeRequestListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-hardware-list",
@@ -149,11 +137,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterHardwareListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-incident-list",
@@ -161,11 +148,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterIncidentListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-service-catalog-item-list",
@@ -173,11 +159,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterServiceCatalogItemListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-user-list",
@@ -185,11 +170,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.FilterUserListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-asset-list",
@@ -197,11 +181,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortAssetListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-change-request-list",
@@ -209,11 +192,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortChangeRequestListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-hardware-list",
@@ -221,11 +203,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortHardwareListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-incident-list",
@@ -233,11 +214,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortIncidentListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-service-catalog-item-list",
@@ -245,11 +225,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortServiceCatalogItemListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.sort-user-list",
@@ -257,11 +236,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.list.SortUserListTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.all-menu",
@@ -269,11 +247,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.navigation.AllMenuTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.impersonation",
@@ -281,11 +258,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.navigation.ImpersonationTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-developer-laptop",
@@ -293,11 +269,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderDeveloperLaptopTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-ipad-mini",
@@ -305,11 +280,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderIpadMiniTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-ipad-pro",
@@ -317,11 +291,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderIpadProTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-sales-laptop",
@@ -329,11 +302,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderSalesLaptopTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-standard-laptop",
@@ -341,11 +313,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderStandardLaptopTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-apple-watch",
@@ -353,11 +324,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderAppleWatchTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-apple-mac-book-pro15",
@@ -365,11 +335,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderAppleMacBookPro15Task",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-development-laptop-p-c",
@@ -377,11 +346,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderDevelopmentLaptopPCTask",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.order-loaner-laptop",
@@ -389,35 +357,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l1",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.service_catalog.OrderLoanerLaptopTask",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesSmallTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-small-l2",
@@ -425,59 +368,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesLargeTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-medium-l2",
@@ -485,11 +379,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-medium-l2",
@@ -497,11 +412,54 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesMediumTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.workload-balancing-small-l2",
@@ -509,23 +467,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.workload-balancing-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingLargeTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.workload-balancing-medium-l2",
@@ -533,71 +478,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.work-assignment-large-l2",
+    "id": "workarena.servicenow.workload-balancing-large-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.work-assignment-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentSmallTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.work-assignment-small-l2",
@@ -605,11 +500,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.work-assignment-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.work-assignment-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentSmallTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-fix-basic-uniform-risk-change-request-scheduling-l2",
@@ -617,47 +588,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixBasicUniformRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.three-changes-basic-uniform-risk-change-request-scheduling-l2",
+    "id": "workarena.servicenow.two-changes-fix-wide-basic-uniform-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicUniformRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.two-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.three-changes-priority-varied-risk-change-request-scheduling-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityVariedRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-basic-varied-risk-change-request-scheduling-l2",
@@ -665,11 +610,109 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesBasicVariedRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-basic-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideBasicUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.three-changes-fix-basic-varied-risk-change-request-scheduling-l2",
@@ -677,11 +720,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixBasicVariedRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-basic-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideBasicVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesPriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWidePriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-fix-priority-uniform-risk-change-request-scheduling-l2",
@@ -689,11 +764,230 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixPriorityUniformRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWidePriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWidePriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWidePriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-tight-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-schedule-tight-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideScheduleTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-tight-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-schedule-tight-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideScheduleTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-tight-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-tight-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-tight-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWidePriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixPriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-priority-uniform-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWidePriorityUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWidePriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-priority-varied-risk-change-request-scheduling-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.three-changes-fix-wide-priority-varied-risk-change-request-scheduling-l2",
@@ -701,155 +995,120 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWidePriorityVariedRiskChangeRequestSchedulingTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-development-laptop-p-c-l2",
+    "id": "workarena.servicenow.three-changes-tight-uniform-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDevelopmentLaptopPCTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-incident-l2",
+    "id": "workarena.servicenow.three-changes-wide-schedule-tight-uniform-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateIncidentTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-problem-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateProblemTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-hardware-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterHardwareListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideScheduleTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-hardware-list-l2",
+    "id": "workarena.servicenow.three-changes-fix-tight-uniform-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterHardwareListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch2-l2",
+    "id": "workarena.servicenow.three-changes-fix-wide-schedule-tight-uniform-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatch2TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideScheduleTightUniformRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.get-warranty-expiration-date-l2",
+    "id": "workarena.servicenow.three-changes-tight-priority-varied-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.GetWarrantyExpirationDateTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-requested-items-and-order-sales-laptop-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderSalesLaptopTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-watch-l2",
+    "id": "workarena.servicenow.three-changes-wide-tight-priority-varied-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleWatchTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-incident-list-l2",
+    "id": "workarena.servicenow.three-changes-fix-tight-priority-varied-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterIncidentListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-microsoft-surface-pro3-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestMicrosoftSurfacePro3TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-requested-items-and-order-developer-laptop-l2",
+    "id": "workarena.servicenow.three-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDeveloperLaptopTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-orderi-pad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-orderi-pad-pro-l2",
@@ -857,59 +1116,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadProTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-asset-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterAssetListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-asset-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterAssetListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-windows-surface-pro4-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-sales-laptop-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestWindowsSurfacePro4TaskL2",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-requested-items-and-order-loaner-laptop-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-standard-laptop-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderLoanerLaptopTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-macbook-pro15-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleMacbookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-loaner-laptop-l2",
@@ -917,59 +1182,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderLoanerLaptopTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-google-nexus7-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-incident-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGoogleNexus7TaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-pro-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadProTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-user-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterUserListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-galaxy-note20-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGalaxyNote20TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateIncidentTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-problem-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateProblemTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-user-list-l2",
@@ -977,71 +1248,274 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterUserListTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.amount-based-expense-management-medium-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-asset-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.basic-expense-management-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementLargeTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.amount-based-expense-management-large-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-hardware-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementLargeTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.basic-expense-management-medium-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-incident-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementMediumTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch2-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatch2TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-ipad3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIpad3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-iphone13pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIphone13proTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-iphone13-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIphone13TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-galaxy-note20-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGalaxyNote20TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-google-nexus7-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGoogleNexus7TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-microsoft-surface-pro3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestMicrosoftSurfacePro3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-pixel4a-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestPixel4aTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-windows-surface-pro4-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestWindowsSurfacePro4TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.get-warranty-expiration-date-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.GetWarrantyExpirationDateTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-apple-mac-book-pro15-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderAppleMacBookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-loaner-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderLoanerLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-expense-management-small-l2",
@@ -1049,71 +1523,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.date-based-expense-management-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.amount-based-expense-management-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.date-based-expense-management-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.date-based-expense-management-small-l2",
@@ -1121,47 +1534,131 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementSmallTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-small-l2",
+    "id": "workarena.servicenow.amount-based-expense-management-small-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsSmallTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-large-l2",
+    "id": "workarena.servicenow.easy-expense-management-small-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-medium-l2",
+    "id": "workarena.servicenow.basic-expense-management-medium-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.date-based-expense-management-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.amount-based-expense-management-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.easy-expense-management-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.basic-expense-management-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.date-based-expense-management-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.amount-based-expense-management-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.easy-expense-management-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-medium-l2",
@@ -1169,35 +1666,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-large-l2",
@@ -1205,23 +1677,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsSmallTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-small-l2",
@@ -1229,95 +1688,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-find-total-return-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndFindTotalReturnSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-large-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsLargeTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-medium-l2",
@@ -1325,23 +1699,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-large-l2",
+    "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-large-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsLargeTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-medium-l2",
@@ -1349,35 +1732,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-large-l2",
@@ -1385,23 +1743,241 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnLargeTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-medium-l2",
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-small-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsMediumTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-find-total-return-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndFindTotalReturnSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-small-l2",
@@ -1409,11 +1985,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-small-l2",
@@ -1421,35 +2051,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-medium-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-small-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsSmallTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-medium-l2",
@@ -1457,11 +2062,241 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-find-total-return-and-select-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-delete-wrong-investments-small-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndDeleteWrongInvestmentsSmallTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-medium-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsMediumTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-large-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsLargeTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-orderi-pad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderiPadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-orderi-pad-pro-l2",
@@ -1469,11 +2304,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderiPadProTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-apple-macbook-pro15-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderAppleMacbookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-loaner-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderLoanerLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-orderi-pad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderiPadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-orderi-pad-pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderiPadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-apple-macbook-pro15-l2",
@@ -1481,11 +2447,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderAppleMacbookPro15TaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-loaner-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderLoanerLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-orderi-pad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderiPadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-orderi-pad-pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderiPadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-apple-watch-l2",
@@ -1493,35 +2535,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderAppleWatchTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-incident-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-apple-macbook-pro15-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateIncidentTaskL2",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderAppleMacbookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-incident-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-development-laptop-p-c-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-loaner-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateIncidentTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderLoanerLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-create-incident-l2",
@@ -1529,35 +2579,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanCreateIncidentTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-problem-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-incident-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateProblemTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateIncidentTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-problem-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-incident-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateProblemTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateIncidentTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-create-problem-l2",
@@ -1565,11 +2612,109 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanCreateProblemTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-problem-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateProblemTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-problem-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateProblemTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-user-list-l2",
@@ -1577,11 +2722,76 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterUserListTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-user-list-l2",
@@ -1589,11 +2799,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterUserListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-asset-list-l2",
@@ -1601,11 +2832,120 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterAssetListTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-watch2-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleWatch2TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-ipad3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIpad3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-iphone13pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13proTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-iphone13-l2",
@@ -1613,11 +2953,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-galaxy-note20-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestGalaxyNote20TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-google-nexus7-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestGoogleNexus7TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-microsoft-surface-pro3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestMicrosoftSurfacePro3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-pixel4a-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestPixel4aTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-windows-surface-pro4-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestWindowsSurfacePro4TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-watch2-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleWatch2TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-ipad3-l2",
@@ -1625,11 +3041,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIpad3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-iphone13pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIpad3TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIphone13proTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-iphone13-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIphone13TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-galaxy-note20-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestGalaxyNote20TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-google-nexus7-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestGoogleNexus7TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-microsoft-surface-pro3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestMicrosoftSurfacePro3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-pixel4a-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestPixel4aTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-windows-surface-pro4-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestWindowsSurfacePro4TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-watch2-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleWatch2TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-ipad3-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIpad3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-iphone13pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIphone13proTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-iphone13-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIphone13TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-galaxy-note20-l2",
@@ -1637,239 +3184,54 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestGalaxyNote20TaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-create-incident-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-google-nexus7-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateIncidentTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestGoogleNexus7TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-order-ipad-pro-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-microsoft-surface-pro3-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadProTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-hardware-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterHardwareListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestMicrosoftSurfacePro3TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-sort-asset-list-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-pixel4a-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortAssetListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.off-board-user-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.OffBoardUserTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.on-board-user-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.OnBoardUserTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-hardware-asset-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateHardwareAssetTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-apple-mac-book-pro15-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleMacBookPro15TaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestPixel4aTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-filter-change-request-list-l2",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-windows-surface-pro4-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterChangeRequestListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-change-request-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortChangeRequestListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-developer-laptop-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDeveloperLaptopTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-service-catalog-item-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterServiceCatalogItemListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-incident-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortIncidentListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-change-request-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateChangeRequestTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-incident-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterIncidentListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-sales-laptop-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderSalesLaptopTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-problem-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateProblemTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-development-laptop-p-c-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDevelopmentLaptopPCTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-user-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortUserListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestWindowsSurfacePro4TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.navigate-and-create-user-l2",
@@ -1877,11 +3239,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateUserTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-incident-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateIncidentTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-change-request-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateChangeRequestTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-problem-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateUserTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateProblemTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-hardware-asset-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateHardwareAssetTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-developer-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDeveloperLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-ipad-pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-ipad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-apple-mac-book-pro15-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleMacBookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.navigate-and-order-loaner-laptop-l2",
@@ -1889,107 +3382,164 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderLoanerLaptopTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-with-reason-l2",
+    "id": "workarena.servicenow.navigate-and-filter-asset-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-change-request-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetWithReasonTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterChangeRequestListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-problem-l2",
+    "id": "workarena.servicenow.navigate-and-filter-hardware-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListWithReasonTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-l2",
+    "id": "workarena.servicenow.navigate-and-filter-service-catalog-item-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterServiceCatalogItemListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-with-reason-l2",
+    "id": "workarena.servicenow.navigate-and-sort-asset-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListWithReasonTaskL2",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-l2",
+    "id": "workarena.servicenow.navigate-and-sort-user-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-change-request-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortChangeRequestListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-service-catalog-item-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortServiceCatalogItemListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.off-board-user-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.OffBoardUserTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.on-board-user-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.OnBoardUserTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-user-with-reason-l2",
@@ -1997,59 +3547,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateUserWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-incident-with-reason-l2",
@@ -2057,83 +3558,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListWithReasonTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l2",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListTaskL2",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-with-reason-l2",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListWithReasonTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-problem-with-reason-l2",
@@ -2141,11 +3580,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-user-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateUserTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-incident-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l2",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemWithReasonTaskL2",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-problem-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-l2",
@@ -2153,11 +3646,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-standard-laptop-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderStandardLaptopWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-sales-laptop-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderSalesLaptopWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-developer-laptop-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDeveloperLaptopWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-mac-book-pro15-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleMacBookPro15WithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-order-development-laptop-p-c-with-reason-l2",
@@ -2165,11 +3734,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDevelopmentLaptopPCWithReasonTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-loaner-laptop-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderLoanerLaptopWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-standard-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderStandardLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-sales-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderSalesLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-order-developer-laptop-l2",
@@ -2177,11 +3778,263 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDeveloperLaptopTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-mac-book-pro15-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleMacBookPro15TaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-development-laptop-p-c-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDevelopmentLaptopPCTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-loaner-laptop-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderLoanerLaptopTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-hardware-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterHardwareListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-user-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortUserListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-change-request-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortChangeRequestListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-with-reason-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListWithReasonTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-with-reason-l2",
@@ -2189,35 +4042,76 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l2",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListWithReasonTaskL2",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-small-l3",
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
+    "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesSmallTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-small-l3",
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-user-list-l2",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
+    "level": "l2",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesSmallTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortUserListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-change-request-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortChangeRequestListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-l2",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l2",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListTaskL2",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-small-l3",
@@ -2225,59 +4119,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesLargeTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-medium-l3",
@@ -2285,11 +4130,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.basic-filter-problems-and-mark-duplicates-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicFilterProblemsAndMarkDuplicatesLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-medium-l3",
@@ -2297,11 +4163,54 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-filter-problems-and-mark-duplicates-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityFilterProblemsAndMarkDuplicatesMediumTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.high-priority-filter-problems-and-mark-duplicates-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.HighPriorityFilterProblemsAndMarkDuplicatesLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.workload-balancing-small-l3",
@@ -2309,23 +4218,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.workload-balancing-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingLargeTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.workload-balancing-medium-l3",
@@ -2333,71 +4229,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.work-assignment-large-l3",
+    "id": "workarena.servicenow.workload-balancing-large-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.work-assignment-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.priority-assignment-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentSmallTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkloadBalancingLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.work-assignment-small-l3",
@@ -2405,11 +4251,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.work-assignment-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.work-assignment-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.priority-assignment-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.WorkAssignmentSmallTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.PriorityAssignmentLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-fix-basic-uniform-risk-change-request-scheduling-l3",
@@ -2417,47 +4339,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixBasicUniformRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.three-changes-basic-uniform-risk-change-request-scheduling-l3",
+    "id": "workarena.servicenow.two-changes-fix-wide-basic-uniform-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicUniformRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.two-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.three-changes-priority-varied-risk-change-request-scheduling-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityVariedRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-basic-varied-risk-change-request-scheduling-l3",
@@ -2465,11 +4361,109 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesBasicVariedRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-basic-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideBasicUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.three-changes-fix-basic-varied-risk-change-request-scheduling-l3",
@@ -2477,11 +4471,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixBasicVariedRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-basic-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideBasicVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesPriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWidePriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.two-changes-fix-priority-uniform-risk-change-request-scheduling-l3",
@@ -2489,11 +4515,230 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixPriorityUniformRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWidePriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWidePriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWidePriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-tight-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-schedule-tight-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideScheduleTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-tight-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-schedule-tight-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideScheduleTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-tight-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-wide-tight-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesWideTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-tight-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.two-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.TwoChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWidePriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixPriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-wide-priority-uniform-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWidePriorityUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-wide-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWidePriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.three-changes-fix-priority-varied-risk-change-request-scheduling-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.three-changes-fix-wide-priority-varied-risk-change-request-scheduling-l3",
@@ -2501,155 +4746,120 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWidePriorityVariedRiskChangeRequestSchedulingTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-development-laptop-p-c-l3",
+    "id": "workarena.servicenow.three-changes-tight-uniform-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDevelopmentLaptopPCTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-incident-l3",
+    "id": "workarena.servicenow.three-changes-wide-schedule-tight-uniform-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateIncidentTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-problem-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateProblemTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-hardware-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterHardwareListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideScheduleTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-hardware-list-l3",
+    "id": "workarena.servicenow.three-changes-fix-tight-uniform-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterHardwareListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch2-l3",
+    "id": "workarena.servicenow.three-changes-fix-wide-schedule-tight-uniform-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatch2TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideScheduleTightUniformRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.get-warranty-expiration-date-l3",
+    "id": "workarena.servicenow.three-changes-tight-priority-varied-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.GetWarrantyExpirationDateTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-requested-items-and-order-sales-laptop-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderSalesLaptopTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-watch-l3",
+    "id": "workarena.servicenow.three-changes-wide-tight-priority-varied-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleWatchTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesWideTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-incident-list-l3",
+    "id": "workarena.servicenow.three-changes-fix-tight-priority-varied-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterIncidentListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-microsoft-surface-pro3-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestMicrosoftSurfacePro3TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-requested-items-and-order-developer-laptop-l3",
+    "id": "workarena.servicenow.three-changes-fix-wide-tight-priority-varied-risk-change-request-scheduling-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDeveloperLaptopTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.ThreeChangesFixWideTightPriorityVariedRiskChangeRequestSchedulingTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-orderi-pad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-orderi-pad-pro-l3",
@@ -2657,59 +4867,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadProTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-asset-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterAssetListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-asset-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterAssetListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderiPadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-windows-surface-pro4-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-sales-laptop-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestWindowsSurfacePro4TaskL3",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-requested-items-and-order-loaner-laptop-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-standard-laptop-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderLoanerLaptopTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-apple-macbook-pro15-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderAppleMacbookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-max-order-loaner-laptop-l3",
@@ -2717,59 +4933,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMaxOrderLoanerLaptopTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-google-nexus7-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-incident-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGoogleNexus7TaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-pro-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadProTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-user-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterUserListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-galaxy-note20-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGalaxyNote20TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateIncidentTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-create-problem-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinCreateProblemTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-min-filter-user-list-l3",
@@ -2777,71 +4999,274 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMinFilterUserListTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.amount-based-expense-management-medium-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-asset-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.basic-expense-management-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementLargeTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.amount-based-expense-management-large-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-hardware-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementLargeTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.basic-expense-management-medium-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-incident-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementMediumTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-watch2-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleWatch2TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-ipad3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIpad3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-iphone13pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIphone13proTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-apple-iphone13-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestAppleIphone13TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-galaxy-note20-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGalaxyNote20TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-google-nexus7-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestGoogleNexus7TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-microsoft-surface-pro3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestMicrosoftSurfacePro3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-pixel4a-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestPixel4aTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-max-request-windows-surface-pro4-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMaxRequestWindowsSurfacePro4TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.get-warranty-expiration-date-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.GetWarrantyExpirationDateTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-ipad-pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderIpadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-apple-mac-book-pro15-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderAppleMacBookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-requested-items-and-order-loaner-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRequestedItemsAndOrderLoanerLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.basic-expense-management-small-l3",
@@ -2849,71 +5274,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.date-based-expense-management-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.amount-based-expense-management-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.date-based-expense-management-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.easy-expense-management-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.date-based-expense-management-small-l3",
@@ -2921,47 +5285,131 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementSmallTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-small-l3",
+    "id": "workarena.servicenow.amount-based-expense-management-small-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsSmallTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-large-l3",
+    "id": "workarena.servicenow.easy-expense-management-small-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-medium-l3",
+    "id": "workarena.servicenow.basic-expense-management-medium-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.date-based-expense-management-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.amount-based-expense-management-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.easy-expense-management-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.basic-expense-management-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.BasicExpenseManagementLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.date-based-expense-management-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DateBasedExpenseManagementLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.amount-based-expense-management-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.AmountBasedExpenseManagementLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.easy-expense-management-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.EasyExpenseManagementLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-medium-l3",
@@ -2969,35 +5417,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-and-find-total-return-large-l3",
@@ -3005,23 +5428,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndFindTotalReturnLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsSmallTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-small-l3",
@@ -3029,95 +5439,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-find-total-return-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndFindTotalReturnSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-large-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsLargeTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-medium-l3",
@@ -3125,23 +5450,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-large-l3",
+    "id": "workarena.servicenow.filter-trivial-expenses-and-find-total-return-large-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndFindTotalReturnLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsLargeTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-medium-l3",
@@ -3149,35 +5483,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-and-find-total-return-large-l3",
@@ -3185,23 +5494,241 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndFindTotalReturnLargeTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-medium-l3",
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-small-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsMediumTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-find-total-return-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndFindTotalReturnLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-find-total-return-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndFindTotalReturnSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-find-total-return-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndFindTotalReturnLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-small-l3",
@@ -3209,11 +5736,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-find-total-return-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-trivial-expenses-find-total-return-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTrivialExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-small-l3",
@@ -3221,35 +5802,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-medium-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-small-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsSmallTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-medium-l3",
@@ -3257,11 +5813,241 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-find-total-return-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-find-total-return-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-find-total-return-and-select-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesFindTotalReturnAndSelectInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-find-total-return-and-select-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesFindTotalReturnAndSelectInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-random-expenses-and-delete-wrong-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterRandomExpensesAndDeleteWrongInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-expenses-and-delete-wrong-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemExpensesAndDeleteWrongInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-single-item-uniform-expenses-and-delete-wrong-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterSingleItemUniformExpensesAndDeleteWrongInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-two-items-uniform-expenses-and-delete-wrong-investments-small-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterTwoItemsUniformExpensesAndDeleteWrongInvestmentsSmallTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-medium-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsMediumTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.filter-three-items-uniform-expenses-and-delete-wrong-investments-large-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.FilterThreeItemsUniformExpensesAndDeleteWrongInvestmentsLargeTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-orderi-pad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderiPadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-orderi-pad-pro-l3",
@@ -3269,11 +6055,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderiPadProTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-apple-macbook-pro15-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderAppleMacbookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mean-order-loaner-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMeanOrderLoanerLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-orderi-pad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderiPadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-orderi-pad-pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderiPadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-apple-macbook-pro15-l3",
@@ -3281,11 +6198,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderAppleMacbookPro15TaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-median-order-loaner-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndMedianOrderLoanerLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-orderi-pad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderiPadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-orderi-pad-pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderiPadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-apple-watch-l3",
@@ -3293,35 +6286,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderAppleWatchTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-incident-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-apple-macbook-pro15-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateIncidentTaskL3",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderAppleMacbookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-incident-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-development-laptop-p-c-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-catalog-and-mode-order-loaner-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateIncidentTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveCatalogAndModeOrderLoanerLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-create-incident-l3",
@@ -3329,35 +6330,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
+    "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanCreateIncidentTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-problem-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-incident-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateProblemTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateIncidentTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-problem-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-incident-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateProblemTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateIncidentTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-create-problem-l3",
@@ -3365,11 +6363,109 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanCreateProblemTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-create-problem-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianCreateProblemTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-create-problem-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeCreateProblemTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-greater-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanGreaterFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-lesser-filter-user-list-l3",
@@ -3377,11 +6473,76 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanLesserFilterUserListTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-greater-filter-user-list-l3",
@@ -3389,11 +6550,32 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-lesser-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianGreaterFilterUserListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianLesserFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-asset-list-l3",
@@ -3401,11 +6583,120 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterAssetListTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-greater-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeGreaterFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-lesser-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeLesserFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-watch2-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleWatch2TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-ipad3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIpad3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-iphone13pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13proTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-apple-iphone13-l3",
@@ -3413,11 +6704,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-galaxy-note20-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestAppleIphone13TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestGalaxyNote20TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-google-nexus7-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestGoogleNexus7TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-microsoft-surface-pro3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestMicrosoftSurfacePro3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-pixel4a-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestPixel4aTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mean-request-windows-surface-pro4-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMeanRequestWindowsSurfacePro4TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-watch2-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleWatch2TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-ipad3-l3",
@@ -3425,11 +6792,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIpad3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-iphone13pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIpad3TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIphone13proTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-apple-iphone13-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestAppleIphone13TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-galaxy-note20-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestGalaxyNote20TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-google-nexus7-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestGoogleNexus7TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-microsoft-surface-pro3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestMicrosoftSurfacePro3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-pixel4a-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestPixel4aTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-median-request-windows-surface-pro4-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndMedianRequestWindowsSurfacePro4TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-watch2-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleWatch2TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-ipad3-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIpad3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-iphone13pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIphone13proTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-apple-iphone13-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestAppleIphone13TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-galaxy-note20-l3",
@@ -3437,239 +6935,54 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestGalaxyNote20TaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-create-incident-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-google-nexus7-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateIncidentTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestGoogleNexus7TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-order-ipad-pro-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-microsoft-surface-pro3-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadProTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-hardware-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterHardwareListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestMicrosoftSurfacePro3TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-sort-asset-list-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-pixel4a-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortAssetListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.off-board-user-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.OffBoardUserTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.on-board-user-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.OnBoardUserTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-hardware-asset-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateHardwareAssetTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-apple-mac-book-pro15-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleMacBookPro15TaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestPixel4aTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.navigate-and-filter-change-request-list-l3",
+    "id": "workarena.servicenow.dashboard-retrieve-incident-and-mode-request-windows-surface-pro4-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterChangeRequestListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-change-request-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortChangeRequestListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-developer-laptop-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDeveloperLaptopTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-service-catalog-item-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterServiceCatalogItemListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-incident-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortIncidentListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-change-request-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateChangeRequestTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-filter-incident-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterIncidentListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-sales-laptop-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderSalesLaptopTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-create-problem-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateProblemTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-order-development-laptop-p-c-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDevelopmentLaptopPCTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.navigate-and-sort-user-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortUserListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.DashboardRetrieveIncidentAndModeRequestWindowsSurfacePro4TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.navigate-and-create-user-l3",
@@ -3677,11 +6990,142 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateUserTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-incident-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateIncidentTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-change-request-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateChangeRequestTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-problem-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateUserTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateProblemTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-create-hardware-asset-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndCreateHardwareAssetTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-developer-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDeveloperLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-ipad-pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-ipad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderIpadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-apple-mac-book-pro15-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderAppleMacBookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.navigate-and-order-loaner-laptop-l3",
@@ -3689,107 +7133,164 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndOrderLoanerLaptopTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-with-reason-l3",
+    "id": "workarena.servicenow.navigate-and-filter-asset-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-filter-change-request-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetWithReasonTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterChangeRequestListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-problem-l3",
+    "id": "workarena.servicenow.navigate-and-filter-hardware-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListWithReasonTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-l3",
+    "id": "workarena.servicenow.navigate-and-filter-service-catalog-item-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndFilterServiceCatalogItemListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-with-reason-l3",
+    "id": "workarena.servicenow.navigate-and-sort-asset-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListWithReasonTaskL3",
-    "extra_info": {}
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-l3",
+    "id": "workarena.servicenow.navigate-and-sort-user-list-l3",
     "split": "test",
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-change-request-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortChangeRequestListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.navigate-and-sort-service-catalog-item-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.NavigateAndSortServiceCatalogItemListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.off-board-user-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.OffBoardUserTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.on-board-user-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.OnBoardUserTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-user-with-reason-l3",
@@ -3797,59 +7298,10 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateUserWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-incident-with-reason-l3",
@@ -3857,83 +7309,21 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListWithReasonTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
-    "level": "l3",
-    "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListTaskL3",
-    "extra_info": {}
-  },
-  {
-    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-with-reason-l3",
-    "split": "test",
-    "abstract_description": "",
-    "recommended_max_steps": null,
-    "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListWithReasonTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-problem-with-reason-l3",
@@ -3941,11 +7331,65 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-user-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateUserTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-incident-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
     "level": "l3",
     "in_human_curriculum": false,
-    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemWithReasonTaskL3",
-    "extra_info": {}
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateIncidentTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-change-request-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateChangeRequestTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-create-problem-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateProblemTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-create-hardware-asset-l3",
@@ -3953,11 +7397,87 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": true,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndCreateHardwareAssetTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-standard-laptop-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderStandardLaptopWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-sales-laptop-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderSalesLaptopWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-developer-laptop-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDeveloperLaptopWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-mac-book-pro15-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleMacBookPro15WithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-order-development-laptop-p-c-with-reason-l3",
@@ -3965,11 +7485,43 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDevelopmentLaptopPCWithReasonTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-loaner-laptop-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderLoanerLaptopWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-standard-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderStandardLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-sales-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderSalesLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-order-developer-laptop-l3",
@@ -3977,11 +7529,263 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDeveloperLaptopTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-pro-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadProTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-ipad-mini-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderIpadMiniTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-watch-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleWatchTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-apple-mac-book-pro15-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderAppleMacBookPro15TaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-development-laptop-p-c-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderDevelopmentLaptopPCTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-order-loaner-laptop-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndOrderLoanerLaptopTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-hardware-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterHardwareListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-change-request-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterChangeRequestListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-filter-service-catalog-item-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndFilterServiceCatalogItemListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-user-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortUserListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-change-request-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortChangeRequestListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-with-reason-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListWithReasonTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   },
   {
     "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-with-reason-l3",
@@ -3989,10 +7793,75 @@
     "abstract_description": "",
     "recommended_max_steps": null,
     "container_config": null,
-    "_type": "workarena_cube.task.WorkArenaTaskMetadata",
     "level": "l3",
     "in_human_curriculum": false,
     "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListWithReasonTaskL3",
-    "extra_info": {}
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-asset-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortAssetListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-user-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortUserListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-incident-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortIncidentListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-change-request-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": true,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortChangeRequestListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-hardware-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortHardwareListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
+  },
+  {
+    "id": "workarena.servicenow.infeasible-navigate-and-sort-service-catalog-item-list-l3",
+    "split": "test",
+    "abstract_description": "",
+    "recommended_max_steps": null,
+    "container_config": null,
+    "level": "l3",
+    "in_human_curriculum": false,
+    "task_class_path": "browsergym.workarena.tasks.compositional.InfeasibleNavigateAndSortServiceCatalogItemListTaskL3",
+    "_type": "workarena_cube.task.WorkArenaTaskMetadata"
   }
 ]

--- a/cubes/workarena/src/workarena_cube/tools.py
+++ b/cubes/workarena/src/workarena_cube/tools.py
@@ -59,7 +59,7 @@ class WorkArenaInfeasibleTool(Tool):
         Args:
             explanation: Brief explanation of why the task cannot be completed.
         """
-        self._messages.append({"role": "infeasible", "content": explanation})
+        self._messages.append({"role": "infeasible", "message": explanation})
         return "Reported task as infeasible."
 
     @property


### PR DESCRIPTION
- Seed generator: L2/L3 tasks now get [meta_seed] directly instead of relying on get_all_tasks_agents curriculum (which varies with meta_seed and produced empty seed lists for some task types). L1 unchanged.
- Infeasible tool: use "message" key instead of "content" to match WorkArena validator expectation.
- Regenerated task_metadata.json (333 → 715 tasks) from canonical ALL_COMPOSITIONAL_TASKS_L2/L3 lists.
