### PR TITLE
feat(investigator): default to terminal (`claude -p`) driver

### DIFF
--- a/src/cube_harness/analyze/investigator/cli.py
+++ b/src/cube_harness/analyze/investigator/cli.py
@@ -85,8 +85,11 @@ def run_cmd(
     path: Annotated[Path, typer.Argument(help="Experiment directory or single episode directory.")],
     recipe: Annotated[str, typer.Option(help="Recipe name (see use_cases/ subdirectories).")] = "general_blame",
     driver: Annotated[
-        str, typer.Option(help="Coding-agent driver: 'claude-code-sdk' (API key) or 'claude-terminal' (subscription).")
-    ] = "claude-code-sdk",
+        str,
+        typer.Option(
+            help="Coding-agent driver: 'claude-terminal' (subscription, default) or 'claude-code-sdk' (API key)."
+        ),
+    ] = "claude-terminal",
     investigator_model: Annotated[
         str | None,
         typer.Option("--investigator-model", help="Override the recipe's per-episode investigator model."),
@@ -190,7 +193,7 @@ def run_cmd(
 @app.command("init-context")
 def init_context_cmd(
     experiment_dir: Annotated[Path, typer.Argument(help="Experiment directory.")],
-    driver: Annotated[str, typer.Option(help="Driver to invoke the context agent through.")] = "claude-code-sdk",
+    driver: Annotated[str, typer.Option(help="Driver to invoke the context agent through.")] = "claude-terminal",
     model: Annotated[str, typer.Option(help="Model name for the context agent.")] = "claude-opus-4-7",
     verbose: Annotated[bool, typer.Option("-v", "--verbose")] = False,
 ) -> None:

--- a/src/cube_harness/analyze/investigator/core.py
+++ b/src/cube_harness/analyze/investigator/core.py
@@ -20,8 +20,8 @@ from cube_harness.analyze.cross_experiment.cross_investigation_agreement import 
 )
 from cube_harness.analyze.investigator.agent_driver import (
     AgentDriver,
-    ClaudeCodeSDKDriver,
     DriverResult,
+    TerminalClaudeDriver,
     ToolAction,
     TraceMode,
 )
@@ -87,7 +87,7 @@ class InvestigationConfig(TypedBaseModel):
 
     # Behaviour
     recipe: InvestigatorRecipe = Field(default_factory=get_default_recipe)
-    driver: AgentDriver = Field(default_factory=ClaudeCodeSDKDriver)
+    driver: AgentDriver = Field(default_factory=TerminalClaudeDriver)
     selector: Selector | None = None
     audit: bool = False
     n_seeds: int = 1
@@ -283,8 +283,8 @@ def _resolve_recipe(recipe: InvestigatorRecipe | None, model_override: str | Non
 
 
 def _resolve_driver(driver: AgentDriver | None) -> AgentDriver:
-    """Default to `ClaudeCodeSDKDriver()` when no driver is given."""
-    return driver or ClaudeCodeSDKDriver()
+    """Default to `TerminalClaudeDriver()` (subscription `claude -p`) when no driver is given."""
+    return driver or TerminalClaudeDriver()
 
 
 def _build_user_prompt(
@@ -776,7 +776,7 @@ def write_summary(
         effective_model = model or next(iter(results.values()))[1].model
         recipe = get_default_recipe().model_copy(update={"model": effective_model})
     if driver is None:
-        driver = ClaudeCodeSDKDriver()
+        driver = TerminalClaudeDriver()
     audit_costs = audit_costs or {}
     outcomes = Counter(o.outcome.value for o, _ in results.values())
     blames = Counter(o.primary_blame.value for o, _ in results.values())

--- a/tests/test_investigator_driver_default.py
+++ b/tests/test_investigator_driver_default.py
@@ -1,0 +1,18 @@
+"""The Investigator defaults to the subscription `claude -p` driver.
+
+Switching the default avoids spending Anthropic API credits on long Auto-CUBE
+batches by routing through the user's Claude subscription instead. The SDK
+driver remains selectable via `--driver claude-code-sdk` / by passing one
+explicitly to `InvestigationConfig`.
+"""
+
+from cube_harness.analyze.investigator.agent_driver import TerminalClaudeDriver
+from cube_harness.analyze.investigator.core import InvestigationConfig, _resolve_driver
+
+
+def test_investigation_config_defaults_to_terminal() -> None:
+    assert isinstance(InvestigationConfig().driver, TerminalClaudeDriver)
+
+
+def test_resolve_driver_none_falls_back_to_terminal() -> None:
+    assert isinstance(_resolve_driver(None), TerminalClaudeDriver)


### PR DESCRIPTION
## What

Flip the Investigator's default coding-agent driver from `ClaudeCodeSDKDriver` to `TerminalClaudeDriver` (subscription `claude -p`). The SDK driver remains selectable via `ch-investigate --driver claude-code-sdk` or by passing one explicitly to `InvestigationConfig`.

## Why

Long Auto-CUBE batches (hundreds of episodes × Investigator + audit) burn Anthropic API credits unnecessarily. Routing through the user's Claude subscription is the right default for the common case. Power users who need API parallelism (n_parallel > 2) or cost reporting can still opt into the SDK driver explicitly.

## Scope

- `InvestigationConfig.driver` default → `TerminalClaudeDriver`
- `_resolve_driver(None)` fallback → `TerminalClaudeDriver`
- `ch-investigate run --driver` default → `"claude-terminal"`
- `ch-investigate init-context --driver` default → `"claude-terminal"`
- Inline fallback in `write_summary()` → `TerminalClaudeDriver`
- New `tests/test_investigator_driver_default.py` covering both default paths

The selection mechanism (`cli._make_driver`) is already extensible — adding `codex` / `codex-terminal` modes later is just another `elif` branch on top of the existing `agent_driver.py` Protocol. No structural changes here, just defaults.

## Test plan

- `pytest tests/ -k investigat` → 63 passed, 1 skipped (all green; new tests pass)
- `make lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)