### PR TITLE
test(recipe): cover in-cube recipe modules + gold-patch smoke

### DIFF
--- a/cubes/swebench-live-cube/scripts/smoke/gold_patch_recipe.py
+++ b/cubes/swebench-live-cube/scripts/smoke/gold_patch_recipe.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Smoke: the SWE-bench-Live gold-patch recipe runs end-to-end on local Docker.
+
+Mirrors the recipe's local experiment (`gold_patch.recipe._exp("local")`) but pins it
+to one known gold-solvable task, then runs it with no LLM (GoldPatchAgent applies the
+gold patch + calls final_step) and asserts the episode resolved (reward >= 1.0). This
+exercises the real path a downstream user hits: Experiment + GoldPatchAgentConfig +
+local Docker infra + SWEBenchLiveTask.evaluate.
+
+Prerequisites:
+  - Docker daemon reachable (honors DOCKER_HOST — e.g. `colima start`).
+  - QEMU, which `LocalInfraConfig.install()` provisions on first use.
+  - One-time `cube install swebench-live-cube` (downloads the task execution cache).
+SKIPs (exit 2) if Docker or QEMU is unavailable, so it is safe to run anywhere.
+
+Run from the cube-harness repo root with the venv:
+    .venv/bin/python cubes/swebench-live-cube/scripts/smoke/gold_patch_recipe.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_NAME = "gold_patch_recipe"
+# gitingest is a small repo (fast container) and is in the gold-solvable debug suite.
+_TASK = "cyclotruc__gitingest-94"
+
+
+def banner(status: str, reason: str = "") -> int:
+    print(f"\nSMOKE {status}: {_NAME}" + (f" — {reason}" if reason else ""))
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+def main() -> int:
+    if shutil.which("docker") is None:
+        return banner("SKIP", "docker not on PATH")
+    try:
+        info = subprocess.run(["docker", "info"], capture_output=True, timeout=15)
+    except Exception as exc:  # daemon hung / socket missing
+        return banner("SKIP", f"`docker info` failed: {type(exc).__name__}: {exc}")
+    if info.returncode != 0:
+        return banner("SKIP", "docker daemon unreachable (set DOCKER_HOST? e.g. colima)")
+    # LocalInfraConfig runs inside a QEMU microVM; without qemu its install() would try
+    # to build it (and can fail), so skip rather than fail when it is absent.
+    if shutil.which("qemu-system-x86_64") is None:
+        return banner("SKIP", "qemu-system-x86_64 absent (LocalInfraConfig can't provision)")
+
+    # Imports after the SKIP gate so a box without the deps still skips cleanly.
+    from swebench_live_cube.benchmark import SWEBenchLiveBenchmarkConfig
+    from swebench_live_cube.gold_patch.agent import GoldPatchAgentConfig
+
+    from cube_harness.exp_runner import run_with_ray
+    from cube_harness.experiment import Experiment
+    from cube_harness.infra import INFRA_CONFIGS
+    from cube_harness.storage import FileStorage
+
+    tmp = Path(tempfile.mkdtemp(prefix="smoke_gold_live_"))
+    # Mirrors gold_patch.recipe._exp("local"), narrowed to one task.
+    exp = Experiment(
+        name=_NAME,
+        agent_config=GoldPatchAgentConfig(),
+        benchmark_config=SWEBenchLiveBenchmarkConfig(oracle_mode=True).subset_from_list([_TASK]),
+        infra=INFRA_CONFIGS["local"],
+        max_steps=5,
+        output_dir=tmp / "run",
+    )
+    try:
+        run_with_ray(exp, n_cpus=1)
+    except Exception as exc:  # a per-episode raise must not crash the batch
+        return banner("FAIL", f"run_with_ray raised at batch level: {type(exc).__name__}: {exc}")
+
+    store = FileStorage(exp.output_dir)
+    statuses = {s.task_id: s for s in store.list_episode_statuses().values()}
+    st = statuses.get(_TASK)
+    if st is None:
+        return banner("FAIL", f"no episode status for {_TASK} (cube install run?)")
+    if not (st.status == "COMPLETED" and (st.reward or 0) >= 1.0):
+        return banner(
+            "FAIL",
+            f"{_TASK}: expected COMPLETED reward>=1.0, got status={st.status!r} "
+            f"reward={st.reward!r} error_type={st.error_type!r}",
+        )
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    return banner("OK", f"{_TASK} → gold patch applied, resolved reward {st.reward}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_recipe_imports.py
+++ b/tests/test_recipe_imports.py
@@ -3,13 +3,16 @@
 1. `test_recipe_local_imports_resolve` — static AST walk: every
    `from <local pkg> import Y` in a recipe resolves. Catches the class of bug
    that broke #381 (a recipe importing a symbol another PR deleted).
-2. `test_recipe_defines_experiment` — executes the recipe module and asserts
-   it builds an `Experiment` (or a `dict[str, Experiment]`). Catches
-   config-schema drift: a renamed config field fails here, not at next run.
+2. `test_recipe_defines_experiment` — executes the recipe (as `__main__`, with
+   `run()` stubbed) and asserts it yields an `Experiment` — assigned at module
+   level OR passed to `run()` by a lazy builder (the gold-patch recipes build
+   their Experiments inside `__main__` to avoid creating output dirs at import).
+   Catches config-schema drift: a renamed config field fails here, not at next run.
 
-No Docker, no network, no LLM (recipes do their run() under `__main__`).
-Recipes whose cube/tool deps aren't installed in this env are skipped, not
-failed — cube CI / local dev with the cube installed picks up the assertion.
+Covers both the top-level `recipes/` and the per-cube recipe modules under
+`cubes/*/` — the entry points downstream users hit first. No Docker, no network,
+no LLM (`run()` is stubbed). Recipes whose cube/tool deps aren't installed in this
+env are skipped, not failed — local dev with the cube installed asserts for real.
 """
 
 from __future__ import annotations
@@ -44,12 +47,15 @@ REPO_ROOT: Path = Path(__file__).resolve().parents[1]
 
 
 def _recipes() -> list[Path]:
-    """Return all recipe .py files under recipes/, excluding venvs and dunders."""
-    return [
-        p
-        for p in REPO_ROOT.glob("recipes/**/*.py")
-        if "venv" not in p.parts and not p.name.startswith("_") and p.name != "__init__.py"
-    ]
+    """All recipe .py files (excluding venvs and dunders): the top-level recipes/
+    plus the per-cube recipe modules (``cubes/*/.../recipe.py`` and ``*_recipe.py``).
+    Those in-cube modules are the entry points downstream users invoke, yet had no
+    import coverage before."""
+    # In-cube recipes are package modules under src/; scoping there keeps helper
+    # scripts (e.g. scripts/smoke/*_recipe.py) out.
+    globs = ("recipes/**/*.py", "cubes/*/src/**/recipe.py", "cubes/*/src/**/*_recipe.py")
+    found = {p for pattern in globs for p in REPO_ROOT.glob(pattern)}
+    return sorted(p for p in found if "venv" not in p.parts and not p.name.startswith("_") and p.name != "__init__.py")
 
 
 def _iter_import_targets(path: Path) -> list[tuple[str, str]]:
@@ -89,11 +95,31 @@ def _runnable_recipes() -> list[Path]:
     return [p for p in _recipes() if not p.name.endswith("_template.py")]
 
 
+def _experiments_in(obj: object) -> list[Experiment]:
+    """Experiments held directly, or as the values of a dict[str, Experiment]."""
+    if isinstance(obj, Experiment):
+        return [obj]
+    if isinstance(obj, dict):
+        return [v for v in obj.values() if isinstance(v, Experiment)]
+    return []
+
+
 @pytest.mark.parametrize("recipe", _runnable_recipes(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
 def test_recipe_defines_experiment(recipe: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Executing the recipe builds at least one Experiment (var or dict value)."""
+    """Executing the recipe yields at least one Experiment — assigned at module
+    level, or passed to run() under __main__ (the lazy `_exp()` builder pattern)."""
     monkeypatch.setattr("cube_harness.experiment.make_experiment_output_dir", lambda *a, **k: tmp_path)
-    spec = importlib.util.spec_from_file_location(recipe.stem, recipe)
+    captured: list[Experiment] = []
+    # Stub run() so the recipe's `if __name__ == "__main__": run(...)` records the
+    # experiments instead of launching them. `from cube_harness.recipe import run`
+    # binds this stub because we patch the source attribute before exec.
+    monkeypatch.setattr(
+        "cube_harness.recipe.run",
+        lambda *args: captured.extend(e for a in args for e in _experiments_in(a)),
+    )
+    # Name the module "__main__" so the recipe's `if __name__ == "__main__"` block
+    # fires (loader and module name must agree, so set it on the spec, not after).
+    spec = importlib.util.spec_from_file_location("__main__", recipe)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     try:
@@ -102,10 +128,7 @@ def test_recipe_defines_experiment(recipe: Path, tmp_path: Path, monkeypatch: py
         # Recipe's cube/tool dep not installed here — the AST guard above
         # already covers import-name resolution when it is installed.
         pytest.skip(f"recipe dependency not installed: {e.name}")
-    exps: list[Experiment] = []
+    exps = list(captured)
     for v in vars(module).values():
-        if isinstance(v, Experiment):
-            exps.append(v)
-        elif isinstance(v, dict):
-            exps.extend(x for x in v.values() if isinstance(x, Experiment))
-    assert exps, f"{recipe.relative_to(REPO_ROOT)} defines no Experiment (a var or a dict[str, Experiment])"
+        exps.extend(_experiments_in(v))
+    assert exps, f"{recipe.relative_to(REPO_ROOT)} defines no Experiment (module-level or passed to run())"


### PR DESCRIPTION
Reopened from #468 — that PR was auto-closed when its base branch was deleted on #456's merge. Same diff (2 files), now rebased onto current `dev`.

## Why

Recipe / "leaf" modules are the entry points downstream users hit first, but the per-cube recipes had **no import coverage**: `tests/test_recipe_imports.py` only globbed the top-level `recipes/`. An import typo or config-schema drift in `cubes/*/.../recipe.py` would surface only at next run.

## Changes

**`tests/test_recipe_imports.py`**
- **Discovery** — also glob in-cube recipes (`cubes/*/src/**/recipe.py` and `*_recipe.py`), so the gold-patch recipes get both guards: AST import-resolution + Experiment-build. Scoped to `src/` so helper scripts like `scripts/smoke/*_recipe.py` aren't mistaken for recipes.
- **Lazy builder support** — `test_recipe_defines_experiment` now executes the recipe as `__main__` with `run()` stubbed, capturing the experiments passed to `run()`. This covers the lazy `_exp()` pattern the gold recipes use to avoid creating output dirs at import time (they expose no module-level `Experiment`, so the old var-scan found nothing). Existing module-level recipes are still covered.

**`cubes/swebench-live-cube/scripts/smoke/gold_patch_recipe.py`** (new)
- Runs the recipe's local experiment over one known gold-solvable task (`cyclotruc__gitingest-94`, small repo) with no LLM, asserts the episode resolved (`reward >= 1.0`). Exercises the real downstream path: `Experiment` + `GoldPatchAgentConfig` + local Docker infra + `SWEBenchLiveTask.evaluate`.
- Follows the `scripts/smoke/` convention: prints `SMOKE OK/FAIL/SKIP`, exits 0/1/2. SKIPs cleanly when Docker or QEMU (which `LocalInfraConfig` provisions) is unavailable.

## CI behaviour

Consistent with the existing recipe guards: in `tests.yml` the workspace cubes aren't installed, so the in-cube recipes **skip** (no false failures). Local dev / any job with the cube installed asserts for real — which is where the live gold recipe now passes both guards.

## Verification

- `pytest tests/test_recipe_imports.py` → live gold recipe **PASSED** both guards; verified gold + uninstalled-cube recipes skip; smoke script correctly excluded. 0 failures.
- Smoke: SKIP paths verified (docker down → SKIP; docker up + qemu absent → SKIP). A full green run was blocked on this box because `brew install qemu` (LocalInfraConfig's dep) fails to build `vde` — an environment limit, not the recipe; the smoke drove the recipe correctly up to infra provisioning.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)