### PR TITLE
fix(storage): detect errored episodes via summary_stats (post-#454 follow-up)

### DIFF
--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -151,14 +151,6 @@ def _extract_tool_names(tools: list[dict]) -> list[str]:
     return names
 
 
-def _extract_error_type(trajectory: Trajectory) -> str | None:
-    """Return the error_type of the first StepError in the trajectory, or None."""
-    for step in trajectory.steps:
-        if hasattr(step.output, "error") and step.output.error is not None:
-            return step.output.error.error_type
-    return None
-
-
 # ---------------------------------------------------------------------------
 # Public models
 # ---------------------------------------------------------------------------

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -12,7 +12,7 @@ import zstandard
 from cube.core import EnvironmentOutput
 from pydantic import BaseModel
 
-from cube_harness.core import AgentOutput, Trajectory, TrajectoryStep
+from cube_harness.core import Trajectory, TrajectoryStep
 from cube_harness.episode_logs import get_log_path as get_episode_log_path
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus
@@ -478,11 +478,11 @@ class FileStorage:
                     summary = ExperimentSummary()
 
                 stats = trajectory.summary_stats or {}
-                has_error = any(
-                    hasattr(step.output, "error") and step.output.error is not None
-                    for step in trajectory.steps
-                    if isinstance(step.output, AgentOutput)
-                )
+                # trajectory.steps is empty post-stream refactor; the first step-level
+                # error_type is captured incrementally by SummaryProcessor and lives in
+                # summary_stats. Walking the (empty) step list here would have silently
+                # always reported no error.
+                has_error = bool(stats.get("error_type"))
 
                 summary.n_episodes += 1
                 if has_error:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -776,6 +776,36 @@ class TestSummaryStats:
         assert summary["total_prompt_tokens"] == 3000
         assert summary["total_cost"] == pytest.approx(0.15)
 
+    def test_experiment_summary_marks_error_via_summary_stats(self, tmp_dir: Path) -> None:
+        """Post-stream refactor, ``trajectory.steps`` is empty when the runner calls into
+        ``update_experiment_summary``. Error detection must read
+        ``summary_stats['error_type']`` (captured incrementally by SummaryProcessor) —
+        walking the in-memory step list would silently always report no error."""
+        storage = FileStorage(tmp_dir)
+        errored = Trajectory(
+            id="task_2_ep0",
+            metadata={"task_id": "task_2", "agent_name": "A"},
+            summary_stats={
+                "n_env_steps": 1,
+                "n_agent_steps": 1,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "cached_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cost": 0.0,
+                "final_reward": 0.0,
+                "error_type": "RuntimeError",
+            },
+            reward_info={"reward": 0.0},
+        )
+        storage.update_experiment_summary(errored)
+
+        with open(tmp_dir / "experiment_summary.json") as f:
+            summary = json.load(f)
+        assert summary["n_episodes"] == 1
+        assert summary["n_errored"] == 1
+        assert summary["n_completed"] == 0
+
 
 class TestNonNativeMetadataSerialization:
     """Regression guard for the Decimal serialization fix.


### PR DESCRIPTION
## Summary

Follow-up to #454. The stream refactor empties `Trajectory.steps` before the runner reaches
`storage.update_experiment_summary`, so the existing `has_error` walk over
`trajectory.steps` always returned `False` — `n_errored` in `experiment_summary.json` was
silently stuck at 0 (and `n_completed` was correspondingly inflated, biasing `avg_reward`).

## Fix

- **`storage.update_experiment_summary`**: read `has_error` from `summary_stats["error_type"]`
  (already captured incrementally by `SummaryProcessor`).
- **`eval_log._extract_error_type`**: remove (dead since #454; `EpisodeRecord.from_trajectory`
  already reads `summary_stats["error_type"]`).

## Test

New regression test
`tests/test_storage.py::TestSummaryStats::test_experiment_summary_marks_error_via_summary_stats`
is **RED before this fix, GREEN after** — proves the bug exists and the fix closes it.

Full fast suite **953 passed**; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
