### PR TITLE
fix(exp_runner): experiment-scoped reaping — never orphan a run's cloud jobs (#206)

### DIFF
--- a/scripts/smoke/experiment_reap_on_death.py
+++ b/scripts/smoke/experiment_reap_on_death.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Smoke: the startup GC reaps a dead run's orphaned toolkit jobs by run_id (auto-fix #206).
+
+End-to-end across repos (toolkit `CUBE_RUN_ID` tagging + harness `_reap_dead_runs`):
+
+  1. Set `CUBE_RUN_ID=<dead>` (what `_experiment_lifecycle` does) and launch a real eai
+     job → the toolkit tags it `cube_run_id=<dead>`.
+  2. Simulate a crashed/slept client: drop the handle (no close) and write a stale
+     `RUNNING` experiment_status.json carrying `<dead>` — i.e. an orphaned job whose
+     owner's heartbeat is long gone.
+  3. A *new* run's `_reap_dead_runs(...)` must reap that orphaned job — and leave a
+     concurrently-launched LIVE run's job (fresh heartbeat) alone.
+
+SKIP if `eai` is absent / not authed.
+
+Run from the cube-harness repo root with the venv (cube-standard must carry the
+CUBE_RUN_ID change — cube-standard#209):
+    EAI_PROFILE=yul101 .venv/bin/python scripts/smoke/experiment_reap_on_death.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+from cube.resource import DockerServiceConfig
+from cube_infra_toolkit.toolkit import ToolkitInfraConfig
+
+from cube_harness.exp_runner import _DEAD_RUN_STALE_AFTER_S, _reap_dead_runs
+from cube_harness.experiment_status import ExperimentStatus
+
+_NAME = "experiment_reap_on_death"
+_ACTIVE = {"queued", "queuing", "running"}
+
+
+def banner(status: str, reason: str = "") -> int:
+    print(f"\nSMOKE {status}: {_NAME}" + (f" — {reason}" if reason else ""))
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+def _state(eai: str, profile: str, job_id: str) -> str:
+    r = subprocess.run(
+        [eai, "--profile", profile, "job", "get", job_id, "--fields", "state", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    for ln in r.stdout.splitlines():
+        if ln.strip():
+            try:
+                return str(json.loads(ln).get("state", "")).lower()
+            except json.JSONDecodeError:
+                continue
+    return ""
+
+
+def _released(eai: str, profile: str, job_id: str, *, deadline_s: int = 30) -> bool:
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        if (st := _state(eai, profile, job_id)) and st not in _ACTIVE:
+            return True
+        time.sleep(2)
+    return False
+
+
+def _write_status(exp_dir: Path, run_id: str, heartbeat_age_s: float) -> None:
+    now = time.time()
+    ExperimentStatus(
+        status="RUNNING",
+        mode="ray",
+        pid=999999,  # not us
+        host="dead-host",
+        started_at=now - heartbeat_age_s - 1,
+        last_heartbeat_at=now - heartbeat_age_s,
+        total_episodes=1,
+        run_id=run_id,
+    ).write(exp_dir / "experiment_status.json")
+
+
+def main() -> int:
+    eai = "eai" if shutil.which("eai") else os.path.expanduser("~/bin/eai")
+    if shutil.which("eai") is None and not os.path.exists(eai):
+        return banner("SKIP", "eai CLI not found")
+    profile = os.environ.get("EAI_PROFILE", "yul101")
+
+    root = Path(tempfile.mkdtemp(prefix="smoke_206_death_"))
+    dead_run, live_run = f"smoke206-{uuid.uuid4().hex[:8]}", f"smoke206-{uuid.uuid4().hex[:8]}"
+    infra = ToolkitInfraConfig(profile=profile, eai_path=eai, cube_data=None, default_ttl_seconds=600)
+    resource = DockerServiceConfig(name="cube-smoke-206d", scope="task", docker_images=["python:3.12-slim"])
+    infra.provision(resource)
+    prev_env = os.environ.get("CUBE_RUN_ID")
+
+    dead_job = live_job = None
+    try:
+        os.environ["CUBE_RUN_ID"] = dead_run  # what _experiment_lifecycle exports
+        dead_h = infra.launch(resource)  # tagged cube_run_id=dead_run
+        dead_job = dead_h.id
+        os.environ["CUBE_RUN_ID"] = live_run
+        live_h = infra.launch(resource)  # a concurrent, healthy run
+        live_job = live_h.id
+
+        # Simulate the crash: dead run's handle is lost (no close), its heartbeat is stale;
+        # the live run is heartbeating now.
+        dead_h = None  # noqa: F841 — drop handle, do NOT close (orphans the job)
+        _write_status(root / "dead", dead_run, heartbeat_age_s=_DEAD_RUN_STALE_AFTER_S + 120)
+        _write_status(root / "live", live_run, heartbeat_age_s=0)
+
+        # A new run starts → its startup GC runs.
+        _reap_dead_runs(infra, root / "current", current_run_id=f"smoke206-{uuid.uuid4().hex[:8]}")
+
+        if not _released(eai, profile, dead_job):
+            return banner("FAIL", f"startup GC did not reap the dead run's orphaned job {dead_job[:8]}")
+        if _state(eai, profile, live_job) not in _ACTIVE:
+            return banner("FAIL", f"startup GC wrongly killed the LIVE run's job {live_job[:8]}")
+        return banner("OK", f"GC reaped dead-run job {dead_job[:8]}; live-run job {live_job[:8]} untouched")
+    except Exception as exc:  # noqa: BLE001
+        return banner("FAIL", f"{type(exc).__name__}: {exc}")
+    finally:
+        os.environ["CUBE_RUN_ID"] = prev_env if prev_env is not None else ""
+        if prev_env is None:
+            os.environ.pop("CUBE_RUN_ID", None)
+        for rid in (dead_run, live_run):
+            try:
+                infra.cleanup(rid)
+            except Exception:  # noqa: BLE001, S110
+                pass
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -79,11 +79,50 @@ def _trajectory_id(episode: Episode) -> str:
     return trajectory_log_id(episode.config.task_config.task_id, episode.config.id)
 
 
+# auto-fix(206)↓ a RUNNING experiment_status.json whose heartbeat is this stale = a dead
+# client (the 30s heartbeat couldn't have lapsed otherwise). Generous vs the interval so
+# a paused/slow driver isn't reaped out from under itself.
+_DEAD_RUN_STALE_AFTER_S: float = 5 * 60
+
+
+def _reap_dead_runs(infra: InfraConfig, exp_dir: Path, current_run_id: str = "") -> None:
+    """Startup GC (identity + liveness): reap cloud resources of *prior* runs that died
+    abnormally (Ray OOM-crash / laptop sleep), so they don't linger to the server-side TTL.
+
+    A sibling run is dead iff its ``experiment_status.json`` is still ``RUNNING`` with a
+    heartbeat older than ``_DEAD_RUN_STALE_AFTER_S`` — a still-heartbeating run is never
+    touched (no time-on-task heuristic; cf. the reverted #445). For each dead run with a
+    recorded ``run_id`` we call ``infra.cleanup(run_id)``, which on this infra reaps only
+    that run's resources — never a live run's, never another session's. Runs with no local
+    status record are left to the TTL backstop (could be another machine's live run).
+    """
+    now = time.time()
+    for status_path in exp_dir.parent.glob(f"*/{EXPERIMENT_STATUS_FILENAME}"):
+        st = ExperimentStatus.read(status_path)
+        if st is None or not st.run_id or st.run_id == current_run_id:
+            continue
+        if st.status == "RUNNING" and (now - st.last_heartbeat_at) > _DEAD_RUN_STALE_AFTER_S:
+            try:
+                infra.cleanup(st.run_id)
+                logger.info(
+                    "startup GC: reaped dead run %s (%s; heartbeat %.0fs stale)",
+                    st.run_id,
+                    status_path.parent.name,
+                    now - st.last_heartbeat_at,
+                )
+            except Exception:
+                logger.warning("startup GC: cleanup(%s) failed", st.run_id, exc_info=True)
+
+
+# /auto-fix(206)
+
+
 @contextmanager
 def _experiment_lifecycle(
     exp_dir: Path,
     mode: Literal["ray", "sequential"],
     infra: InfraConfig | None = None,
+    run_id: str = "",
 ) -> Iterator[tuple[ExperimentStatus, Path]]:
     """Manage `experiment_status.json` from RUNNING through terminal write.
 
@@ -117,12 +156,24 @@ def _experiment_lifecycle(
         started_at=now,
         last_heartbeat_at=now,
         total_episodes=0,
+        run_id=run_id,
     )
     exp_status_path = exp_dir / EXPERIMENT_STATUS_FILENAME
     try:
         exp_status.write(exp_status_path)
     except Exception:
         logger.warning("Failed to write initial experiment status", exc_info=True)
+
+    # auto-fix(206)↓ identity-based reaping. Export CUBE_RUN_ID so the infra tags every
+    # cloud resource this run launches with it (→ cleanup(run_id) reaps the whole run),
+    # then GC any *prior* run whose heartbeat proves it died (Ray crash / sleep) before we
+    # add cluster load. See cube-standard#206 and resource/spec.md.
+    prev_run_id_env = os.environ.get("CUBE_RUN_ID")
+    if run_id:
+        os.environ["CUBE_RUN_ID"] = run_id
+    if infra is not None:
+        _reap_dead_runs(infra, exp_dir, current_run_id=run_id)
+    # /auto-fix(206)
 
     prev_sigterm = None
     if infra is not None:
@@ -151,8 +202,13 @@ def _experiment_lifecycle(
             except ValueError:
                 pass
 
+        if prev_run_id_env is None:
+            os.environ.pop("CUBE_RUN_ID", None)
+        else:
+            os.environ["CUBE_RUN_ID"] = prev_run_id_env
+
         if infra is not None:
-            _run_cleanup_with_grace(infra, timeout_s=_CLEANUP_GRACE_TIMEOUT_S)
+            _run_cleanup_with_grace(infra, timeout_s=_CLEANUP_GRACE_TIMEOUT_S, run_id=run_id)
 
 
 def _raise_systemexit_on_sigterm(signum: int, frame: object) -> None:
@@ -168,7 +224,9 @@ def _raise_systemexit_on_sigterm(signum: int, frame: object) -> None:
     raise SystemExit(128 + signum)
 
 
-def _run_cleanup_with_grace(infra: InfraConfig, timeout_s: float) -> Literal["OK", "ERROR", "TIMEOUT", "FORCED"]:
+def _run_cleanup_with_grace(
+    infra: InfraConfig, timeout_s: float, run_id: str = ""
+) -> Literal["OK", "ERROR", "TIMEOUT", "FORCED"]:
     """Run ``infra.cleanup_stale()`` with a timeout and Ctrl+C escalation.
 
     Cleanup runs in a daemon thread; the main thread polls for completion and
@@ -188,6 +246,12 @@ def _run_cleanup_with_grace(infra: InfraConfig, timeout_s: float) -> Literal["OK
 
     def _worker() -> None:
         try:
+            # auto-fix(206): reap THIS run's resources by id first — identity-scoped,
+            # regardless of TTL — so a graceful/SIGTERM/Ctrl+C exit leaves nothing behind
+            # (the exit-path companion to the startup GC). Then the TTL + orphan
+            # port-forward sweep as defense-in-depth across runs.
+            if run_id:
+                infra.cleanup(run_id)
             result["deleted"] = infra.cleanup_stale()
         except Exception as exc:
             result["error"] = exc
@@ -302,7 +366,10 @@ def run_with_ray(
     try:
         with (
             tracer.benchmark(exp.name),
-            _experiment_lifecycle(exp.output_dir, mode="ray", infra=exp.infra) as (exp_status, exp_status_path),
+            _experiment_lifecycle(exp.output_dir, mode="ray", infra=exp.infra, run_id=exp.run_id) as (
+                exp_status,
+                exp_status_path,
+            ),
         ):
             return _run_with_retries(
                 exp,
@@ -413,12 +480,15 @@ def _run_with_ray_impl(
 
     if not ray.is_initialized():
         _warn_if_ephemeral_venv()
+        # auto-fix(206): propagate CUBE_RUN_ID to workers so the infra (which launches
+        # each task's resources inside a Ray worker) tags them with the run's id.
+        env_vars = {**get_trace_env_vars(), "CUBE_RUN_ID": exp.run_id}
         ray.init(
             num_cpus=n_cpus,
             dashboard_host="0.0.0.0",
             include_dashboard=True,
             log_to_driver=True,
-            runtime_env={"env_vars": get_trace_env_vars()},
+            runtime_env={"env_vars": env_vars},
         )  # TODO: Ray breaks signal handling, we cannot react to Ctrl+C here, still cannot find a workaround
 
     with exp.benchmark_config.make(exp.infra) as benchmark:
@@ -685,7 +755,10 @@ def run_sequentially(
     try:
         with (
             tracer.benchmark(exp.name),
-            _experiment_lifecycle(exp.output_dir, mode="sequential", infra=exp.infra) as (exp_status, exp_status_path),
+            _experiment_lifecycle(exp.output_dir, mode="sequential", infra=exp.infra, run_id=exp.run_id) as (
+                exp_status,
+                exp_status_path,
+            ),
         ):
             return _run_sequentially_with_retries(
                 exp,
@@ -838,4 +911,26 @@ def _run_sequentially_impl(
 #   tested:    tests/test_experiment.py — QUEUED + all-slots-busy (idle_capacity_since None)
 #              not cancelled even at 2h; QUEUED + sustained idle capacity cancelled;
 #              momentary idle dip not cancelled.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.
+#
+# auto-fix-note(206) {class=L1 anchor=issue#206 hash=PENDING ctx=exp-runner/experiment-scoped-reaping/cube-harness@dev}
+#   symptoms:  on abnormal client exit (Ray OOM-crash / laptop sleep / SIGKILL) the
+#              in-flight toolkit (EAI) jobs orphaned ~24h to --max-run-time: handle.close()
+#              never ran and exit cleanup was TTL-only (cleanup_stale()).
+#   invariant: a run's cloud resources are reaped when the run ends, including an abnormal
+#              end — identity + liveness based (whose run owns it × is its client alive),
+#              never time-on-task (the reverted #445/#458 lesson). A still-heartbeating run
+#              is never touched; a run with no local status record is left to the TTL
+#              backstop (cross-machine/cross-session safe).
+#   why:       export a stable Experiment.run_id as CUBE_RUN_ID (driver env + Ray worker
+#              runtime_env) → the toolkit tags every job cube_run_id=<run_id> (paired
+#              cube-standard#209) → infra.cleanup(run_id) reaps the whole run. Exit reaper
+#              calls cleanup(run_id) (graceful/SIGTERM/Ctrl+C); startup GC _reap_dead_runs
+#              reaps prior runs whose experiment_status.json is RUNNING with a heartbeat
+#              older than _DEAD_RUN_STALE_AFTER_S (hard-kill/sleep, where the exit reaper
+#              can't run).
+#   tested:    tests/test_reap_dead_runs.py (reaps only the stale-RUNNING sibling by id;
+#              leaves live/terminal/no-id/self; cleanup error swallowed);
+#              scripts/smoke/experiment_reap_on_death.py (end-to-end on toolkit yul101:
+#              dead-run job reaped, concurrent live-run job untouched).
 #   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -68,6 +68,12 @@ class Experiment(TypedBaseModel):
     max_steps: int = MAX_STEPS
     max_retries: int = 3
     git_cwd: str | None = None
+    run_id: str = Field(default_factory=lambda: uuid4().hex)
+    """Stable per-run id, exported as ``CUBE_RUN_ID`` so the infra tags every cloud
+    resource this run launches with it. Lets ``infra.cleanup(run_id)`` (on exit) and the
+    startup GC reap the *whole* run when its client dies abnormally (Ray crash / sleep),
+    identity-scoped — never another run's resources. Serialized, so it survives resume.
+    See cube-standard #206."""
 
     @model_validator(mode="after")
     def _ensure_unique_output_dir(self) -> "Experiment":

--- a/src/cube_harness/experiment_status.py
+++ b/src/cube_harness/experiment_status.py
@@ -61,6 +61,9 @@ class ExperimentStatus:
     stale: int = 0
     ray_dashboard_url: str | None = None
     ended_at: float | None = None
+    run_id: str = ""
+    """The experiment's CUBE_RUN_ID. Lets a later run's startup GC map this (possibly
+    dead) run's heartbeat to the cloud resources it owns and reap them. See #206."""
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2)

--- a/tests/test_reap_dead_runs.py
+++ b/tests/test_reap_dead_runs.py
@@ -1,0 +1,86 @@
+"""Unit tests for the startup GC `_reap_dead_runs` (auto-fix #206).
+
+Pins the identity + liveness reaping rules without a cluster: reap a prior run's
+resources iff its experiment_status.json is RUNNING with a stale heartbeat, by
+`run_id` — never a live run, a terminal run, the current run, or a run with no id.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from cube_harness.exp_runner import _DEAD_RUN_STALE_AFTER_S, _reap_dead_runs
+from cube_harness.experiment_status import ExperimentStatus
+
+
+class _RecordingInfra:
+    """Minimal InfraConfig stand-in that records cleanup(run_id) calls."""
+
+    def __init__(self) -> None:
+        self.reaped: list[str] = []
+
+    def cleanup(self, run_id: str) -> None:
+        self.reaped.append(run_id)
+
+
+def _write_status(
+    root: Path,
+    dir_name: str,
+    *,
+    status: str,
+    run_id: str,
+    heartbeat_age_s: float,
+) -> Path:
+    now = time.time()
+    st = ExperimentStatus(
+        status=status,  # type: ignore[arg-type]
+        mode="ray",
+        pid=123,
+        host="h",
+        started_at=now - heartbeat_age_s - 1,
+        last_heartbeat_at=now - heartbeat_age_s,
+        total_episodes=1,
+        run_id=run_id,
+    )
+    exp_dir = root / dir_name
+    st.write(exp_dir / "experiment_status.json")
+    return exp_dir
+
+
+def test_reaps_only_dead_runs_by_id(tmp_path: Path) -> None:
+    stale = _DEAD_RUN_STALE_AFTER_S + 60
+    _write_status(tmp_path, "dead", status="RUNNING", run_id="rid-dead", heartbeat_age_s=stale)
+    _write_status(tmp_path, "alive", status="RUNNING", run_id="rid-alive", heartbeat_age_s=5)
+    _write_status(tmp_path, "done", status="COMPLETED", run_id="rid-done", heartbeat_age_s=stale)
+    _write_status(tmp_path, "no_id", status="RUNNING", run_id="", heartbeat_age_s=stale)
+    current = _write_status(tmp_path, "current", status="RUNNING", run_id="rid-cur", heartbeat_age_s=0)
+
+    infra = _RecordingInfra()
+    _reap_dead_runs(infra, current, current_run_id="rid-cur")
+
+    # Only the stale RUNNING sibling with a run_id is reaped.
+    assert infra.reaped == ["rid-dead"]
+
+
+def test_no_siblings_is_noop(tmp_path: Path) -> None:
+    current = _write_status(tmp_path, "current", status="RUNNING", run_id="rid-cur", heartbeat_age_s=0)
+    infra = _RecordingInfra()
+    _reap_dead_runs(infra, current, current_run_id="rid-cur")
+    assert infra.reaped == []
+
+
+def test_cleanup_failure_is_swallowed(tmp_path: Path) -> None:
+    """A backend cleanup error for one dead run must not abort the GC / the launch."""
+    stale = _DEAD_RUN_STALE_AFTER_S + 60
+    _write_status(tmp_path, "dead", status="RUNNING", run_id="rid-dead", heartbeat_age_s=stale)
+    current = _write_status(tmp_path, "current", status="RUNNING", run_id="rid-cur", heartbeat_age_s=0)
+
+    class _Boom(_RecordingInfra):
+        def cleanup(self, run_id: str) -> None:
+            super().cleanup(run_id)
+            raise RuntimeError("backend down")
+
+    infra = _Boom()
+    _reap_dead_runs(infra, current, current_run_id="rid-cur")  # must not raise
+    assert infra.reaped == ["rid-dead"]


### PR DESCRIPTION
# Fix Report — experiment-scoped reaping: never orphan a run's cloud jobs (harness half of #206)

**Class**: L1 · **Anchor**: design-debt **#206**
**Context fingerprint**: `eai-toolkit/yul101/uid-13011/cube-harness@dev`
**Depends-on**: cube-standard/fix/toolkit-experiment-run-id (PR #209 — toolkit reads `CUBE_RUN_ID`). **Closes #206 once both land.**

## Invariant
A run's cloud resources must be reaped when the run ends — including an **abnormal** end (Ray OOM-crash, laptop sleep, SIGKILL). Reaping is **identity + liveness** based (whose run + is its client alive), never time-on-task (the reverted #445/#458 lesson).

## Root cause
On abnormal exit the per-episode `handle.close()` never runs, and the exit cleanup was TTL-only (`cleanup_stale()`), so in-flight jobs orphaned to the 24h `--max-run-time`. There was also no per-run handle: toolkit minted a per-job `run_id`, so nothing could reap "this run's jobs" (fixed in the paired cube-standard PR).

## The fix (three coordinated pieces)
1. **`Experiment.run_id`** — a stable per-run id (serialized, survives resume), exported as **`CUBE_RUN_ID`**: into the driver env (sequential + driver-side launches) and the **Ray worker** `runtime_env.env_vars` (where each task's resource is launched). The toolkit then tags every job `cube_run_id=<run_id>` (paired PR).
2. **Exit reaper** — `_run_cleanup_with_grace` now calls `infra.cleanup(run_id)` (identity-scoped, regardless of TTL) before the TTL/port-forward `cleanup_stale()` sweep. Covers graceful / SIGTERM / Ctrl+C exits.
3. **Startup GC** — `_reap_dead_runs` runs at lifecycle entry: scans sibling `experiment_status.json`, and for any **`RUNNING` with a heartbeat older than 5 min** (a dead client — the 30s heartbeat couldn't otherwise lapse) calls `infra.cleanup(its run_id)`. Covers the **hard-kill/sleep** case where (2) can't run. `ExperimentStatus` gains a `run_id` field so the GC can map a dead status file → its cloud jobs.

## Why identity + liveness (not time)
`_reap_dead_runs` keys on *whose run owns the job* (`run_id` tag) × *is that run's client alive* (heartbeat) — a still-heartbeating run is never touched, no matter how long its jobs run; a crashed run is reaped within minutes. This sidesteps the #458 trap (a fixed elapsed-time threshold false-cancelled 141/300). Runs with no local status record are left to the TTL backstop (could be another machine's live run) → cross-machine/cross-session safe.

## Blast radius
- `experiment.py` (+`run_id` field), `experiment_status.py` (+`run_id` field), `exp_runner.py` (export + exit reaper + `_reap_dead_runs` + Ray env propagation). All additive; default-off when `run_id`/infra absent.
- **Follow-up (not in this PR):** a Ray fan-out guard (warn on large local `n_cpus`) to reduce the OOM-crash *trigger* — separate concern from reaping; noted on #206.

## Test
- **Unit** `tests/test_reap_dead_runs.py` (3): reaps only the stale-`RUNNING` sibling by id; leaves live/terminal/no-id/self; cleanup error is swallowed (one bad backend can't abort a launch). Existing `tests/test_experiment.py` 45/45.
- **Smoke** `scripts/smoke/experiment_reap_on_death.py` (validated on toolkit yul101): launch a job under `CUBE_RUN_ID=<dead>`, drop the handle + write a stale `RUNNING` status, then a new run's `_reap_dead_runs` reaps the orphaned job while a concurrent live run's job is untouched. Exercises the full chain: `CUBE_RUN_ID` export → toolkit tag → GC reap.
