### PR TITLE
feat(auto-cube): headless outer-loop driver (ch-auto-cube)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ ch-trace = "cube_harness.analyze.trace:main"
 ch-investigate = "cube_harness.analyze.investigator:main"
 ch-investigation-report = "cube_harness.analyze.investigation_report:main"
 ch-reset-episodes = "cube_harness.analyze.reset_episodes:main"
+ch-auto-cube = "cube_harness.auto_cube.driver:main"
 
 [dependency-groups]
 dev = [

--- a/src/cube_harness/analyze/investigator/agent_driver.py
+++ b/src/cube_harness/analyze/investigator/agent_driver.py
@@ -164,6 +164,7 @@ class ClaudeCodeSDKDriver:
         permission_mode: Literal["bypassPermissions", "ask"] = "bypassPermissions",
         verbose: bool = False,
         trace_mode: TraceMode = "actions",
+        max_turns: int | None = None,
     ) -> DriverResult:
         try:
             from claude_agent_sdk import (
@@ -190,6 +191,7 @@ class ClaudeCodeSDKDriver:
             cwd=str(cwd),
             add_dirs=[str(p) for p in additional_dirs],
             model=model,
+            max_turns=max_turns,
             include_partial_messages=False,
         )
         if verbose:

--- a/src/cube_harness/auto_cube/__init__.py
+++ b/src/cube_harness/auto_cube/__init__.py
@@ -1,0 +1,6 @@
+"""Auto-CUBE outer-loop methodology and headless driver.
+
+The per-use-case methodology lives in ``use_cases/<name>/SKILL.md`` (loaded
+interactively by Claude Code, or headlessly as the system prompt by
+``driver.run_session``).
+"""

--- a/src/cube_harness/auto_cube/driver.py
+++ b/src/cube_harness/auto_cube/driver.py
@@ -1,0 +1,159 @@
+"""Headless launcher for the Auto-CUBE outer loop.
+
+Runs a use case's methodology — its ``SKILL.md``, used verbatim as the agent's
+system prompt — as a headless Claude Agent SDK session, mirroring how the
+Investigator runs per-episode analyses (it reuses the same
+``ClaudeCodeSDKDriver``). The orchestrator makes experiments by writing and
+running recipes via Bash (subprocess) — Python is the configuration.
+
+    ch-auto-cube --use-case hinter --objective "raise miniwob score on slider tasks"
+
+Each session is rooted at ``~/auto_cube/<session-id>/`` (``experiments/`` via
+``CH_EXP_DIR`` + ``journal/``). Re-run with the same ``--session-id`` to
+**resume**: the agent reads the existing journal and continues.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+if TYPE_CHECKING:
+    from cube_harness.analyze.investigator.agent_driver import DriverResult
+
+logger = logging.getLogger(__name__)
+
+USE_CASES_DIR = Path(__file__).parent / "use_cases"
+
+# Allowlist for the outer-loop orchestrator. Broader than the Investigator's
+# read-only set: it authors exp_config.py + journal entries (Write/Edit) and
+# runs experiments / git / gh / ch-investigate (Bash). Bash is intentionally
+# powerful — a headless session ships PRs and stands up infra.
+AUTO_CUBE_ALLOWED_TOOLS: tuple[str, ...] = ("Read", "Write", "Edit", "Bash", "Glob", "Grep")
+
+DEFAULT_MODEL = "claude-opus-4-7"
+# Safety cap on agent turns. The outer loop is long; a session that hits the
+# cap is resumed (same --session-id) rather than lost — the journal is the
+# checkpoint.
+DEFAULT_MAX_TURNS = 500
+
+
+def _auto_cube_root() -> Path:
+    return Path("~/auto_cube").expanduser()
+
+
+def load_system_prompt(use_case: str) -> str:
+    """Return a use case's ``SKILL.md`` verbatim — the agent's system prompt."""
+    skill = USE_CASES_DIR / use_case / "SKILL.md"
+    if not skill.is_file():
+        available = sorted(p.name for p in USE_CASES_DIR.iterdir() if (p / "SKILL.md").is_file())
+        raise FileNotFoundError(f"No SKILL.md for use case {use_case!r}; available: {available}")
+    return skill.read_text()
+
+
+def build_kickoff(use_case: str, objective: str, session_dir: Path, resume: bool) -> str:
+    """The user-turn that kicks off (or resumes) a session. The methodology
+    lives in the system prompt; this only frames the objective and paths."""
+    journal = session_dir / "journal"
+    experiments = session_dir / "experiments"
+    if resume:
+        return (
+            f"Resume the Auto-CUBE **{use_case}** session at `{session_dir}`.\n\n"
+            f"Read `{journal}/session.md` and the latest `round_<N>/notes.md`, then continue the "
+            f"methodology from where it left off toward this objective:\n\n{objective}\n\n"
+            f"Experiment output goes to `{experiments}` (CH_EXP_DIR is already exported); the "
+            f"journal lives at `{journal}`."
+        )
+    return (
+        f"Run an Auto-CUBE **{use_case}** session toward this objective:\n\n{objective}\n\n"
+        f"Session id: `{session_dir.name}`. Create `{journal}/session.md` from the template and "
+        f"work the methodology in your system prompt. Experiment output goes to `{experiments}` "
+        f"(CH_EXP_DIR is already exported); keep all journal artifacts under `{journal}`."
+    )
+
+
+def run_session(
+    *,
+    use_case: str,
+    objective: str,
+    session_id: str | None = None,
+    model: str = DEFAULT_MODEL,
+    max_turns: int = DEFAULT_MAX_TURNS,
+    cwd: Path | None = None,
+    verbose: bool = True,
+) -> "DriverResult":
+    """Launch (or resume) one headless Auto-CUBE session and return the result."""
+    # Lazy import: `cube_harness.analyze.*` eagerly pulls pandas/gradio, and the
+    # SDK itself is the optional `investigator` extra — keep this module import-light.
+    from cube_harness.analyze.investigator.agent_driver import ClaudeCodeSDKDriver
+
+    system_prompt = load_system_prompt(use_case)
+    session_id = session_id or f"{use_case}-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
+    session_dir = _auto_cube_root() / session_id
+    journal = session_dir / "journal"
+    experiments = session_dir / "experiments"
+    resume = (journal / "session.md").is_file()
+    journal.mkdir(parents=True, exist_ok=True)
+    experiments.mkdir(parents=True, exist_ok=True)
+
+    # Decision: experiments run as subprocesses; this exports CH_EXP_DIR so every
+    # run the agent launches lands in the session instead of ~/cube_harness_results/.
+    os.environ["CH_EXP_DIR"] = str(experiments)
+
+    cwd = Path(cwd) if cwd else Path.cwd()
+    kickoff = build_kickoff(use_case, objective, session_dir, resume)
+    logger.info(
+        "Auto-CUBE %s session %s (%s) — cwd=%s, model=%s",
+        use_case,
+        session_id,
+        "resume" if resume else "new",
+        cwd,
+        model,
+    )
+    driver = ClaudeCodeSDKDriver()
+    return asyncio.run(
+        driver.run(
+            system_prompt=system_prompt,
+            user_prompt=kickoff,
+            cwd=cwd,
+            additional_dirs=[session_dir],
+            model=model,
+            allowed_tools=AUTO_CUBE_ALLOWED_TOOLS,
+            permission_mode="bypassPermissions",
+            verbose=verbose,
+            max_turns=max_turns,
+        )
+    )
+
+
+def _main(
+    objective: str = typer.Option(..., "--objective", "-o", help="What this session should achieve."),
+    use_case: str = typer.Option("debug", "--use-case", "-u", help="Auto-CUBE use case (debug, hinter, ...)."),
+    session_id: str | None = typer.Option(None, "--session-id", help="Reuse to resume an existing session."),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Orchestrator model."),
+    max_turns: int = typer.Option(DEFAULT_MAX_TURNS, "--max-turns", help="Safety cap on turns; resume to continue."),
+    cwd: Path | None = typer.Option(None, "--cwd", help="Agent working dir (default: current dir)."),
+) -> None:
+    """Launch the Auto-CUBE outer loop headlessly via the Claude Agent SDK."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    result = run_session(
+        use_case=use_case,
+        objective=objective,
+        session_id=session_id,
+        model=model,
+        max_turns=max_turns,
+        cwd=cwd,
+    )
+    print(f"\nSession done — {result.duration_s:.0f}s, ${result.cost_usd:.2f}, {len(result.actions)} tool calls.")
+
+
+def main() -> None:
+    typer.run(_main)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auto_cube_driver.py
+++ b/tests/test_auto_cube_driver.py
@@ -1,0 +1,46 @@
+"""Tests for the Auto-CUBE headless driver — pure helpers, no SDK call.
+
+`driver.py` lazy-imports the SDK driver inside `run_session`, so importing this
+module (and these helpers) needs neither claude-agent-sdk nor the analyze extras.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cube_harness.auto_cube.driver import (
+    AUTO_CUBE_ALLOWED_TOOLS,
+    build_kickoff,
+    load_system_prompt,
+)
+
+
+def test_load_system_prompt_reads_debug_skill() -> None:
+    prompt = load_system_prompt("debug")
+    assert len(prompt) > 500
+    assert "session" in prompt.lower()
+
+
+def test_load_system_prompt_unknown_use_case_raises() -> None:
+    with pytest.raises(FileNotFoundError, match="No SKILL.md for use case 'nope'"):
+        load_system_prompt("nope")
+
+
+def test_allowlist_can_author_and_run() -> None:
+    # Broader than the read-only Investigator set: must author files and run experiments.
+    for tool in ("Read", "Write", "Edit", "Bash", "Glob", "Grep"):
+        assert tool in AUTO_CUBE_ALLOWED_TOOLS
+
+
+def test_kickoff_new_session_frames_objective_and_paths() -> None:
+    msg = build_kickoff("hinter", "raise the slider score", Path("/x/auto_cube/s1"), resume=False)
+    assert "raise the slider score" in msg
+    assert "s1" in msg
+    assert "Create" in msg
+    assert "CH_EXP_DIR" in msg
+
+
+def test_kickoff_resume_points_at_journal() -> None:
+    msg = build_kickoff("hinter", "raise the slider score", Path("/x/auto_cube/s1"), resume=True)
+    assert "Resume" in msg
+    assert "session.md" in msg


### PR DESCRIPTION
**Re-opening for review.** Same content as the previous #441, which was merged before review and reverted by #471 so we can iterate on it properly.

Originally landed as #441 (now reverted) — see the original PR body / commit `9bab0a23` for the full design rationale (SKILL.md as system prompt, recipe-via-Bash subprocess, per-session `~/auto_cube/` layout, resume via `--session-id`, `--max-turns`, tool allowlist, `max_turns` added to `ClaudeCodeSDKDriver`).

The follow-up #467 (terminal-default + `--driver` flag) will rebase onto this branch so it's the small delta on top of this driver, rather than carrying the full driver itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)