### PR TITLE
feat(reproducibility): converters + CLIs for cube-registry journal + EEE

### DIFF
--- a/scripts/scan_experiments.py
+++ b/scripts/scan_experiments.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""scan_experiments.py — survey ``~/cube_harness_results/`` for journal-
+eligible experiments.
+
+For each direct child directory that contains an ``experiment_record.json``,
+the script classifies it into one of:
+
+  • already_submitted  — ``submissions.json`` already has a 'journal' decision
+  • broken             — cannot produce a meaningful submission (silent
+                          rejection persisted into ``submissions.json``)
+  • unfinished         — still running; state may change, re-scan later
+  • subset_review      — passed integrity but not a "complete named subset";
+                          requires ``--yes`` to submit
+  • submittable        — clean run of a full benchmark or a complete named
+                          subset; queue for submission
+
+Output: a markdown table + a one-line summary. With ``--submit`` it
+invokes ``submit_to_journal.py --auto-pr`` on each submittable run.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from cube_harness.reproducibility import submissions
+from cube_harness.reproducibility.scan import (
+    DEFAULT_SYSTEM_ERROR_THRESHOLD,
+    ScanCategory,
+    ScanResult,
+    walk,
+)
+
+DEFAULT_RESULTS_DIR = Path.home() / "cube_harness_results"
+
+_CATEGORY_ICON = {
+    ScanCategory.already_submitted: "✓",
+    ScanCategory.submittable: "→",
+    ScanCategory.subset_review: "?",
+    ScanCategory.unfinished: "…",
+    ScanCategory.broken: "✗",
+}
+
+
+def _format_table(results: list[ScanResult]) -> str:
+    """Compact markdown summary, one row per experiment."""
+    if not results:
+        return "(no experiment directories found)"
+    rows = [
+        ["", "experiment", "category", "subset", "n_tasks", "errors", "diagnosis"],
+        ["---"] * 7,
+    ]
+    for r in results:
+        subset = r.benchmark_subset_name
+        if r.benchmark_subset_filter:
+            subset += f" / {r.benchmark_subset_filter}"
+        if r.has_explicit_task_list:
+            subset += " [list]"
+        n_tasks_cell = ""
+        if r.n_tasks is not None:
+            n_tasks_cell = f"{r.n_terminal}/{r.n_tasks}"
+        err_cell = f"{r.n_system_error}" if r.n_terminal else ""
+        diagnosis = "; ".join(r.reasons) if r.reasons else "—"
+        rows.append(
+            [
+                _CATEGORY_ICON[r.category],
+                r.experiment_dir.name,
+                r.category.value,
+                subset or "—",
+                n_tasks_cell,
+                err_cell,
+                diagnosis,
+            ]
+        )
+    # Pad columns to align.
+    widths = [max(len(row[c]) for row in rows) for c in range(len(rows[0]))]
+    return "\n".join("| " + " | ".join(cell.ljust(w) for cell, w in zip(row, widths)) + " |" for row in rows)
+
+
+def _persist_broken_decisions(results: list[ScanResult]) -> int:
+    """Write submissions.json rejection entries for every broken experiment.
+
+    Returns the number of dirs newly stamped (those that already had a
+    decision are left alone)."""
+    n = 0
+    for r in results:
+        if r.category is not ScanCategory.broken:
+            continue
+        if submissions.has_decision(r.experiment_dir, "journal"):
+            continue
+        reason = r.reasons[0] if r.reasons else "unclassified"
+        submissions.record_rejected(r.experiment_dir, "journal", reason=f"broken: {reason}")
+        n += 1
+    return n
+
+
+def _invoke_submitter(
+    submit_to_journal: Path,
+    experiment_dir: Path,
+    *,
+    auto_pr: bool,
+    yes: bool,
+) -> int:
+    """Spawn ``submit_to_journal.py`` for one experiment dir. Returns its rc."""
+    cmd = [
+        sys.executable,
+        str(submit_to_journal),
+        str(experiment_dir),
+        "--i-understand-this-is-not-a-leaderboard",
+    ]
+    if auto_pr:
+        cmd.append("--auto-pr")
+    # `--yes` doesn't exist on submit_to_journal yet — for now the scan
+    # script's --yes only governs whether subset_review entries are forwarded.
+    _ = yes
+    typer.echo(f"  invoking: {' '.join(cmd)}")
+    return subprocess.run(cmd, check=False).returncode
+
+
+def main(
+    root: Annotated[
+        Path,
+        typer.Argument(help="Experiments root (default: ~/cube_harness_results)."),
+    ] = DEFAULT_RESULTS_DIR,
+    system_error_threshold: Annotated[
+        float,
+        typer.Option(
+            "--system-error-threshold",
+            help="Fraction of episodes that must hit FAILED/STALE/INVALID_CONFIG "
+            "before an experiment is marked broken. Default 0.10 (10%).",
+            min=0.0,
+            max=1.0,
+        ),
+    ] = DEFAULT_SYSTEM_ERROR_THRESHOLD,
+    submit: Annotated[
+        bool,
+        typer.Option(
+            "--submit",
+            help="Invoke submit_to_journal.py for each submittable experiment "
+            "(default: dry-run, just print the table).",
+        ),
+    ] = False,
+    auto_pr: Annotated[
+        bool,
+        typer.Option(
+            "--auto-pr",
+            help="When invoking submit_to_journal, pass --auto-pr through "
+            "(forks cube-registry and opens the PR via gh).",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Also submit experiments classified as subset_review (debug "
+            "runs / hand-picked task lists). Default: skip them.",
+        ),
+    ] = False,
+    persist_broken: Annotated[
+        bool,
+        typer.Option(
+            "--persist-broken/--no-persist-broken",
+            help="Write rejection entries to submissions.json for broken "
+            "experiments so future scans skip them. On by default.",
+        ),
+    ] = True,
+) -> None:
+    """Survey *root* and either report or hand off to the submitter."""
+    results = walk(root, system_error_threshold=system_error_threshold)
+    typer.echo(_format_table(results))
+
+    # Summary counts
+    counts: dict[ScanCategory, int] = {c: 0 for c in ScanCategory}
+    for r in results:
+        counts[r.category] += 1
+    typer.echo("")
+    typer.echo(" · ".join(f"{c.value}: {counts[c]}" for c in ScanCategory if counts[c] > 0) or "(nothing classifiable)")
+
+    if persist_broken:
+        n_stamped = _persist_broken_decisions(results)
+        if n_stamped:
+            typer.echo(f"persisted {n_stamped} broken decision(s) into submissions.json")
+
+    if not submit:
+        if counts[ScanCategory.submittable] or (yes and counts[ScanCategory.subset_review]):
+            typer.echo("")
+            typer.echo("Re-run with --submit to hand off to submit_to_journal.py.")
+        return
+
+    submit_to_journal = Path(__file__).with_name("submit_to_journal.py")
+    if not submit_to_journal.exists():
+        typer.echo(f"submit_to_journal.py not found at {submit_to_journal}", err=True)
+        raise typer.Exit(code=1)
+
+    eligible = [r for r in results if r.category is ScanCategory.submittable]
+    if yes:
+        eligible.extend(r for r in results if r.category is ScanCategory.subset_review)
+
+    if not eligible:
+        typer.echo("Nothing eligible to submit.")
+        return
+
+    typer.echo("")
+    typer.echo(f"Submitting {len(eligible)} experiment(s) …")
+    n_failed = 0
+    for r in eligible:
+        rc = _invoke_submitter(submit_to_journal, r.experiment_dir, auto_pr=auto_pr, yes=yes)
+        if rc != 0:
+            n_failed += 1
+            typer.echo(f"  ✗ {r.experiment_dir.name} (exit {rc})", err=True)
+    if n_failed:
+        raise typer.Exit(code=1)
+
+
+# `gh` and `shutil` are imported for the doc string + future expansion, keep
+# the linter happy until we wire them through.
+_ = shutil
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/scan_experiments.py
+++ b/scripts/scan_experiments.py
@@ -33,6 +33,7 @@ from cube_harness.reproducibility.scan import (
     DEFAULT_SYSTEM_ERROR_THRESHOLD,
     ScanCategory,
     ScanResult,
+    archive_experiment_dir,
     walk,
 )
 
@@ -169,9 +170,41 @@ def main(
             "experiments so future scans skip them. On by default.",
         ),
     ] = True,
+    sweep_stale: Annotated[
+        bool,
+        typer.Option(
+            "--sweep-stale/--no-sweep-stale",
+            help="Before classifying, reuse cube_harness.experiment.sweep_stale_statuses "
+            "to mark dead RUNNING/QUEUED episodes as STALE based on heartbeat age. "
+            "Catches experiments where Ray crashed mid-run. On by default — pass "
+            "--no-sweep-stale for a strictly read-only scan.",
+        ),
+    ] = True,
+    archive_broken: Annotated[
+        bool,
+        typer.Option(
+            "--archive-broken",
+            help="After scanning, rename every broken experiment dir to "
+            "<name>.archived_<ts> so future scans skip them and the results "
+            "root stays uncluttered. Uses the same ARCHIVED_MARKER convention "
+            "as FileStorage's per-episode archive.",
+        ),
+    ] = False,
+    archive_debug: Annotated[
+        bool,
+        typer.Option(
+            "--archive-debug",
+            help="Also archive experiments classified as subset_review (debug "
+            "runs / hand-picked task lists). Implies --archive-broken=True.",
+        ),
+    ] = False,
 ) -> None:
     """Survey *root* and either report or hand off to the submitter."""
-    results = walk(root, system_error_threshold=system_error_threshold)
+    results = walk(
+        root,
+        system_error_threshold=system_error_threshold,
+        sweep_stale=sweep_stale,
+    )
     typer.echo(_format_table(results))
 
     # Summary counts
@@ -186,7 +219,24 @@ def main(
         if n_stamped:
             typer.echo(f"persisted {n_stamped} broken decision(s) into submissions.json")
 
+    def _archive_pass() -> None:
+        """Rename broken (and optionally subset_review) dirs to .archived_<ts>."""
+        targets = [r for r in results if r.category is ScanCategory.broken]
+        if archive_debug:
+            targets.extend(r for r in results if r.category is ScanCategory.subset_review)
+        for r in targets:
+            try:
+                new_path = archive_experiment_dir(r.experiment_dir)
+                typer.echo(f"archived: {r.experiment_dir.name} -> {new_path.name}")
+            except Exception as e:
+                typer.echo(f"  ✗ archive failed for {r.experiment_dir.name}: {e}", err=True)
+
     if not submit:
+        # Archive only if we're not also submitting from this invocation —
+        # otherwise we'd rename dirs that submit_to_journal still has to
+        # touch. Re-run with --submit to actually push.
+        if archive_broken or archive_debug:
+            _archive_pass()
         if counts[ScanCategory.submittable] or (yes and counts[ScanCategory.subset_review]):
             typer.echo("")
             typer.echo("Re-run with --submit to hand off to submit_to_journal.py.")
@@ -213,6 +263,11 @@ def main(
         if rc != 0:
             n_failed += 1
             typer.echo(f"  ✗ {r.experiment_dir.name} (exit {rc})", err=True)
+    # Now safe to archive — submit_to_journal already read everything it needed
+    # from the broken/debug dirs (only broken get persisted-rejected; the
+    # submittable ones were eligible and won't be archived here).
+    if archive_broken or archive_debug:
+        _archive_pass()
     if n_failed:
         raise typer.Exit(code=1)
 

--- a/scripts/scan_experiments.py
+++ b/scripts/scan_experiments.py
@@ -20,7 +20,6 @@ invokes ``submit_to_journal.py --auto-pr`` on each submittable run.
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -105,9 +104,15 @@ def _invoke_submitter(
     experiment_dir: Path,
     *,
     auto_pr: bool,
-    yes: bool,
 ) -> int:
-    """Spawn ``submit_to_journal.py`` for one experiment dir. Returns its rc."""
+    """Spawn ``submit_to_journal.py`` for one experiment dir. Returns its rc.
+
+    The scan script's ``--yes`` controls eligibility upstream (whether
+    ``subset_review`` rows make it into the ``eligible`` list); the per-row
+    submission itself doesn't need to re-ask. submit_to_journal trusts the
+    classification that produced its argv and skips its own framing wall
+    via ``--i-understand-this-is-not-a-leaderboard``.
+    """
     cmd = [
         sys.executable,
         str(submit_to_journal),
@@ -116,9 +121,6 @@ def _invoke_submitter(
     ]
     if auto_pr:
         cmd.append("--auto-pr")
-    # `--yes` doesn't exist on submit_to_journal yet — for now the scan
-    # script's --yes only governs whether subset_review entries are forwarded.
-    _ = yes
     typer.echo(f"  invoking: {' '.join(cmd)}")
     return subprocess.run(cmd, check=False).returncode
 
@@ -259,7 +261,7 @@ def main(
     typer.echo(f"Submitting {len(eligible)} experiment(s) …")
     n_failed = 0
     for r in eligible:
-        rc = _invoke_submitter(submit_to_journal, r.experiment_dir, auto_pr=auto_pr, yes=yes)
+        rc = _invoke_submitter(submit_to_journal, r.experiment_dir, auto_pr=auto_pr)
         if rc != 0:
             n_failed += 1
             typer.echo(f"  ✗ {r.experiment_dir.name} (exit {rc})", err=True)
@@ -270,11 +272,6 @@ def main(
         _archive_pass()
     if n_failed:
         raise typer.Exit(code=1)
-
-
-# `gh` and `shutil` are imported for the doc string + future expansion, keep
-# the linter happy until we wire them through.
-_ = shutil
 
 
 if __name__ == "__main__":

--- a/scripts/submit_to_eee.py
+++ b/scripts/submit_to_eee.py
@@ -21,7 +21,8 @@ from typing import Annotated
 
 import typer
 
-from cube_harness.reproducibility.eee import build_eee_record
+from cube_harness.reproducibility import submissions
+from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
 
 
 def _eee_path(out_dir: Path, record: dict) -> Path:
@@ -55,8 +56,25 @@ def main(
             help="Root for the EEE-expected on-disk layout (data/<benchmark>/<dev>/<model>/<uuid>.json).",
         ),
     ] = Path("./eee-out"),
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Re-emit even when submissions.json already records an 'eee' decision.",
+        ),
+    ] = False,
 ) -> None:
     """Build an EEE record from a completed experiment and write it under <out-dir>/data/."""
+    if not force and submissions.has_decision(experiment_dir, "eee"):
+        prior = submissions.read(experiment_dir).get("eee", {})
+        typer.echo(
+            f"experiment_dir already has an 'eee' decision: {prior.get('status')} "
+            f"({prior.get('reason') or prior.get('evaluation_id')}).",
+            err=True,
+        )
+        typer.echo("Pass --force to override.", err=True)
+        raise typer.Exit(code=2)
+
     record = build_eee_record(
         experiment_dir,
         source_organization_name=submitter_org,
@@ -73,6 +91,13 @@ def main(
     typer.echo("")
     typer.echo("To submit upstream:")
     typer.echo(f"  huggingface-cli upload <hf-dataset-id> {target} {target.relative_to(out_dir)} --repo-type dataset")
+    submissions.record_submitted(
+        experiment_dir,
+        "eee",
+        evaluation_id=record["evaluation_id"],
+        schema_version=EEE_SCHEMA_VERSION,
+        local_path=str(target),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/submit_to_eee.py
+++ b/scripts/submit_to_eee.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""submit_to_eee.py — convert an experiment dir into an Every Eval Ever (EEE)
+record and write it to the EEE-expected on-disk layout
+(``data/{benchmark}/{developer}/{model}/{uuid}.json``).
+
+Pushing to the upstream HuggingFace dataset is left to the operator — V1 just
+materializes the JSON next to the experiment so it can be inspected and
+uploaded via ``huggingface-cli upload`` separately.
+
+Usage:
+  scripts/submit_to_eee.py <experiment_dir>
+  scripts/submit_to_eee.py <experiment_dir> --out-dir ~/eee-staging
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from cube_harness.reproducibility.eee import build_eee_record
+
+
+def _eee_path(out_dir: Path, record: dict) -> Path:
+    """Render the EEE-expected file path ``data/{benchmark}/{developer}/{model}/{uuid}.json``."""
+    benchmark = record["evaluation_results"][0]["evaluation_name"].split("[", 1)[0]
+    developer = record["model_info"].get("developer") or "unknown"
+    model = record["model_info"]["id"].replace("/", "__") or "unknown"
+    target_dir = out_dir / "data" / benchmark / developer / model
+    target_dir.mkdir(parents=True, exist_ok=True)
+    return target_dir / f"{uuid.uuid4().hex}.json"
+
+
+def main(
+    experiment_dir: Annotated[Path, typer.Argument(help="Path to the experiment output dir.")],
+    submitter_org: Annotated[
+        str,
+        typer.Option(
+            "--submitter-org",
+            help="Free-text identifier for the submitting organization "
+            "(shown in EEE's UI as source_metadata.source_organization_name).",
+        ),
+    ] = "cube-harness submitter",
+    submitter_url: Annotated[
+        str | None,
+        typer.Option("--submitter-url", help="Optional URL for the submitter org."),
+    ] = None,
+    out_dir: Annotated[
+        Path,
+        typer.Option(
+            "--out-dir",
+            help="Root for the EEE-expected on-disk layout (data/<benchmark>/<dev>/<model>/<uuid>.json).",
+        ),
+    ] = Path("./eee-out"),
+) -> None:
+    """Build an EEE record from a completed experiment and write it under <out-dir>/data/."""
+    record = build_eee_record(
+        experiment_dir,
+        source_organization_name=submitter_org,
+        source_organization_url=submitter_url,
+    )
+    target = _eee_path(out_dir, record)
+    target.write_text(json.dumps(record, indent=2) + "\n")
+    typer.echo(f"wrote: {target}")
+    typer.echo(
+        f"  {record['evaluation_results'][0]['evaluation_name']} · "
+        f"{record['model_info']['id']} · "
+        f"score={record['evaluation_results'][0]['score_details']['score']:.3f}"
+    )
+    typer.echo("")
+    typer.echo("To submit upstream:")
+    typer.echo(f"  huggingface-cli upload <hf-dataset-id> {target} {target.relative_to(out_dir)} --repo-type dataset")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -32,6 +32,7 @@ from cube_harness.reproducibility import (
     JOURNAL_SCHEMA_VERSION,
     build_journal_record,
     sanitize_filename,
+    submissions,
 )
 
 CUBE_REGISTRY_REPO = "The-AI-Alliance/cube-registry"
@@ -230,6 +231,14 @@ def main(
             help="Clone cube-registry, commit the record on a fresh branch, push, and open the PR via gh.",
         ),
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Re-submit even when submissions.json already records a 'journal' decision "
+            "(default: refuse to avoid duplicate submissions).",
+        ),
+    ] = False,
     i_understand_this_is_not_a_leaderboard: Annotated[
         bool,
         typer.Option(
@@ -240,6 +249,19 @@ def main(
     ] = False,
 ) -> None:
     """Build a cube-registry community-journal record and (optionally) open a PR."""
+    # Idempotency check first — refuse early before showing the framing wall
+    # or building the record. Use --force to override (e.g. for re-submission
+    # after a correction).
+    if not force and submissions.has_decision(experiment_dir, "journal"):
+        prior = submissions.read(experiment_dir).get("journal", {})
+        typer.echo(
+            f"experiment_dir already has a 'journal' decision: {prior.get('status')} "
+            f"({prior.get('reason') or prior.get('evaluation_id')}).",
+            err=True,
+        )
+        typer.echo("Pass --force to override.", err=True)
+        raise typer.Exit(code=2)
+
     _confirm_not_a_leaderboard(acknowledged=i_understand_this_is_not_a_leaderboard)
     submitter = submitter or _git_user_handle()
     typer.echo(f"submitter: {submitter}")
@@ -267,6 +289,18 @@ def main(
     branch = f"results/{record['benchmark_name']}/{sanitize_filename(record['evaluation_id'])}"
     pr_url = _open_pr(target_path, record, branch)
     typer.echo(f"PR opened: {pr_url}")
+    # Stamp idempotency so a repeat invocation (or the scan script) sees that
+    # this experiment has already been submitted to the journal.
+    submissions.record_submitted(
+        experiment_dir,
+        "journal",
+        evaluation_id=record["evaluation_id"],
+        schema_version=record["schema_version"],
+        submitted_by=submitter,
+        pr_url=pr_url,
+        local_path=str(target_path),
+    )
+    typer.echo(f"recorded in {experiment_dir / submissions.SUBMISSIONS_FILENAME}")
 
 
 if __name__ == "__main__":

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""submit_to_journal.py — convert an experiment dir into a cube-registry
+community-journal record and (optionally) open a PR against cube-registry.
+
+Usage:
+  scripts/submit_to_journal.py <experiment_dir>
+  scripts/submit_to_journal.py <experiment_dir> --auto-pr
+
+Without ``--auto-pr`` the script writes the JSON to
+``./journal-out/results/<cube>/<file>.json`` and prints the ``gh`` command you
+can run to open the PR by hand. With ``--auto-pr``, it clones cube-registry to
+``/tmp``, creates a branch, copies the file in, commits, pushes, and opens the
+PR via ``gh``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from cube_harness.reproducibility import (
+    JOURNAL_SCHEMA_VERSION,
+    build_journal_record,
+    sanitize_filename,
+)
+
+CUBE_REGISTRY_REPO = "The-AI-Alliance/cube-registry"
+CUBE_REGISTRY_URL = f"https://github.com/{CUBE_REGISTRY_REPO}.git"
+
+
+def _git_user_handle() -> str:
+    """Best-effort GitHub handle: ``GIT_AUTHOR_NAME`` env > ``git config user.name``."""
+    env = os.environ.get("GIT_AUTHOR_NAME") or os.environ.get("USER")
+    if env:
+        return env
+    try:
+        out = subprocess.check_output(["git", "config", "user.name"], text=True, stderr=subprocess.DEVNULL)
+        return out.strip() or "submitter"
+    except subprocess.CalledProcessError:
+        return "submitter"
+
+
+def _write_record(record: dict, out_root: Path) -> Path:
+    cube_id = record["benchmark_name"]
+    eid = record["evaluation_id"]
+    target_dir = out_root / "results" / cube_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / f"{sanitize_filename(eid)}.json"
+    target_path.write_text(json.dumps(record, indent=2) + "\n")
+    return target_path
+
+
+def _open_pr(record_path: Path, record: dict, branch: str) -> str:
+    """Clone cube-registry to a temp dir, copy *record_path* in, push, gh pr create."""
+    with tempfile.TemporaryDirectory(prefix="cube-registry-submit-") as tmp:
+        clone_dir = Path(tmp) / "cube-registry"
+        subprocess.run(
+            ["git", "clone", "--depth", "1", CUBE_REGISTRY_URL, str(clone_dir)],
+            check=True,
+        )
+        subprocess.run(["git", "-C", str(clone_dir), "checkout", "-b", branch], check=True)
+        # Copy the record into the clone at the expected path.
+        cube_id = record["benchmark_name"]
+        dst_dir = clone_dir / "results" / cube_id
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst_path = dst_dir / record_path.name
+        shutil.copyfile(record_path, dst_path)
+        subprocess.run(
+            ["git", "-C", str(clone_dir), "add", str(dst_path.relative_to(clone_dir))],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(clone_dir),
+                "commit",
+                "-s",
+                "-m",
+                f"results: add {record['evaluation_id']}",
+            ],
+            check=True,
+        )
+        subprocess.run(["git", "-C", str(clone_dir), "push", "-u", "origin", branch], check=True)
+        title = f"results: {record['benchmark_name']} — {record['agent']['llm_model']}"
+        body = (
+            f"Adds one community evaluation result for `{record['benchmark_name']}`.\n\n"
+            f"- agent: `{record['agent']['config_type']}` on `{record['agent']['llm_model']}`\n"
+            f"- score: **{record['results']['avg_score']:.3f}** "
+            f"± {record['results']['std_err']:.3f}\n"
+            f"- subset: `{record['benchmark_subset']['name']}` "
+            f"({record['benchmark_subset']['n_tasks']} tasks)\n"
+            f"- outcomes: {record['results']['outcomes']}\n\n"
+            f"_Submitted via cube-harness `scripts/submit_to_journal.py`._"
+        )
+        pr = subprocess.check_output(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                CUBE_REGISTRY_REPO,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            text=True,
+            cwd=clone_dir,
+        ).strip()
+        return pr
+
+
+def main(
+    experiment_dir: Annotated[Path, typer.Argument(help="Path to the experiment output dir.")],
+    submitter: Annotated[
+        str | None,
+        typer.Option(
+            "--submitter",
+            help="GitHub handle for the evaluation_id namespace (defaults to git config user.name).",
+        ),
+    ] = None,
+    cube_id: Annotated[
+        str | None,
+        typer.Option(
+            "--cube-id",
+            help="Override the cube id when it differs from the benchmark name "
+            "(e.g. 'miniwob[level=all]' is benchmark_name; cube-id is 'miniwob').",
+        ),
+    ] = None,
+    out_dir: Annotated[
+        Path,
+        typer.Option(
+            "--out-dir",
+            help="Local output directory. The file is written under <out-dir>/results/<cube>/.",
+        ),
+    ] = Path("./journal-out"),
+    auto_pr: Annotated[
+        bool,
+        typer.Option(
+            "--auto-pr",
+            help="Clone cube-registry, commit the record on a fresh branch, push, and open the PR via gh.",
+        ),
+    ] = False,
+) -> None:
+    """Build a cube-registry community-journal record and (optionally) open a PR."""
+    submitter = submitter or _git_user_handle()
+    typer.echo(f"submitter: {submitter}")
+    typer.echo(f"experiment_dir: {experiment_dir}")
+
+    record = build_journal_record(experiment_dir, submitter=submitter, cube_id=cube_id)
+    assert record["schema_version"] == JOURNAL_SCHEMA_VERSION
+    target_path = _write_record(record, out_dir)
+    typer.echo(f"wrote: {target_path}")
+    typer.echo(
+        f"  {record['benchmark_name']} v{record['benchmark_version']} · "
+        f"{record['agent']['config_type']} / {record['agent']['llm_model']} · "
+        f"score={record['results']['avg_score']:.3f}"
+    )
+
+    if not auto_pr:
+        typer.echo("")
+        typer.echo("To submit by hand:")
+        typer.echo("  1. Fork https://github.com/The-AI-Alliance/cube-registry and clone it locally.")
+        typer.echo(f"  2. Copy {target_path} into <clone>/results/{record['benchmark_name']}/")
+        typer.echo("  3. Commit (with -s) and open a PR — CI will validate + auto-merge.")
+        typer.echo("Or re-run with --auto-pr.")
+        return
+
+    branch = f"results/{record['benchmark_name']}/{sanitize_filename(record['evaluation_id'])}"
+    pr_url = _open_pr(target_path, record, branch)
+    typer.echo(f"PR opened: {pr_url}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Annotated
@@ -33,6 +34,56 @@ from cube_harness.reproducibility import (
 
 CUBE_REGISTRY_REPO = "The-AI-Alliance/cube-registry"
 CUBE_REGISTRY_URL = f"https://github.com/{CUBE_REGISTRY_REPO}.git"
+
+# The framing wall — every code path that produces a journal record sees this
+# before any actual work happens. Mirrors the amber callout rendered on each
+# cube's registry page. Edit both at the same time if you change the wording.
+_LEADERBOARD_DISCLAIMER = """\
+╔══════════════════════════════════════════════════════════════════════════╗
+║  REPRODUCIBILITY JOURNAL  —  NOT A LEADERBOARD                            ║
+╠══════════════════════════════════════════════════════════════════════════╣
+║                                                                          ║
+║  You're about to submit an evaluation result to the cube-registry        ║
+║  community journal.                                                      ║
+║                                                                          ║
+║  This is for publishing REFERENCE values — to let others detect drift    ║
+║  across infrastructures, cube versions, and package versions.            ║
+║                                                                          ║
+║  This is NOT a place to publish a new agent or fine-tune to "win" the    ║
+║  benchmark. There is no ranking. Submissions are self-reported and       ║
+║  not independently verified.                                             ║
+║                                                                          ║
+║  Want to showcase a new agent or model? Use ATLAS / EEE / your own       ║
+║  benchmark page instead.                                                 ║
+║                                                                          ║
+╚══════════════════════════════════════════════════════════════════════════╝
+"""
+
+
+def _confirm_not_a_leaderboard(*, acknowledged: bool) -> None:
+    """Show the framing wall and require explicit confirmation.
+
+    The framing matters more than the data — the registry journal's value
+    depends on submitters understanding it's not a competition. *acknowledged*
+    is true when the caller passed ``--i-understand-this-is-not-a-leaderboard``
+    (skips the prompt; the flag name is itself the friction). On a non-TTY
+    stdin (CI / pipes / nohup), refuse without that flag rather than auto-
+    answering yes — accidental scripted submissions would defeat the point.
+    """
+    typer.echo(_LEADERBOARD_DISCLAIMER)
+    if acknowledged:
+        typer.echo("Acknowledgement flag set — proceeding.")
+        return
+    if not sys.stdin.isatty():
+        typer.echo(
+            "Non-interactive stdin and no --i-understand-this-is-not-a-leaderboard flag — refusing.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    answer = typer.prompt("Continue with submission? [y/N]", default="N", show_default=False)
+    if answer.strip().lower() not in {"y", "yes"}:
+        typer.echo("Aborted — no record written.")
+        raise typer.Exit(code=1)
 
 
 def _git_user_handle() -> str:
@@ -149,8 +200,17 @@ def main(
             help="Clone cube-registry, commit the record on a fresh branch, push, and open the PR via gh.",
         ),
     ] = False,
+    i_understand_this_is_not_a_leaderboard: Annotated[
+        bool,
+        typer.Option(
+            "--i-understand-this-is-not-a-leaderboard",
+            help="Acknowledge the framing wall and skip the interactive prompt. "
+            "The flag name is deliberately verbose — reading it IS the friction.",
+        ),
+    ] = False,
 ) -> None:
     """Build a cube-registry community-journal record and (optionally) open a PR."""
+    _confirm_not_a_leaderboard(acknowledged=i_understand_this_is_not_a_leaderboard)
     submitter = submitter or _git_user_handle()
     typer.echo(f"submitter: {submitter}")
     typer.echo(f"experiment_dir: {experiment_dir}")

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -8,9 +8,11 @@ Usage:
 
 Without ``--auto-pr`` the script writes the JSON to
 ``./journal-out/results/<cube>/<file>.json`` and prints the ``gh`` command you
-can run to open the PR by hand. With ``--auto-pr``, it clones cube-registry to
-``/tmp``, creates a branch, copies the file in, commits, pushes, and opens the
-PR via ``gh``.
+can run to open the PR by hand. With ``--auto-pr``, it forks cube-registry
+(via ``gh repo fork``, idempotent — gh reuses an existing fork), clones the
+fork to ``/tmp``, creates a branch, copies the file in, commits, pushes to
+the fork, and opens the PR against the upstream repo. Works for any GitHub
+user, not just members of The-AI-Alliance org.
 """
 
 from __future__ import annotations
@@ -109,15 +111,38 @@ def _write_record(record: dict, out_root: Path) -> Path:
 
 
 def _open_pr(record_path: Path, record: dict, branch: str) -> str:
-    """Clone cube-registry to a temp dir, copy *record_path* in, push, gh pr create."""
+    """Fork cube-registry, copy *record_path* into the fork, push, gh pr create.
+
+    Uses ``gh repo fork --clone`` so this works for any GitHub user, not just
+    members of The-AI-Alliance org. The fork is idempotent — gh detects an
+    existing user fork and reuses it. After the clone, ``origin`` points at
+    the user's fork and ``upstream`` at the canonical repo; we push to
+    ``origin`` and open the PR against ``upstream``.
+    """
     with tempfile.TemporaryDirectory(prefix="cube-registry-submit-") as tmp:
         clone_dir = Path(tmp) / "cube-registry"
+        # `gh repo fork --clone --remote` forks (if needed) and clones into
+        # the cwd's subdirectory. We feed it the parent and let gh pick the
+        # directory name. Quiet output keeps the user-visible echo clean.
         subprocess.run(
-            ["git", "clone", "--depth", "1", CUBE_REGISTRY_URL, str(clone_dir)],
+            [
+                "gh",
+                "repo",
+                "fork",
+                CUBE_REGISTRY_REPO,
+                "--clone",
+                "--remote",
+                "--clone-flags=--depth=1",
+            ],
+            cwd=tmp,
             check=True,
         )
+        # gh names the directory after the repo basename ("cube-registry").
+        # The created remotes are `origin` (the fork) and `upstream` (canonical).
+        if not clone_dir.exists():
+            raise FileNotFoundError(f"expected `gh repo fork` to create {clone_dir}; got {list(Path(tmp).iterdir())}")
+
         subprocess.run(["git", "-C", str(clone_dir), "checkout", "-b", branch], check=True)
-        # Copy the record into the clone at the expected path.
         cube_id = record["benchmark_name"]
         dst_dir = clone_dir / "results" / cube_id
         dst_dir.mkdir(parents=True, exist_ok=True)
@@ -139,7 +164,9 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
             ],
             check=True,
         )
+        # Push to the *fork* (origin). The canonical repo is `upstream`.
         subprocess.run(["git", "-C", str(clone_dir), "push", "-u", "origin", branch], check=True)
+
         title = f"results: {record['benchmark_name']} — {record['agent']['llm_model']}"
         body = (
             f"Adds one community evaluation result for `{record['benchmark_name']}`.\n\n"
@@ -151,6 +178,9 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
             f"- outcomes: {record['results']['outcomes']}\n\n"
             f"_Submitted via cube-harness `scripts/submit_to_journal.py`._"
         )
+        # `gh pr create` from inside the fork clone defaults to opening the PR
+        # against the parent (upstream) repo. We pass --repo explicitly to
+        # make the target unambiguous.
         pr = subprocess.check_output(
             [
                 "gh",

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -425,6 +425,15 @@ class BenchmarkSubset(TypedBaseModel):
         default=None,
         description="Glob expression if the subset was created via subset_from_glob.",
     )
+    task_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Explicit task list when the subset was constructed via subset_from_list. "
+            "Hand-picked subsets without a natural name don't make good reproducibility "
+            "reference points — the journal-eligibility scan flags them as subset_review. "
+            "None when the subset was built from a filter or is the full benchmark."
+        ),
+    )
 
     @classmethod
     def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset":
@@ -577,6 +586,16 @@ class ExperimentRecord(TypedBaseModel):
     benchmark_name: str = Field(description="Benchmark name from benchmark_metadata.name.")
     benchmark_version: str | None = Field(default=None, description="Benchmark version string.")
     benchmark_subset: BenchmarkSubset = Field(description="Subset descriptor for MNAR propensity correction.")
+    debug_limit: int | None = Field(
+        default=None,
+        description=(
+            "If set, the runner truncated the task list to the first N entries at run time. "
+            "Surfaced for downstream tooling — the reproducibility-journal scan script uses "
+            "this signal to flag debug runs as non-submittable without re-reading the full "
+            "ExperimentConfig. None means: no truncation was applied (or the recipe used a "
+            "code path that didn't propagate the value into the record)."
+        ),
+    )
     investigator_llm_config: InvestigatorLLMConfig | None = Field(
         default=None,
         description="Investigator configuration if a post-hoc LLM investigator was run on these episodes.",
@@ -590,6 +609,7 @@ class ExperimentRecord(TypedBaseModel):
         agent_config: Any,
         benchmark_config: BenchmarkConfig,
         git_cwd: str | None = None,
+        debug_limit: int | None = None,
     ) -> "ExperimentRecord":
         """Build ExperimentRecord from experiment parameters."""
         harness_version = _get_package_version("cube-harness") or "unknown"
@@ -607,6 +627,7 @@ class ExperimentRecord(TypedBaseModel):
             benchmark_name=bm_name,
             benchmark_version=bm_version,
             benchmark_subset=BenchmarkSubset.from_benchmark_config(benchmark_config),
+            debug_limit=debug_limit,
         )
 
     def write(self, output_dir: Path) -> None:

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -53,21 +53,41 @@ EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
 # walk in _imported_distributions() misses them. The walker is the primary
 # capture mechanism — this list is a small backstop for the harness invariants
 # every run must surface.
-_ALWAYS_INCLUDE_DEPENDENCIES: frozenset[str] = frozenset({"cube-harness", "cube"})
+# The installed distribution name for cube-standard is "cube-standard", NOT
+# "cube" (the import is `import cube` but `importlib.metadata.version("cube")`
+# raises PackageNotFoundError). Using the wrong name silently dropped
+# cube-standard from every recorded `dependency_versions` — direct PS-001
+# violation, since cube-standard's contracts are the most consequential
+# dependency in the whole system.
+_ALWAYS_INCLUDE_DEPENDENCIES: frozenset[str] = frozenset({"cube-harness", "cube-standard"})
 
 # Distributions whose version drift is most likely to swing scores — surfaced
 # prominently by downstream UIs (journal, EEE) instead of being buried in the
 # full list. Subset of what gets recorded; never used for filtering.
 _PRIMARY_DEPENDENCIES: frozenset[str] = frozenset(
     {
+        # Core (note: distribution is "cube-standard", not "cube" — see
+        # _ALWAYS_INCLUDE_DEPENDENCIES above).
         "cube-harness",
-        "cube",
+        "cube-standard",
+        "pydantic",
+        # LLM gateway + provider SDKs — silent retry/streaming changes here
+        # swing benchmark scores even at fixed prompts.
         "litellm",
         "openai",
         "anthropic",
+        # HTTP stack — version drift in retry/timeout/connection-pool behavior
+        # changes LLM-call success rates under flaky upstreams (well-documented
+        # in cube-harness's own session notes, e.g. tbench2-daytona-r0).
+        "httpx",
+        "urllib3",
+        "tenacity",
+        # Tokenization (affects context-window decisions, sometimes scoring).
         "tiktoken",
         "tokenizers",
-        "pydantic",
+        # Env runtimes — these only land in primary for the cubes that
+        # actually import them (set intersection with the recorded versions),
+        # so no false positives for non-browser/non-gym runs.
         "playwright",
         "browsergym-core",
         "gymnasium",
@@ -336,7 +356,7 @@ class AgentInfo(TypedBaseModel):
         description=(
             "Git SHA-1 of the installed cube-standard (`cube`) package's repo HEAD. Populated only "
             "when cube-standard is an editable/source checkout (the common case while it tracks an "
-            "unreleased branch); None for a released wheel — use dependency_versions['cube'] then."
+            "unreleased branch); None for a released wheel — use dependency_versions['cube-standard'] then."
         ),
     )
     cube_standard_git_is_dirty: bool | None = Field(

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -30,6 +30,7 @@ import json
 import logging
 import re
 import subprocess
+import sys
 import time
 from enum import Enum
 from pathlib import Path
@@ -48,17 +49,81 @@ logger = logging.getLogger(__name__)
 EPISODE_RECORD_FILENAME = "episode_record.json"
 EXPERIMENT_RECORD_FILENAME = "experiment_record.json"
 
-_TRACKED_PACKAGES: list[str] = [
-    "cube-harness",
-    "cube",
-    "litellm",
-    "anthropic",
-    "openai",
-    "browsergym-core",
-    "playwright",
-    "pydantic",
-    "ray",
-]
+# Distributions that are always recorded when present, even if the sys.modules
+# walk in _imported_distributions() misses them. The walker is the primary
+# capture mechanism — this list is a small backstop for the harness invariants
+# every run must surface.
+_ALWAYS_INCLUDE_DEPENDENCIES: frozenset[str] = frozenset({"cube-harness", "cube"})
+
+# Distributions whose version drift is most likely to swing scores — surfaced
+# prominently by downstream UIs (journal, EEE) instead of being buried in the
+# full list. Subset of what gets recorded; never used for filtering.
+_PRIMARY_DEPENDENCIES: frozenset[str] = frozenset(
+    {
+        "cube-harness",
+        "cube",
+        "litellm",
+        "openai",
+        "anthropic",
+        "tiktoken",
+        "tokenizers",
+        "pydantic",
+        "playwright",
+        "browsergym-core",
+        "gymnasium",
+    }
+)
+
+# Behaviorally-inert plumbing imported by ~half the Python ecosystem. Dropped
+# from the dep capture so the recorded set stays roughly 45 packages instead
+# of 80 — and so manual readers can find the deps that actually matter. Each
+# category-comment justifies why dropping is safe; revisit if a future
+# reproducibility failure points back at one of these.
+_AUTO_DROP_DEPENDENCIES: frozenset[str] = frozenset(
+    {
+        # typing & data-structure helpers — API stable, no runtime behavior
+        "annotated-types",
+        "attrs",
+        "frozenlist",
+        "multidict",
+        "propcache",
+        "rpds-py",
+        "typing_extensions",
+        "typing-inspection",
+        # terminal display only — irrelevant to recorded scores
+        "rich",
+        "Pygments",
+        "termcolor",
+        "MarkupSafe",
+        "click",
+        "tqdm",
+        # encoding / file plumbing — deterministic, version-stable
+        "certifi",
+        "charset-normalizer",
+        "idna",
+        "brotli",
+        "zstandard",
+        "zipp",
+        "filelock",
+        "distro",
+        # tiny utilities, no behavioral surface
+        "aiohappyeyeballs",
+        "aiosignal",
+        "sniffio",
+        "importlib_metadata",
+        "packaging",
+        # identity / parsing helpers
+        "pyparsing",
+        "docstring_parser",
+        "fastuuid",
+        "yarl",
+        "Farama-Notifications",
+        # duplicates a primary signal / no critical-path use
+        "pydantic_core",
+        "msgpack",
+        "python-dotenv",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -73,9 +138,43 @@ def _get_package_version(name: str) -> str | None:
         return None
 
 
-def _collect_dependency_versions() -> dict[str, str]:
-    """Return installed versions for all tracked packages that are present."""
-    return {pkg: v for pkg in _TRACKED_PACKAGES if (v := _get_package_version(pkg)) is not None}
+def _imported_distributions() -> set[str]:
+    """Distributions whose top-level module is currently in ``sys.modules``.
+
+    The idea: a package whose code was never imported into the experiment's
+    process cannot have affected the recorded score, so it's not worth
+    capturing. The dep capture happens at ``Experiment.save_config()`` time,
+    *after* the recipe has imported its agent / benchmark / tools at module
+    level — so the typical set is ~80 distributions.
+
+    Returns an empty set on any introspection failure rather than raising —
+    losing the dep capture is non-fatal.
+    """
+    try:
+        top_level = {name.split(".", 1)[0] for name in sys.modules if not name.startswith("_")}
+        pkg_to_dist = importlib.metadata.packages_distributions()
+        return {dist for mod in top_level for dist in pkg_to_dist.get(mod, [])}
+    except Exception:
+        return set()
+
+
+def _collect_dependency_versions() -> tuple[dict[str, str], list[str]]:
+    """Return ``(versions, primary_names)`` for the currently-loaded distributions.
+
+    ``versions``: imported distributions (from :func:`_imported_distributions`)
+    plus the always-include backstop, minus the auto-drop list. Sorted by name
+    for stable JSON.
+
+    ``primary_names``: subset present in :data:`_PRIMARY_DEPENDENCIES` — the
+    version-drift hotspots UIs render prominently.
+    """
+    candidates = (_imported_distributions() | _ALWAYS_INCLUDE_DEPENDENCIES) - _AUTO_DROP_DEPENDENCIES
+    versions: dict[str, str] = {}
+    for name in sorted(candidates):
+        if (v := _get_package_version(name)) is not None:
+            versions[name] = v
+    primary = sorted(set(versions) & _PRIMARY_DEPENDENCIES)
+    return versions, primary
 
 
 def _to_github_url(remote_url: str, commit: str) -> str | None:
@@ -206,7 +305,19 @@ class AgentInfo(TypedBaseModel):
     framework_version: str = Field(description="cube-harness version at eval time.")
     dependency_versions: dict[str, str] = Field(
         default_factory=dict,
-        description="Installed versions of tracked packages (cube-harness, litellm, anthropic, openai, ...).",
+        description=(
+            "Installed versions of every distribution imported into the experiment's process "
+            "at eval time, minus a curated drop-list of behaviorally-inert plumbing. See "
+            "_AUTO_DROP_DEPENDENCIES + _PRIMARY_DEPENDENCIES in eval_log.py for the rationale."
+        ),
+    )
+    primary_dependencies: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Subset of dependency_versions whose version drift most directly affects scores "
+            "(LLM gateway + provider SDKs, tokenizers, env runtimes, schema validation). Surfaced "
+            "prominently by downstream UIs; the full set stays in dependency_versions."
+        ),
     )
     git_commit: str | None = Field(default=None, description="Git SHA-1 of the repo HEAD at eval time.")
     git_remote_url: str | None = Field(
@@ -262,13 +373,16 @@ class AgentInfo(TypedBaseModel):
         cube_standard_dir = str(Path(cube.__file__).resolve().parent)
         cube_standard_git_commit, _, cube_standard_git_is_dirty = _get_git_info(cwd=cube_standard_dir)
 
+        dependency_versions, primary_dependencies = _collect_dependency_versions()
+
         return cls(
             agent_id=agent_id,
             config_type=config_type,
             config=config_dict,
             llm_model=llm_model,
             framework_version=harness_version,
-            dependency_versions=_collect_dependency_versions(),
+            dependency_versions=dependency_versions,
+            primary_dependencies=primary_dependencies,
             git_commit=git_commit,
             git_remote_url=git_remote_url,
             git_is_dirty=git_is_dirty,

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -99,6 +99,13 @@ _PRIMARY_DEPENDENCIES: frozenset[str] = frozenset(
 # of 80 — and so manual readers can find the deps that actually matter. Each
 # category-comment justifies why dropping is safe; revisit if a future
 # reproducibility failure points back at one of these.
+#
+# Public alias `AUTO_DROP_DEPENDENCIES` is exported below so cube authors can
+# guard their critical deps in a smoke test, e.g.:
+#
+#     from cube_harness.eval_log import AUTO_DROP_DEPENDENCIES
+#     assert "filelock" not in AUTO_DROP_DEPENDENCIES, "my cube needs filelock"
+#
 _AUTO_DROP_DEPENDENCIES: frozenset[str] = frozenset(
     {
         # typing & data-structure helpers — API stable, no runtime behavior
@@ -144,6 +151,11 @@ _AUTO_DROP_DEPENDENCIES: frozenset[str] = frozenset(
         "python-dotenv",
     }
 )
+
+# Public alias for cube-author introspection. Keep the underscore-prefixed
+# name as the load-bearing identifier inside this module (every existing
+# call site uses it); the public name is a thin re-export.
+AUTO_DROP_DEPENDENCIES = _AUTO_DROP_DEPENDENCIES
 
 
 # ---------------------------------------------------------------------------
@@ -327,8 +339,14 @@ class AgentInfo(TypedBaseModel):
         default_factory=dict,
         description=(
             "Installed versions of every distribution imported into the experiment's process "
-            "at eval time, minus a curated drop-list of behaviorally-inert plumbing. See "
-            "_AUTO_DROP_DEPENDENCIES + _PRIMARY_DEPENDENCIES in eval_log.py for the rationale."
+            "at eval time, minus a curated drop-list of behaviorally-inert plumbing. "
+            "Captured at ExperimentRecord build time (Experiment.save_config), which runs "
+            "BEFORE any episode — so distributions only imported lazily during run-time "
+            "(e.g. `import torch` inside a tool's execute()) won't be in sys.modules yet "
+            "and are silently missed. Cube authors who rely on lazy imports should either "
+            "promote them to module-level or add the distribution to "
+            "_ALWAYS_INCLUDE_DEPENDENCIES in cube_harness.eval_log. See _AUTO_DROP_DEPENDENCIES "
+            "+ _PRIMARY_DEPENDENCIES in the same module for the curated allow/deny lists."
         ),
     )
     primary_dependencies: list[str] = Field(

--- a/src/cube_harness/exp_runner.py
+++ b/src/cube_harness/exp_runner.py
@@ -20,7 +20,12 @@ from cube_harness.core import Trajectory
 from cube_harness.episode import Episode
 from cube_harness.episode_logs import LOG_FORMAT, get_log_path, redirect_output_to_log, trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, TERMINAL_STATUSES, EpisodeStatus, next_retry_count
-from cube_harness.experiment import Experiment, ExpResult, sweep_stale_statuses
+from cube_harness.experiment import (
+    DEFAULT_ORPHAN_THRESHOLD_S,
+    Experiment,
+    ExpResult,
+    sweep_stale_statuses,
+)
 from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
 from cube_harness.metrics.tracer import get_trace_env_vars, get_tracer
 from cube_harness.storage import FileStorage, Storage
@@ -285,7 +290,7 @@ def run_with_ray(
     step_timeout_s: float = DEFAULT_STEP_TIMEOUT_S,
     setup_timeout_s: float = DEFAULT_SETUP_TIMEOUT_S,
     cancel_grace_s: float = DEFAULT_CANCEL_GRACE_S,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,
@@ -479,7 +484,7 @@ def _poll_ray(
     step_timeout_s: float,
     setup_timeout_s: float,
     cancel_grace_s: float,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     exp_status: ExperimentStatus,
     exp_status_path: Path,
 ) -> ExpResult:
@@ -570,7 +575,7 @@ def _kill_stale_workers(
     step_timeout_s: float,
     setup_timeout_s: float,
     cancel_grace_s: float,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     idle_capacity_since: float | None = None,
 ) -> None:
     """Read each active episode's status.json; force-kill stalled or orphaned workers.
@@ -668,7 +673,7 @@ def run_sequentially(
     *,
     step_timeout_s: float = DEFAULT_STEP_TIMEOUT_S,
     cancel_grace_s: float = DEFAULT_CANCEL_GRACE_S,
-    orphan_threshold_s: float = 3600.0,
+    orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
     max_retry_rounds: int = 3,
     otlp_endpoint: str | None = None,
     model: str | None = None,

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -22,6 +22,15 @@ from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_ORPHAN_THRESHOLD_S: float = 3600.0
+"""How long a QUEUED episode can sit before sweep marks it STALE.
+
+Co-located with :func:`sweep_stale_statuses` so the runner (``exp_runner``)
+and the offline scan script (``cube_harness.reproducibility.scan``) share
+one source of truth. The sister timeouts (``DEFAULT_STEP_TIMEOUT_S``,
+``DEFAULT_CANCEL_GRACE_S``) live in ``exp_runner`` because they govern
+the runner's wall-clock behavior outside the sweep predicate."""
+
 EXP_DIR = Path(os.environ.get("CH_EXP_DIR", "~/cube_harness_results")).expanduser().resolve()
 _UUID_SUFFIX_RE = re.compile(r"_[0-9a-f]{8}$")
 
@@ -105,7 +114,7 @@ class Experiment(TypedBaseModel):
         *,
         step_timeout_s: float = 1800.0,
         cancel_grace_s: float = 120.0,
-        orphan_threshold_s: float = 3600.0,
+        orphan_threshold_s: float = DEFAULT_ORPHAN_THRESHOLD_S,
         process_start_s: float | None = None,
     ) -> list[Episode]:
         """Return episodes to run based on `resume`.

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -68,6 +68,16 @@ class Experiment(TypedBaseModel):
     max_steps: int = MAX_STEPS
     max_retries: int = 3
     git_cwd: str | None = None
+    debug_limit: int | None = None
+    """If set, the runner truncates the task list to the first N entries.
+
+    Surfaced into ExperimentRecord so the reproducibility-journal scan script
+    can distinguish debug runs from real evaluations without re-reading the
+    full ExperimentConfig. Recipes that set this on the Experiment object get
+    it captured automatically; recipes that pass it directly to
+    ``run_sequentially`` / ``run_with_ray`` need the runner to propagate it
+    here before ``save_config()`` if they want the same coverage.
+    """
 
     @model_validator(mode="after")
     def _ensure_unique_output_dir(self) -> "Experiment":
@@ -199,6 +209,7 @@ class Experiment(TypedBaseModel):
             agent_config=self.agent_config,
             benchmark_config=self.benchmark_config,
             git_cwd=self.git_cwd,
+            debug_limit=self.debug_limit,
         )
         exp_record.write(output_path)
 

--- a/src/cube_harness/reproducibility/__init__.py
+++ b/src/cube_harness/reproducibility/__init__.py
@@ -12,6 +12,7 @@ Both read the same :class:`cube_harness.eval_log.EvalLog` + per-episode
 ``status.json`` files; neither depends on the other.
 """
 
+from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
 from cube_harness.reproducibility.journal import (
     JOURNAL_SCHEMA_VERSION,
     Outcomes,
@@ -20,8 +21,10 @@ from cube_harness.reproducibility.journal import (
 )
 
 __all__ = [
+    "EEE_SCHEMA_VERSION",
     "JOURNAL_SCHEMA_VERSION",
     "Outcomes",
+    "build_eee_record",
     "build_journal_record",
     "sanitize_filename",
 ]

--- a/src/cube_harness/reproducibility/__init__.py
+++ b/src/cube_harness/reproducibility/__init__.py
@@ -12,6 +12,7 @@ Both read the same :class:`cube_harness.eval_log.EvalLog` + per-episode
 ``status.json`` files; neither depends on the other.
 """
 
+from cube_harness.reproducibility import submissions
 from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
 from cube_harness.reproducibility.journal import (
     JOURNAL_SCHEMA_VERSION,
@@ -27,4 +28,5 @@ __all__ = [
     "build_eee_record",
     "build_journal_record",
     "sanitize_filename",
+    "submissions",
 ]

--- a/src/cube_harness/reproducibility/__init__.py
+++ b/src/cube_harness/reproducibility/__init__.py
@@ -1,0 +1,27 @@
+"""Reproducibility — convert an experiment's :class:`EvalLog` into the formats
+consumed by external community journals.
+
+Two destinations, one source of truth:
+
+- :mod:`.journal` builds the cube-registry community-journal record
+  (per-cube, typed, drives the per-cube UI on the registry site).
+- :mod:`.eee` builds an `Every Eval Ever <https://evalevalai.com>`_-shaped
+  record for upstream submission to the EvalEval HuggingFace dataset.
+
+Both read the same :class:`cube_harness.eval_log.EvalLog` + per-episode
+``status.json`` files; neither depends on the other.
+"""
+
+from cube_harness.reproducibility.journal import (
+    JOURNAL_SCHEMA_VERSION,
+    Outcomes,
+    build_journal_record,
+    sanitize_filename,
+)
+
+__all__ = [
+    "JOURNAL_SCHEMA_VERSION",
+    "Outcomes",
+    "build_journal_record",
+    "sanitize_filename",
+]

--- a/src/cube_harness/reproducibility/eee.py
+++ b/src/cube_harness/reproducibility/eee.py
@@ -1,0 +1,155 @@
+"""Convert an experiment :class:`EvalLog` into an Every Eval Ever (EEE) record.
+
+EEE (`<https://evalevalai.com/events/shared-task-every-eval-ever/>`_) is a
+community shared task building a unified HF-hosted database of LLM
+evaluations. cube-harness becomes a peer of HELM / lm-eval / Inspect AI by
+emitting records that conform to ``every_eval_ever/schemas/eval.schema.json``
+(v0.2.2 at time of writing).
+
+The schema is strict (``additionalProperties: false`` at the top), so
+cube-specific provenance (git hashes, dep versions, agent config hash, cube-
+standard checkout state) goes into ``source_metadata.additional_details`` as
+string KVs. Aggregate score + uncertainty go into one
+``evaluation_results[]`` entry; per-episode data is not emitted (EEE has
+``detailed_evaluation_results`` for that — left optional for V1).
+
+This module is pure — no I/O beyond the experiment directory.
+"""
+
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+from typing import Any
+
+from cube_harness.eval_log import EvalLog
+
+EEE_SCHEMA_VERSION = "0.2.2"
+
+
+def _to_string_kvs(d: dict[str, Any]) -> dict[str, str]:
+    """EEE's ``additional_details`` requires string-typed values."""
+    return {k: str(v) for k, v in d.items() if v is not None}
+
+
+def _llm_developer(llm_model: str | None) -> str:
+    """Best-effort extraction of the model developer from a LiteLLM-style id.
+
+    ``azure/gpt-5.4-mini`` → ``Azure``;  ``anthropic/claude-opus-4-7`` →
+    ``Anthropic``.  Falls back to ``""`` when the prefix is missing.
+    """
+    if not llm_model or "/" not in llm_model:
+        return ""
+    return llm_model.split("/", 1)[0].title()
+
+
+def build_eee_record(
+    experiment_dir: Path,
+    *,
+    source_organization_name: str = "cube-harness submitter",
+    source_organization_url: str | None = None,
+    evaluator_relationship: str = "third_party",
+) -> dict[str, Any]:
+    """Build one EEE-shaped record from a completed experiment.
+
+    Args:
+        experiment_dir: Path to the experiment output directory.
+        source_organization_name: Free-text identifier for the submitter (a
+            person or org); shown in EEE's UI.
+        source_organization_url: Optional URL for the org.
+        evaluator_relationship: One of ``first_party``, ``third_party``,
+            ``collaborative``, ``other``. Defaults to ``third_party`` because
+            the typical cube-harness user is not the model developer.
+
+    Returns:
+        A dict matching EEE ``eval.schema.json`` v0.2.2.
+    """
+    experiment_dir = Path(experiment_dir)
+    eval_log = EvalLog.load(experiment_dir)
+    exp = eval_log.experiment
+    episodes = eval_log.episodes
+
+    scores = [ep.score for ep in episodes]
+    avg_score = sum(scores) / len(scores) if scores else 0.0
+    std_err = statistics.stdev(scores) / (len(scores) ** 0.5) if len(scores) > 1 else 0.0
+
+    bench_name = exp.benchmark_subset.name
+    cube_id = bench_name.split("[", 1)[0]
+
+    provenance = _to_string_kvs(
+        {
+            "cube_harness_version": exp.eval_library.version,
+            "cube_harness_git_commit": exp.agent.git_commit,
+            "cube_harness_git_remote_url": exp.agent.git_remote_url,
+            "cube_harness_git_is_dirty": exp.agent.git_is_dirty,
+            "cube_standard_git_commit": exp.agent.cube_standard_git_commit,
+            "cube_standard_git_is_dirty": exp.agent.cube_standard_git_is_dirty,
+            "agent_id": exp.agent.agent_id,
+            "agent_config_type": exp.agent.config_type,
+            **{f"dep:{k}": v for k, v in exp.agent.dependency_versions.items()},
+        }
+    )
+
+    source_metadata: dict[str, Any] = {
+        "source_type": "evaluation_run",
+        "source_organization_name": source_organization_name,
+        "evaluator_relationship": evaluator_relationship,
+        "additional_details": provenance,
+    }
+    if source_organization_url:
+        source_metadata["source_organization_url"] = source_organization_url
+
+    model_info: dict[str, Any] = {
+        "name": exp.agent.llm_model or "",
+        "id": exp.agent.llm_model or "",
+    }
+    developer = _llm_developer(exp.agent.llm_model)
+    if developer:
+        model_info["developer"] = developer
+
+    record: dict[str, Any] = {
+        "schema_version": EEE_SCHEMA_VERSION,
+        "evaluation_id": f"{cube_id}/{exp.agent.llm_model}/{exp.evaluation_id}",
+        "retrieved_timestamp": str(int(exp.evaluation_timestamp)),
+        "evaluation_timestamp": str(int(exp.evaluation_timestamp)),
+        "source_metadata": source_metadata,
+        "eval_library": {
+            "name": exp.eval_library.name,
+            "version": exp.eval_library.version,
+        },
+        "model_info": model_info,
+        "evaluation_results": [
+            {
+                "evaluation_result_id": f"{cube_id}.reward",
+                "evaluation_name": bench_name,
+                "source_data": {
+                    "dataset_name": bench_name,
+                    "source_type": "other",
+                    "additional_details": {
+                        "benchmark_version": exp.benchmark_version or "unknown",
+                        "n_tasks": str(exp.benchmark_subset.n_tasks),
+                    },
+                },
+                "metric_config": {
+                    "metric_id": f"{cube_id}.reward",
+                    "metric_name": "Mean episode reward",
+                    "metric_kind": "accuracy",
+                    "lower_is_better": False,
+                    "score_type": "continuous",
+                    "min_score": 0,
+                    "max_score": 1,
+                },
+                "score_details": {
+                    "score": round(avg_score, 6),
+                    "uncertainty": {
+                        "standard_error": {
+                            "value": round(std_err, 6),
+                            "method": "analytic",
+                        },
+                        "num_samples": len(scores),
+                    },
+                },
+            }
+        ],
+    }
+    return record

--- a/src/cube_harness/reproducibility/eee.py
+++ b/src/cube_harness/reproducibility/eee.py
@@ -32,15 +32,49 @@ def _to_string_kvs(d: dict[str, Any]) -> dict[str, str]:
     return {k: str(v) for k, v in d.items() if v is not None}
 
 
+# Curated provider-prefix → display-name mapping. `str.title()` mangles
+# common prefixes (`openai` → `Openai`, `vertex_ai` → `Vertex_Ai`,
+# `huggingface` → `Huggingface`) and doesn't model multi-segment prefixes
+# where the model's actual developer is one level deeper (e.g.
+# `openrouter/anthropic/claude-*` is an Anthropic model served via
+# OpenRouter). Keep the map small + explicit; fall back to the prefix
+# verbatim when an unknown provider appears.
+_PROVIDER_DISPLAY_NAME: dict[str, str] = {
+    "openai": "OpenAI",
+    "azure": "Azure",
+    "anthropic": "Anthropic",
+    "google": "Google",
+    "vertex_ai": "Google Vertex AI",
+    "gemini": "Google",
+    "mistral": "Mistral",
+    "cohere": "Cohere",
+    "huggingface": "HuggingFace",
+    "bedrock": "AWS Bedrock",
+    "together_ai": "Together AI",
+    "fireworks_ai": "Fireworks AI",
+    "groq": "Groq",
+    "replicate": "Replicate",
+    "ollama": "Ollama",
+}
+
+
 def _llm_developer(llm_model: str | None) -> str:
     """Best-effort extraction of the model developer from a LiteLLM-style id.
 
-    ``azure/gpt-5.4-mini`` → ``Azure``;  ``anthropic/claude-opus-4-7`` →
-    ``Anthropic``.  Falls back to ``""`` when the prefix is missing.
+    Handles the common single-prefix case (``openai/gpt-4o`` → ``OpenAI``)
+    and the routed-provider case (``openrouter/anthropic/claude-3-5`` →
+    ``Anthropic``). Falls back to the verbatim prefix when neither segment
+    matches a known provider, and to ``""`` when no prefix is present.
     """
     if not llm_model or "/" not in llm_model:
         return ""
-    return llm_model.split("/", 1)[0].title()
+    segments = llm_model.split("/")
+    # Routed prefixes (openrouter, bedrock proxy, etc.) put the actual
+    # developer in segment 1; check that first, then fall back to segment 0.
+    if len(segments) >= 3 and segments[1].lower() in _PROVIDER_DISPLAY_NAME:
+        return _PROVIDER_DISPLAY_NAME[segments[1].lower()]
+    first = segments[0].lower()
+    return _PROVIDER_DISPLAY_NAME.get(first, segments[0])
 
 
 def build_eee_record(
@@ -107,9 +141,15 @@ def build_eee_record(
     if developer:
         model_info["developer"] = developer
 
+    # `exp.agent.llm_model` can be None when the harness couldn't infer the
+    # model name from the agent config. Stringify defensively so the EEE id
+    # doesn't end up as "miniwob/None/…" (W3) — "unknown" is a clearer signal
+    # to a reader and collides less catastrophically than the literal "None".
+    llm_model_segment = exp.agent.llm_model or "unknown"
+
     record: dict[str, Any] = {
         "schema_version": EEE_SCHEMA_VERSION,
-        "evaluation_id": f"{cube_id}/{exp.agent.llm_model}/{exp.evaluation_id}",
+        "evaluation_id": f"{cube_id}/{llm_model_segment}/{exp.evaluation_id}",
         "retrieved_timestamp": str(int(exp.evaluation_timestamp)),
         "evaluation_timestamp": str(int(exp.evaluation_timestamp)),
         "source_metadata": source_metadata,

--- a/src/cube_harness/reproducibility/journal.py
+++ b/src/cube_harness/reproducibility/journal.py
@@ -172,6 +172,8 @@ def build_journal_record(
     # sending null sentinels we don't actually have.
     if exp.agent.dependency_versions:
         agent_dict["dependency_versions"] = exp.agent.dependency_versions
+    if exp.agent.primary_dependencies:
+        agent_dict["primary_dependencies"] = exp.agent.primary_dependencies
     if exp.agent.git_remote_url:
         agent_dict["git_remote_url"] = exp.agent.git_remote_url
     if exp.agent.git_is_dirty is not None:

--- a/src/cube_harness/reproducibility/journal.py
+++ b/src/cube_harness/reproducibility/journal.py
@@ -134,17 +134,15 @@ def build_journal_record(
     derived_cube_id = cube_id or bench_name.split("[", 1)[0]
 
     # ── outcome breakdown from per-episode status.json files ───────────────
+    # `iter_episode_statuses` already dedups by (task_id, episode_id), so
+    # the per-status sum equals the number of attempted tasks. Tasks in the
+    # subset that produced no status file at all roll into n_missing.
     outcomes = Outcomes()
-    exp_result = ExperimentResult(experiment_dir)
-    seen_task_ids: set[str] = set()
-    for status in exp_result.iter_episode_statuses():
+    for status in ExperimentResult(experiment_dir).iter_episode_statuses():
         bucket = classify(status)
         setattr(outcomes, bucket, getattr(outcomes, bucket) + 1)
-        seen_task_ids.add(status.task_id)
-    # Tasks in the subset that produced no status file at all → missing.
     n_total = exp.benchmark_subset.n_tasks
-    n_missing_no_file = max(0, n_total - outcomes.total())
-    outcomes.n_missing += n_missing_no_file
+    outcomes.n_missing += max(0, n_total - outcomes.total())
 
     # ── aggregate score + uncertainty from per-episode records ─────────────
     scores = [ep.score for ep in episodes]

--- a/src/cube_harness/reproducibility/journal.py
+++ b/src/cube_harness/reproducibility/journal.py
@@ -1,0 +1,218 @@
+"""Convert an experiment directory into a cube-registry community-journal record.
+
+The output dict conforms to ``results-schema.json`` in cube-registry; the
+companion ``scripts/submit_to_journal.py`` writes it to a file (and optionally
+opens a PR against cube-registry). The schema is documented in
+``cube-registry/openspec/changes/results-journal/design.md``.
+
+This module is pure — no I/O beyond reading the experiment directory.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cube_harness.episode_status import EpisodeStatus, Status
+from cube_harness.eval_log import EvalLog
+from cube_harness.results import ExperimentResult
+
+JOURNAL_SCHEMA_VERSION = "1.0"
+
+# Slash → __ when sanitizing evaluation_id into a filename stem (matches
+# cube-registry's results_check.py).
+_FILENAME_REPLACE = str.maketrans({"/": "__"})
+
+
+@dataclass
+class Outcomes:
+    """Mutually-exclusive, exhaustive outcome counts over ``n_tasks``.
+
+    Maps cube-harness :data:`EpisodeStatus.Status` values into the five
+    buckets the cube-registry schema requires:
+
+    ===========================  ================
+    Source status                 Bucket
+    ===========================  ================
+    COMPLETED, reward > 0        n_success
+    COMPLETED, reward == 0       n_failure
+    MAX_STEPS_REACHED            n_max_steps
+    FAILED / STALE / INVALID     n_system_error
+    CANCELLED / in-flight / —    n_missing
+    ===========================  ================
+    """
+
+    n_success: int = 0
+    n_failure: int = 0
+    n_max_steps: int = 0
+    n_system_error: int = 0
+    n_missing: int = 0
+
+    def total(self) -> int:
+        return self.n_success + self.n_failure + self.n_max_steps + self.n_system_error + self.n_missing
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "n_success": self.n_success,
+            "n_failure": self.n_failure,
+            "n_max_steps": self.n_max_steps,
+            "n_system_error": self.n_system_error,
+            "n_missing": self.n_missing,
+        }
+
+
+_SYSTEM_ERROR_STATUSES: frozenset[Status] = frozenset({"FAILED", "STALE", "INVALID_CONFIG"})
+_MISSING_STATUSES: frozenset[Status] = frozenset({"CANCELLED", "QUEUED", "RUNNING"})
+
+
+def classify(status: EpisodeStatus) -> str:
+    """Return the outcome bucket name (``n_success``/…) for one episode status."""
+    s: Status = status.status
+    if s == "COMPLETED":
+        return "n_success" if (status.reward or 0) > 0 else "n_failure"
+    if s == "MAX_STEPS_REACHED":
+        return "n_max_steps"
+    if s in _SYSTEM_ERROR_STATUSES:
+        return "n_system_error"
+    if s in _MISSING_STATUSES:
+        return "n_missing"
+    raise ValueError(f"unknown EpisodeStatus: {s!r}")
+
+
+def sanitize_filename(evaluation_id: str) -> str:
+    """``alacoste/run1`` → ``alacoste__run1`` (matches cube-registry's results_check)."""
+    return evaluation_id.translate(_FILENAME_REPLACE)
+
+
+def _read_max_steps(experiment_dir: Path) -> int | None:
+    """Read ``experiment_config.json`` and return the experiment's max_steps cap.
+
+    Returns ``None`` when the file is missing or unparseable — non-fatal,
+    just leaves the field out of the journal record.
+    """
+    config_path = experiment_dir / "experiment_config.json"
+    if not config_path.exists():
+        return None
+    try:
+        data = json.loads(config_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    value = data.get("max_steps")
+    return value if isinstance(value, int) else None
+
+
+def build_journal_record(
+    experiment_dir: Path,
+    *,
+    submitter: str,
+    cube_id: str | None = None,
+) -> dict[str, Any]:
+    """Build one cube-registry journal record from a completed experiment.
+
+    Args:
+        experiment_dir: Path to the experiment output directory (the dir holding
+            ``experiment_record.json`` and ``episodes/``).
+        submitter: GitHub handle of the submitter. Used to namespace the
+            ``evaluation_id`` (``<submitter>/<exp_dir.name>``).
+        cube_id: Override the cube id when the benchmark name in
+            ``ExperimentRecord`` does not match the cube's registry id
+            (e.g. ``"miniwob[level=all]"`` → ``"miniwob"``). Defaults to the
+            benchmark name with any ``[…]`` suffix stripped.
+
+    Returns:
+        A dict matching cube-registry's ``results-schema.json`` 1.0.
+    """
+    experiment_dir = Path(experiment_dir)
+    eval_log = EvalLog.load(experiment_dir)
+    exp = eval_log.experiment
+    episodes = eval_log.episodes
+
+    bench_name = exp.benchmark_subset.name
+    derived_cube_id = cube_id or bench_name.split("[", 1)[0]
+
+    # ── outcome breakdown from per-episode status.json files ───────────────
+    outcomes = Outcomes()
+    exp_result = ExperimentResult(experiment_dir)
+    seen_task_ids: set[str] = set()
+    for status in exp_result.iter_episode_statuses():
+        bucket = classify(status)
+        setattr(outcomes, bucket, getattr(outcomes, bucket) + 1)
+        seen_task_ids.add(status.task_id)
+    # Tasks in the subset that produced no status file at all → missing.
+    n_total = exp.benchmark_subset.n_tasks
+    n_missing_no_file = max(0, n_total - outcomes.total())
+    outcomes.n_missing += n_missing_no_file
+
+    # ── aggregate score + uncertainty from per-episode records ─────────────
+    scores = [ep.score for ep in episodes]
+    avg_score = sum(scores) / len(scores) if scores else 0.0
+    std_err = 0.0
+    if len(scores) > 1:
+        std_err = statistics.stdev(scores) / (len(scores) ** 0.5)
+
+    # ── cost + wall time ───────────────────────────────────────────────────
+    total_cost_usd = sum(ep.usage.total_cost_usd for ep in episodes)
+    wall_times = [ep.wall_time_s for ep in episodes if ep.wall_time_s is not None]
+    avg_wall_time_s = sum(wall_times) / len(wall_times) if wall_times else None
+
+    max_steps = _read_max_steps(experiment_dir)
+
+    agent_dict: dict[str, Any] = {
+        "agent_id": exp.agent.agent_id,
+        "config_type": exp.agent.config_type,
+        "llm_model": exp.agent.llm_model or "",
+        "framework_version": exp.agent.framework_version,
+        "git_commit": exp.agent.git_commit or "",
+    }
+    # Optional fields — only include when non-empty / non-None so the
+    # journal-schema's additionalProperties: false stays happy without
+    # sending null sentinels we don't actually have.
+    if exp.agent.dependency_versions:
+        agent_dict["dependency_versions"] = exp.agent.dependency_versions
+    if exp.agent.git_remote_url:
+        agent_dict["git_remote_url"] = exp.agent.git_remote_url
+    if exp.agent.git_is_dirty is not None:
+        agent_dict["git_is_dirty"] = exp.agent.git_is_dirty
+    if exp.agent.cube_standard_git_commit:
+        agent_dict["cube_standard_git_commit"] = exp.agent.cube_standard_git_commit
+    if exp.agent.cube_standard_git_is_dirty is not None:
+        agent_dict["cube_standard_git_is_dirty"] = exp.agent.cube_standard_git_is_dirty
+    if exp.agent.config:
+        agent_dict["config"] = exp.agent.config
+
+    subset_dict: dict[str, Any] = {
+        "name": bench_name,
+        "n_tasks": n_total,
+    }
+    if exp.benchmark_subset.filter:
+        subset_dict["filter"] = exp.benchmark_subset.filter
+
+    results_dict: dict[str, Any] = {
+        "avg_score": round(avg_score, 6),
+        "std_err": round(std_err, 6),
+        "total_cost_usd": round(total_cost_usd, 6),
+        "outcomes": outcomes.to_dict(),
+    }
+    if avg_wall_time_s is not None:
+        results_dict["avg_wall_time_s"] = round(avg_wall_time_s, 3)
+    if max_steps is not None:
+        results_dict["max_steps_per_episode"] = max_steps
+
+    record: dict[str, Any] = {
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "evaluation_id": f"{submitter}/{exp.evaluation_id}",
+        "evaluation_timestamp": exp.evaluation_timestamp,
+        "eval_library": {
+            "name": exp.eval_library.name,
+            "version": exp.eval_library.version,
+        },
+        "agent": agent_dict,
+        "benchmark_name": derived_cube_id,
+        "benchmark_version": exp.benchmark_version or "unknown",
+        "benchmark_subset": subset_dict,
+        "results": results_dict,
+    }
+    return record

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from cube_harness.episode_status import IN_FLIGHT_STATUSES
 from cube_harness.eval_log import EXPERIMENT_RECORD_FILENAME, ExperimentRecord
 from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
-from cube_harness.experiment import sweep_stale_statuses
+from cube_harness.experiment import DEFAULT_ORPHAN_THRESHOLD_S, sweep_stale_statuses
 from cube_harness.reproducibility import submissions
 from cube_harness.results import ExperimentResult
 from cube_harness.storage import ARCHIVED_MARKER, FileStorage
@@ -51,17 +51,14 @@ than about the model — the run is marked BROKEN. 10% is intentionally tight
 """
 
 
-# Stale-sweep defaults match the runner's defaults so the same heartbeat
-# semantics apply whether sweep is invoked online (during run_with_ray) or
-# offline (by this script). See cube_harness.exp_runner.
-_DEFAULT_ORPHAN_THRESHOLD_S: float = 3600.0
-
-
 def sweep_stale_in_dir(experiment_dir: Path) -> list[str]:
     """Mark dead RUNNING/QUEUED episodes as STALE in *experiment_dir*.
 
     Pure delegation to :func:`cube_harness.experiment.sweep_stale_statuses` —
-    the same code path the runner uses online. Returns the list of swept
+    the same code path the runner uses online. Reuses the runner's defaults
+    (``DEFAULT_STEP_TIMEOUT_S`` / ``DEFAULT_CANCEL_GRACE_S`` /
+    ``DEFAULT_ORPHAN_THRESHOLD_S``) so heartbeat semantics stay identical
+    whether sweep is invoked online or offline. Returns the list of swept
     trajectory_ids. Non-fatal: any storage error is logged and swallowed so
     the scan can proceed with whatever statuses are currently on disk.
     """
@@ -71,7 +68,7 @@ def sweep_stale_in_dir(experiment_dir: Path) -> list[str]:
             storage,
             step_timeout_s=DEFAULT_STEP_TIMEOUT_S,
             cancel_grace_s=DEFAULT_CANCEL_GRACE_S,
-            orphan_threshold_s=_DEFAULT_ORPHAN_THRESHOLD_S,
+            orphan_threshold_s=DEFAULT_ORPHAN_THRESHOLD_S,
         )
     except Exception as e:
         logger.warning("stale-status sweep failed for %s: %s", experiment_dir, e)

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -1,0 +1,251 @@
+"""Classify experiment directories by reproducibility-journal eligibility.
+
+Used by ``scripts/scan_experiments.py``. Lives in the package so it can be
+unit-tested without subprocess invocation.
+
+Categories (more restrictive than the original sketch — the philosophy is
+"refuse rather than ship a borderline submission"):
+
+  • ``already_submitted``  — ``submissions.json`` has a ``journal`` decision
+    (either ``submitted`` or ``rejected``). Either way, skip — re-decision
+    is an explicit ``--force`` operation handled by ``submit_to_journal.py``.
+  • ``broken``             — the experiment cannot produce a meaningful score.
+    Missing/corrupt ``experiment_record.json``, OR > N% system errors, OR
+    every episode missing. Permanently marked via ``record_rejected``.
+  • ``unfinished``         — some episode is still ``QUEUED`` / ``RUNNING``,
+    OR no terminal-status episodes exist yet. State will change; don't
+    write to ``submissions.json``.
+  • ``subset_review``      — passed the integrity checks but the subset shape
+    isn't a "complete named subset" (debug_limit applied, hand-picked task
+    list via ``subset_from_list``, or filter set but n_missing > 0). The
+    operator can submit with ``--yes`` after eyeballing the diagnosis.
+  • ``submittable``        — clean run of a complete named subset or the full
+    benchmark. Hand off to ``submit_to_journal.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from cube_harness.episode_status import IN_FLIGHT_STATUSES
+from cube_harness.eval_log import EXPERIMENT_RECORD_FILENAME, ExperimentRecord
+from cube_harness.reproducibility import submissions
+from cube_harness.results import ExperimentResult
+
+DEFAULT_SYSTEM_ERROR_THRESHOLD = 0.10
+"""Episodes that hit FAILED / STALE / INVALID_CONFIG count as system errors.
+
+Above this fraction the recorded ``avg_score`` says more about your infra
+than about the model — the run is marked BROKEN. 10% is intentionally tight
+("be restrictive about what gets pushed"). Tunable per scan invocation.
+"""
+
+
+class ScanCategory(str, Enum):
+    already_submitted = "already_submitted"
+    broken = "broken"
+    unfinished = "unfinished"
+    subset_review = "subset_review"
+    submittable = "submittable"
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """One experiment dir + its eligibility classification.
+
+    *reasons* explains the classification — empty when ``submittable``; one
+    or more diagnoses otherwise. For ``broken``, the first reason is also
+    persisted into ``submissions.json`` as the rejection note.
+    """
+
+    experiment_dir: Path
+    category: ScanCategory
+    reasons: tuple[str, ...] = ()
+    # Diagnostics for the operator. Always populated when possible so a
+    # `--verbose` listing shows the underlying numbers.
+    n_tasks: int | None = None
+    n_terminal: int = 0
+    n_in_flight: int = 0
+    n_system_error: int = 0
+    n_missing: int = 0
+    debug_limit: int | None = None
+    benchmark_subset_name: str = ""
+    benchmark_subset_filter: str | None = None
+    has_explicit_task_list: bool = False
+
+
+def _load_experiment_record(experiment_dir: Path) -> ExperimentRecord | None:
+    """Parse ``experiment_record.json`` or return None on missing/corrupt."""
+    record_path = experiment_dir / EXPERIMENT_RECORD_FILENAME
+    if not record_path.exists():
+        return None
+    try:
+        return ExperimentRecord.model_validate_json(record_path.read_text())
+    except Exception:
+        return None
+
+
+def _read_debug_limit_fallback(experiment_dir: Path) -> int | None:
+    """Old experiment records predate ExperimentRecord.debug_limit; fall back to
+    experiment_config.json so the scan classifier still has the signal."""
+    config_path = experiment_dir / "experiment_config.json"
+    if not config_path.exists():
+        return None
+    try:
+        value = json.loads(config_path.read_text()).get("debug_limit")
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, int) else None
+
+
+def classify(
+    experiment_dir: Path,
+    *,
+    system_error_threshold: float = DEFAULT_SYSTEM_ERROR_THRESHOLD,
+) -> ScanResult:
+    """Decide which bucket *experiment_dir* falls into.
+
+    Pure — no writes to disk. Caller decides whether to persist the verdict
+    into ``submissions.json`` (typically only for ``broken``).
+    """
+    experiment_dir = Path(experiment_dir)
+
+    # ── Already-decided takes priority over every other signal ────────────
+    if submissions.has_decision(experiment_dir, "journal"):
+        prior = submissions.read(experiment_dir).get("journal", {})
+        return ScanResult(
+            experiment_dir,
+            ScanCategory.already_submitted,
+            (f"prior journal decision: {prior.get('status')} — {prior.get('reason') or prior.get('evaluation_id')}",),
+        )
+
+    # ── Integrity: must have a parseable ExperimentRecord ─────────────────
+    record = _load_experiment_record(experiment_dir)
+    if record is None:
+        return ScanResult(
+            experiment_dir,
+            ScanCategory.broken,
+            (f"missing or unparseable {EXPERIMENT_RECORD_FILENAME}",),
+        )
+
+    bench_subset = record.benchmark_subset
+    n_tasks = bench_subset.n_tasks
+    debug_limit = record.debug_limit
+    if debug_limit is None:
+        debug_limit = _read_debug_limit_fallback(experiment_dir)
+
+    # ── Outcome breakdown from the per-episode status files ──────────────
+    n_terminal = 0
+    n_in_flight = 0
+    n_system_error = 0
+    seen_task_ids: set[str] = set()
+    try:
+        for status in ExperimentResult(experiment_dir).iter_episode_statuses():
+            seen_task_ids.add(status.task_id)
+            if status.status in IN_FLIGHT_STATUSES:
+                n_in_flight += 1
+                continue
+            n_terminal += 1
+            if status.status in {"FAILED", "STALE", "INVALID_CONFIG"}:
+                n_system_error += 1
+    except Exception as e:
+        return ScanResult(
+            experiment_dir,
+            ScanCategory.broken,
+            (f"failed to read episode statuses: {e}",),
+            n_tasks=n_tasks,
+        )
+
+    n_missing = max(0, n_tasks - len(seen_task_ids))
+    has_explicit_task_list = bool(bench_subset.task_ids)
+
+    base = dict(
+        experiment_dir=experiment_dir,
+        n_tasks=n_tasks,
+        n_terminal=n_terminal,
+        n_in_flight=n_in_flight,
+        n_system_error=n_system_error,
+        n_missing=n_missing,
+        debug_limit=debug_limit,
+        benchmark_subset_name=bench_subset.name,
+        benchmark_subset_filter=bench_subset.filter,
+        has_explicit_task_list=has_explicit_task_list,
+    )
+
+    # ── In-flight episodes mean the experiment is still running ──────────
+    if n_in_flight > 0:
+        return ScanResult(
+            **base,
+            category=ScanCategory.unfinished,
+            reasons=(f"{n_in_flight} episode(s) still QUEUED/RUNNING",),
+        )
+
+    # ── No terminal episodes at all ⇒ nothing to submit ─────────────────
+    if n_terminal == 0:
+        return ScanResult(
+            **base,
+            category=ScanCategory.broken,
+            reasons=("no terminal-status episodes recorded — experiment never produced any data",),
+        )
+
+    # ── System-error rate is permanent broken-ness ──────────────────────
+    err_rate = n_system_error / n_terminal if n_terminal else 0.0
+    if err_rate > system_error_threshold:
+        return ScanResult(
+            **base,
+            category=ScanCategory.broken,
+            reasons=(
+                f"{n_system_error}/{n_terminal} episodes errored "
+                f"({err_rate * 100:.0f}%, threshold {system_error_threshold * 100:.0f}%)",
+            ),
+        )
+
+    # ── Missing tasks ⇒ unfinished (could resume) ───────────────────────
+    if n_missing > 0:
+        return ScanResult(
+            **base,
+            category=ScanCategory.unfinished,
+            reasons=(f"{n_missing}/{n_tasks} task(s) have no status file — experiment may have stopped early",),
+        )
+
+    # ── Subset-shape gate: more restrictive than the original sketch ─────
+    review_reasons: list[str] = []
+    if debug_limit:
+        review_reasons.append(f"debug_limit={debug_limit} was applied — not a full subset")
+    if has_explicit_task_list:
+        # subset_from_list submissions are not reproducibility-reference-able
+        # without external documentation of why those specific tasks were
+        # chosen. Default to requiring operator acknowledgement.
+        review_reasons.append(
+            f"benchmark_subset.task_ids is set ({len(bench_subset.task_ids or [])} explicit tasks) — "
+            "hand-picked subsets need --yes to submit"
+        )
+
+    if review_reasons:
+        return ScanResult(**base, category=ScanCategory.subset_review, reasons=tuple(review_reasons))
+
+    return ScanResult(**base, category=ScanCategory.submittable)
+
+
+def walk(
+    root: Path,
+    *,
+    system_error_threshold: float = DEFAULT_SYSTEM_ERROR_THRESHOLD,
+) -> list[ScanResult]:
+    """Classify every direct subdirectory of *root* that contains an
+    ``experiment_record.json``. Dirs without that file are silently skipped
+    (they're not experiment dirs at all)."""
+    root = Path(root)
+    results: list[ScanResult] = []
+    if not root.is_dir():
+        return results
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if not (entry / EXPERIMENT_RECORD_FILENAME).exists():
+            continue
+        results.append(classify(entry, system_error_threshold=system_error_threshold))
+    return results

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -26,14 +26,21 @@ Categories (more restrictive than the original sketch — the philosophy is
 from __future__ import annotations
 
 import json
+import logging
+import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
 from cube_harness.episode_status import IN_FLIGHT_STATUSES
 from cube_harness.eval_log import EXPERIMENT_RECORD_FILENAME, ExperimentRecord
+from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
+from cube_harness.experiment import sweep_stale_statuses
 from cube_harness.reproducibility import submissions
 from cube_harness.results import ExperimentResult
+from cube_harness.storage import ARCHIVED_MARKER, FileStorage
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SYSTEM_ERROR_THRESHOLD = 0.10
 """Episodes that hit FAILED / STALE / INVALID_CONFIG count as system errors.
@@ -42,6 +49,49 @@ Above this fraction the recorded ``avg_score`` says more about your infra
 than about the model — the run is marked BROKEN. 10% is intentionally tight
 ("be restrictive about what gets pushed"). Tunable per scan invocation.
 """
+
+
+# Stale-sweep defaults match the runner's defaults so the same heartbeat
+# semantics apply whether sweep is invoked online (during run_with_ray) or
+# offline (by this script). See cube_harness.exp_runner.
+_DEFAULT_ORPHAN_THRESHOLD_S: float = 3600.0
+
+
+def sweep_stale_in_dir(experiment_dir: Path) -> list[str]:
+    """Mark dead RUNNING/QUEUED episodes as STALE in *experiment_dir*.
+
+    Pure delegation to :func:`cube_harness.experiment.sweep_stale_statuses` —
+    the same code path the runner uses online. Returns the list of swept
+    trajectory_ids. Non-fatal: any storage error is logged and swallowed so
+    the scan can proceed with whatever statuses are currently on disk.
+    """
+    try:
+        storage = FileStorage(experiment_dir)
+        return sweep_stale_statuses(
+            storage,
+            step_timeout_s=DEFAULT_STEP_TIMEOUT_S,
+            cancel_grace_s=DEFAULT_CANCEL_GRACE_S,
+            orphan_threshold_s=_DEFAULT_ORPHAN_THRESHOLD_S,
+        )
+    except Exception as e:
+        logger.warning("stale-status sweep failed for %s: %s", experiment_dir, e)
+        return []
+
+
+def archive_experiment_dir(experiment_dir: Path) -> Path:
+    """Rename *experiment_dir* to ``<name>.archived_<ts>`` so :func:`walk` skips it.
+
+    Mirrors the per-episode archive convention used by FileStorage — same
+    ``ARCHIVED_MARKER`` constant + timestamp suffix, just applied one level up.
+    Returns the new path. No-op if the dir is already archived.
+    """
+    experiment_dir = Path(experiment_dir)
+    if ARCHIVED_MARKER in experiment_dir.name:
+        return experiment_dir
+    target = experiment_dir.parent / f"{experiment_dir.name}{ARCHIVED_MARKER}{time.time()}"
+    experiment_dir.rename(target)
+    logger.info("archived %s -> %s", experiment_dir.name, target.name)
+    return target
 
 
 class ScanCategory(str, Enum):
@@ -105,13 +155,21 @@ def classify(
     experiment_dir: Path,
     *,
     system_error_threshold: float = DEFAULT_SYSTEM_ERROR_THRESHOLD,
+    sweep_stale: bool = True,
 ) -> ScanResult:
     """Decide which bucket *experiment_dir* falls into.
 
-    Pure — no writes to disk. Caller decides whether to persist the verdict
-    into ``submissions.json`` (typically only for ``broken``).
+    Pure with respect to ``submissions.json`` and the result classification.
+    When *sweep_stale* is True (the default), runs
+    :func:`sweep_stale_in_dir` first so dead RUNNING/QUEUED episodes (from a
+    crashed Ray driver or killed worker) are reclassified as STALE before the
+    eligibility logic runs. Without the sweep, those experiments would be
+    permanently flagged as ``unfinished`` even when no worker is alive to
+    finish them. Pass ``sweep_stale=False`` for a strictly read-only scan.
     """
     experiment_dir = Path(experiment_dir)
+    if sweep_stale:
+        sweep_stale_in_dir(experiment_dir)
 
     # ── Already-decided takes priority over every other signal ────────────
     if submissions.has_decision(experiment_dir, "journal"):
@@ -234,10 +292,13 @@ def walk(
     root: Path,
     *,
     system_error_threshold: float = DEFAULT_SYSTEM_ERROR_THRESHOLD,
+    sweep_stale: bool = True,
 ) -> list[ScanResult]:
     """Classify every direct subdirectory of *root* that contains an
     ``experiment_record.json``. Dirs without that file are silently skipped
-    (they're not experiment dirs at all)."""
+    (they're not experiment dirs at all). Archived dirs — those carrying the
+    standard ``ARCHIVED_MARKER`` suffix — are also skipped, so re-scanning a
+    root after ``--archive-broken`` doesn't re-surface what was just moved."""
     root = Path(root)
     results: list[ScanResult] = []
     if not root.is_dir():
@@ -245,7 +306,15 @@ def walk(
     for entry in sorted(root.iterdir()):
         if not entry.is_dir():
             continue
+        if ARCHIVED_MARKER in entry.name:
+            continue
         if not (entry / EXPERIMENT_RECORD_FILENAME).exists():
             continue
-        results.append(classify(entry, system_error_threshold=system_error_threshold))
+        results.append(
+            classify(
+                entry,
+                system_error_threshold=system_error_threshold,
+                sweep_stale=sweep_stale,
+            )
+        )
     return results

--- a/src/cube_harness/reproducibility/submissions.py
+++ b/src/cube_harness/reproducibility/submissions.py
@@ -1,0 +1,149 @@
+"""Read / write ``submissions.json`` inside an experiment directory.
+
+Each entry records a per-destination outcome — either a successful submission
+(so the scan script skips the dir on the next run) or an explicit rejection
+(so a broken experiment is permanently marked non-submission-worthy with the
+diagnosis preserved). Schema is dict-keyed by destination name so the same
+file covers both the cube-registry journal and EEE.
+
+File path: ``<experiment_dir>/submissions.json``.
+
+File format (additive — both shapes round-trip cleanly through Python):
+
+    {
+      "journal": {
+        "status": "submitted",
+        "evaluation_id": "alacoste/20260404_195953_genny_miniwob",
+        "schema_version": "1.0",
+        "submitted_at": "2026-06-03T12:00:00Z",
+        "submitted_by": "alacoste",
+        "pr_url": "https://github.com/The-AI-Alliance/cube-registry/pull/124",
+        "local_path": "./journal-out/results/miniwob/…json"
+      },
+      "eee": {
+        "status": "submitted",
+        "evaluation_id": "miniwob/azure/gpt-5.4-mini/20260404_…",
+        "schema_version": "0.2.2",
+        "submitted_at": "2026-06-03T12:05:00Z",
+        "local_path": "./eee-out/data/miniwob/Azure/…json"
+      }
+    }
+
+Or for a broken experiment:
+
+    {
+      "journal": {
+        "status": "rejected",
+        "reason": "broken: 18% of episodes errored, threshold is 10%",
+        "decided_at": "2026-06-03T12:00:00Z"
+      }
+    }
+
+The scan script treats both ``"status": "submitted"`` and
+``"status": "rejected"`` as "do not consider for re-submission." Only the
+absence of a destination key triggers a fresh eligibility check.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+SUBMISSIONS_FILENAME = "submissions.json"
+
+# Destination keys used in submissions.json. Extend the literal as new
+# destinations are added.
+SubmissionDestination = Literal["journal", "eee"]
+
+
+def _path(experiment_dir: Path) -> Path:
+    return Path(experiment_dir) / SUBMISSIONS_FILENAME
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def read(experiment_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return the parsed submissions.json, or an empty dict when the file is missing."""
+    path = _path(experiment_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def has_decision(experiment_dir: Path, destination: SubmissionDestination) -> bool:
+    """True iff *destination* already has a submitted-or-rejected entry."""
+    entry = read(experiment_dir).get(destination)
+    return isinstance(entry, dict) and entry.get("status") in {"submitted", "rejected"}
+
+
+def _write_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """tmp-file + os.replace so a crash mid-write never leaves a half-file behind."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def record_submitted(
+    experiment_dir: Path,
+    destination: SubmissionDestination,
+    *,
+    evaluation_id: str,
+    schema_version: str,
+    submitted_by: str | None = None,
+    pr_url: str | None = None,
+    local_path: str | None = None,
+) -> None:
+    """Record a successful submission for *destination*.
+
+    Idempotent: overwrites a prior entry for the same destination. The scan
+    script considers any present entry as "do not re-submit", so a re-run is
+    safe but pointless.
+    """
+    payload = read(experiment_dir)
+    entry: dict[str, Any] = {
+        "status": "submitted",
+        "evaluation_id": evaluation_id,
+        "schema_version": schema_version,
+        "submitted_at": _now_iso(),
+    }
+    if submitted_by:
+        entry["submitted_by"] = submitted_by
+    if pr_url:
+        entry["pr_url"] = pr_url
+    if local_path:
+        entry["local_path"] = local_path
+    payload[destination] = entry
+    _write_atomic(_path(experiment_dir), payload)
+
+
+def record_rejected(
+    experiment_dir: Path,
+    destination: SubmissionDestination,
+    *,
+    reason: str,
+) -> None:
+    """Permanently mark *destination* as non-submission-worthy with *reason*.
+
+    Used by the scan script when an experiment fails an eligibility check that
+    can never resolve favorably (e.g. > N% system errors). Idempotent: keeps
+    the original rejection timestamp if one was already recorded, so the
+    diagnosis history isn't lost.
+    """
+    payload = read(experiment_dir)
+    existing = payload.get(destination, {})
+    decided_at = existing.get("decided_at") if existing.get("status") == "rejected" else _now_iso()
+    payload[destination] = {
+        "status": "rejected",
+        "reason": reason,
+        "decided_at": decided_at,
+    }
+    _write_atomic(_path(experiment_dir), payload)

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -234,6 +234,37 @@ def test_agent_info_from_agent_config_basic(mock_agent_config) -> None:
     assert isinstance(info.framework_version, str)
 
 
+def test_agent_info_primary_dependencies_subset_of_versions(mock_agent_config) -> None:
+    """primary_dependencies must always be a subset of the recorded versions dict."""
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    assert set(info.primary_dependencies).issubset(info.dependency_versions)
+
+
+def test_agent_info_includes_cube_harness_in_deps(mock_agent_config) -> None:
+    """cube-harness is in _ALWAYS_INCLUDE — must appear even if sys.modules walk fails."""
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    assert "cube-harness" in info.dependency_versions
+
+
+def test_collect_dependency_versions_excludes_drop_list() -> None:
+    """The drop-list filters behaviorally-inert plumbing out of the recorded deps."""
+    from cube_harness.eval_log import _AUTO_DROP_DEPENDENCIES, _collect_dependency_versions
+
+    versions, _ = _collect_dependency_versions()
+    assert set(versions).isdisjoint(_AUTO_DROP_DEPENDENCIES), (
+        f"drop-list leak: {set(versions) & _AUTO_DROP_DEPENDENCIES}"
+    )
+
+
+def test_collect_dependency_versions_primary_is_marked() -> None:
+    """primary_names only contains distributions present in _PRIMARY_DEPENDENCIES AND installed."""
+    from cube_harness.eval_log import _PRIMARY_DEPENDENCIES, _collect_dependency_versions
+
+    versions, primary = _collect_dependency_versions()
+    assert set(primary).issubset(_PRIMARY_DEPENDENCIES)
+    assert set(primary).issubset(versions)
+
+
 def test_agent_info_captures_cube_standard_git(mock_agent_config) -> None:
     info = AgentInfo.from_agent_config(mock_agent_config)
     # Populated only for an editable/source cube-standard checkout; None for a

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -246,6 +246,22 @@ def test_agent_info_includes_cube_harness_in_deps(mock_agent_config) -> None:
     assert "cube-harness" in info.dependency_versions
 
 
+def test_agent_info_records_cube_standard_distribution(mock_agent_config) -> None:
+    """The installed cube-standard distribution must be recorded (PS-001).
+
+    Regression test for a code-review finding: the original _ALWAYS_INCLUDE
+    listed 'cube' (the import name) instead of 'cube-standard' (the
+    distribution name), silently dropping cube-standard's version from
+    every recorded run. PR-#476 review W1.
+    """
+    info = AgentInfo.from_agent_config(mock_agent_config)
+    assert "cube-standard" in info.dependency_versions, (
+        f"cube-standard missing from recorded dependency_versions; "
+        f"recorded distributions: {sorted(info.dependency_versions)}"
+    )
+    assert "cube-standard" in info.primary_dependencies
+
+
 def test_collect_dependency_versions_excludes_drop_list() -> None:
     """The drop-list filters behaviorally-inert plumbing out of the recorded deps."""
     from cube_harness.eval_log import _AUTO_DROP_DEPENDENCIES, _collect_dependency_versions

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -234,6 +234,50 @@ class TestBuildEEERecord:
         record = build_eee_record(populated_exp_dir)
         assert record["model_info"]["developer"] == "Azure"
 
+
+class TestProviderPrefixMapping:
+    """Coverage for the explicit prefix → display-name table (W4)."""
+
+    @pytest.mark.parametrize(
+        "llm_model,expected",
+        [
+            ("openai/gpt-4o", "OpenAI"),  # was "Openai"
+            ("azure/gpt-5.4-mini", "Azure"),
+            ("anthropic/claude-opus-4-7", "Anthropic"),
+            ("vertex_ai/gemini-2.0", "Google Vertex AI"),  # was "Vertex_Ai"
+            ("huggingface/llama", "HuggingFace"),  # was "Huggingface"
+            ("bedrock/anthropic.claude-3-5", "AWS Bedrock"),  # was "Bedrock"
+            ("openrouter/anthropic/claude-3-5-sonnet", "Anthropic"),  # 2-deep routing
+            ("together_ai/llama", "Together AI"),
+            ("groq/llama-3-70b", "Groq"),
+            ("nonexistent_provider/model", "nonexistent_provider"),  # fallback
+            ("", ""),
+            ("no-slash-model", ""),
+        ],
+    )
+    def test_llm_developer_mapping(self, llm_model: str, expected: str) -> None:
+        from cube_harness.reproducibility.eee import _llm_developer
+
+        assert _llm_developer(llm_model) == expected
+
+
+class TestEEEEvaluationIdNoneSafety:
+    """Regression for W3: f"{None}" formatting in evaluation_id."""
+
+    def test_none_llm_model_does_not_appear_as_literal_None(self, populated_exp_dir: Path) -> None:
+        # Reload + null out llm_model on disk to simulate the bad path.
+        import json as _json
+
+        rec_path = populated_exp_dir / "experiment_record.json"
+        data = _json.loads(rec_path.read_text())
+        data["agent"]["llm_model"] = None
+        rec_path.write_text(_json.dumps(data))
+
+        record = build_eee_record(populated_exp_dir)
+        eid = record["evaluation_id"]
+        assert "/None/" not in eid, f"literal 'None' leaked into EEE id: {eid!r}"
+        assert "/unknown/" in eid, f"expected 'unknown' fallback, got: {eid!r}"
+
     def test_evaluation_results_has_one_entry_with_score_and_uncertainty(self, populated_exp_dir: Path) -> None:
         record = build_eee_record(populated_exp_dir)
         results = record["evaluation_results"]

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,244 @@
+"""Tests for cube_harness.reproducibility — journal + EEE converters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cube_harness.episode_status import STATUS_FILENAME, EpisodeStatus, Status
+from cube_harness.eval_log import (
+    AgentInfo,
+    BenchmarkSubset,
+    EpisodeRecord,
+    EvalLibrary,
+    EvalLog,
+    ExperimentRecord,
+    UsageSummary,
+)
+from cube_harness.reproducibility import (
+    JOURNAL_SCHEMA_VERSION,
+    Outcomes,
+    build_journal_record,
+    sanitize_filename,
+)
+from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
+from cube_harness.reproducibility.journal import classify
+from cube_harness.storage import EPISODES_DIR
+
+
+def _agent_info() -> AgentInfo:
+    return AgentInfo(
+        agent_id="a" * 64,
+        config_type="GennyConfig",
+        config={"_type": "GennyConfig", "model": "azure/gpt-5.4-mini"},
+        llm_model="azure/gpt-5.4-mini",
+        framework_version="0.5.2",
+        dependency_versions={"cube-harness": "0.5.2", "cube": "0.3.1"},
+        git_commit="f" * 40,
+        git_remote_url="https://github.com/The-AI-Alliance/cube-harness/tree/" + "f" * 40,
+        git_is_dirty=False,
+        cube_standard_git_commit="8" * 40,
+        cube_standard_git_is_dirty=False,
+    )
+
+
+def _exp_record(n_tasks: int = 5) -> ExperimentRecord:
+    return ExperimentRecord(
+        evaluation_id="20260404_195953_genny_miniwob",
+        experiment_name="genny_miniwob",
+        evaluation_timestamp=1_748_560_000.0,
+        eval_library=EvalLibrary(version="0.5.2"),
+        agent=_agent_info(),
+        benchmark_name="miniwob",
+        benchmark_version="1.0.0",
+        benchmark_subset=BenchmarkSubset(name="miniwob[level=all]", n_tasks=n_tasks, filter="level=all"),
+    )
+
+
+def _ep_record(task_id: str, score: float, error: str | None = None) -> EpisodeRecord:
+    return EpisodeRecord(
+        evaluation_id="20260404_195953_genny_miniwob",
+        sample_id=task_id,
+        is_correct=score > 0,
+        score=score,
+        error=error,
+        num_turns=3,
+        n_agent_steps=1,
+        n_env_steps=2,
+        wall_time_s=10.0,
+        usage=UsageSummary(total_cost_usd=0.05),
+        trajectory_id=f"{task_id}_ep0",
+        timestamp=1_748_560_000.0,
+    )
+
+
+def _write_status(exp_dir: Path, task_id: str, status: Status, reward: float | None) -> None:
+    """Write the per-episode status.json that ExperimentResult.iter_episode_statuses() reads."""
+    trajectory_id = f"{task_id}_ep0"
+    ep_dir = exp_dir / EPISODES_DIR / trajectory_id
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    EpisodeStatus(
+        status=status,
+        task_id=task_id,
+        episode_id=0,
+        started_at=1.0,
+        ended_at=2.0,
+        reward=reward,
+    ).write(ep_dir / STATUS_FILENAME)
+
+
+@pytest.fixture
+def populated_exp_dir(tmp_path: Path) -> Path:
+    """An experiment dir with one episode per outcome bucket (success/failure/max_steps/system_error/missing-CANCELLED)."""
+    exp_dir = tmp_path / "20260404_195953_genny_miniwob"
+    exp_dir.mkdir()
+
+    exp = _exp_record(n_tasks=5)
+    episodes = [
+        _ep_record("t_success", score=1.0),
+        _ep_record("t_failure", score=0.0),
+        _ep_record("t_max_steps", score=0.0),
+        _ep_record("t_system_error", score=0.0, error="ValueError"),
+        # t_missing has no EpisodeRecord — exercises the "no record" missing path.
+    ]
+    EvalLog(experiment=exp, episodes=episodes).save(exp_dir)
+
+    _write_status(exp_dir, "t_success", "COMPLETED", reward=1.0)
+    _write_status(exp_dir, "t_failure", "COMPLETED", reward=0.0)
+    _write_status(exp_dir, "t_max_steps", "MAX_STEPS_REACHED", reward=0.0)
+    _write_status(exp_dir, "t_system_error", "FAILED", reward=None)
+    _write_status(exp_dir, "t_missing", "CANCELLED", reward=None)
+    return exp_dir
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "status,reward,expected",
+        [
+            ("COMPLETED", 1.0, "n_success"),
+            ("COMPLETED", 0.5, "n_success"),
+            ("COMPLETED", 0.0, "n_failure"),
+            ("COMPLETED", None, "n_failure"),
+            ("MAX_STEPS_REACHED", 0.0, "n_max_steps"),
+            ("FAILED", None, "n_system_error"),
+            ("STALE", None, "n_system_error"),
+            ("INVALID_CONFIG", None, "n_system_error"),
+            ("CANCELLED", None, "n_missing"),
+            ("QUEUED", None, "n_missing"),
+            ("RUNNING", None, "n_missing"),
+        ],
+    )
+    def test_classify(self, status: Status, reward: float | None, expected: str) -> None:
+        es = EpisodeStatus(status=status, task_id="t", episode_id=0, started_at=1.0, reward=reward)
+        assert classify(es) == expected
+
+
+class TestSanitizeFilename:
+    def test_slashes_become_double_underscore(self) -> None:
+        assert sanitize_filename("alacoste/run1") == "alacoste__run1"
+
+    def test_no_op_when_no_slash(self) -> None:
+        assert sanitize_filename("plain-id") == "plain-id"
+
+
+class TestOutcomes:
+    def test_total_sums_all_buckets(self) -> None:
+        o = Outcomes(n_success=3, n_failure=2, n_max_steps=1, n_system_error=4, n_missing=0)
+        assert o.total() == 10
+
+    def test_to_dict_round_trip(self) -> None:
+        o = Outcomes(n_success=1, n_failure=1, n_max_steps=1, n_system_error=1, n_missing=1)
+        d = o.to_dict()
+        assert set(d) == {"n_success", "n_failure", "n_max_steps", "n_system_error", "n_missing"}
+        assert sum(d.values()) == 5
+
+
+class TestBuildJournalRecord:
+    def test_outcomes_breakdown(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        outcomes = record["results"]["outcomes"]
+        assert outcomes == {
+            "n_success": 1,
+            "n_failure": 1,
+            "n_max_steps": 1,
+            "n_system_error": 1,
+            "n_missing": 1,  # 1 CANCELLED — see status.json setup
+        }
+
+    def test_outcomes_sum_equals_n_tasks(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        outcomes = record["results"]["outcomes"]
+        assert sum(outcomes.values()) == record["benchmark_subset"]["n_tasks"]
+
+    def test_avg_score_from_episode_records(self, populated_exp_dir: Path) -> None:
+        # 4 episodes recorded (one of them score=1.0, three score=0.0): mean = 0.25.
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["results"]["avg_score"] == pytest.approx(0.25)
+
+    def test_total_cost_summed(self, populated_exp_dir: Path) -> None:
+        # 4 episodes × 0.05 USD = 0.20.
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["results"]["total_cost_usd"] == pytest.approx(0.20)
+
+    def test_evaluation_id_namespaced_by_submitter(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["evaluation_id"] == "alacoste/20260404_195953_genny_miniwob"
+
+    def test_schema_version_pinned(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["schema_version"] == JOURNAL_SCHEMA_VERSION
+
+    def test_cube_id_defaults_to_stripped_benchmark_name(self, populated_exp_dir: Path) -> None:
+        # ExperimentRecord.benchmark_subset.name is "miniwob[level=all]" — must
+        # become "miniwob" as benchmark_name (cube-registry's <cube-id>).
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["benchmark_name"] == "miniwob"
+
+    def test_cube_id_override_respected(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste", cube_id="forced")
+        assert record["benchmark_name"] == "forced"
+
+    def test_agent_provenance_included(self, populated_exp_dir: Path) -> None:
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        agent = record["agent"]
+        assert agent["git_commit"] == "f" * 40
+        assert agent["cube_standard_git_commit"] == "8" * 40
+        assert agent["git_is_dirty"] is False
+        assert agent["agent_id"] == "a" * 64
+
+
+class TestBuildEEERecord:
+    def test_schema_version_and_required_top_level(self, populated_exp_dir: Path) -> None:
+        record = build_eee_record(populated_exp_dir)
+        assert record["schema_version"] == EEE_SCHEMA_VERSION
+        for key in (
+            "evaluation_id",
+            "retrieved_timestamp",
+            "source_metadata",
+            "model_info",
+            "eval_library",
+            "evaluation_results",
+        ):
+            assert key in record, f"missing required EEE field: {key}"
+
+    def test_provenance_stashed_in_source_metadata_additional_details(self, populated_exp_dir: Path) -> None:
+        record = build_eee_record(populated_exp_dir)
+        extras = record["source_metadata"]["additional_details"]
+        # All values must be strings (EEE schema rule).
+        assert all(isinstance(v, str) for v in extras.values())
+        assert extras["cube_harness_git_commit"] == "f" * 40
+        assert extras["cube_standard_git_commit"] == "8" * 40
+
+    def test_model_developer_extracted_from_provider_prefix(self, populated_exp_dir: Path) -> None:
+        record = build_eee_record(populated_exp_dir)
+        assert record["model_info"]["developer"] == "Azure"
+
+    def test_evaluation_results_has_one_entry_with_score_and_uncertainty(self, populated_exp_dir: Path) -> None:
+        record = build_eee_record(populated_exp_dir)
+        results = record["evaluation_results"]
+        assert len(results) == 1
+        result = results[0]
+        assert result["score_details"]["score"] == pytest.approx(0.25)
+        assert "uncertainty" in result["score_details"]
+        assert result["score_details"]["uncertainty"]["num_samples"] == 4

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from cube_harness.episode_status import Status
+from cube_harness.episode_status import EpisodeStatus, Status
 from cube_harness.eval_log import EvalLog
 from cube_harness.reproducibility import submissions
 from cube_harness.reproducibility.scan import (
@@ -230,3 +230,90 @@ class TestWalk:
 
     def test_walk_returns_empty_for_missing_root(self, tmp_path: Path) -> None:
         assert walk(tmp_path / "does_not_exist") == []
+
+
+class TestSweepIntegration:
+    def _write_dead_worker_episode(self, exp_dir: Path, task_id: str = "t3") -> str:
+        """Plant a RUNNING episode whose heartbeat is way past the sweep threshold.
+
+        FileStorage.list_episode_statuses only surfaces episode dirs that
+        carry an episode_config.json (planned-or-run marker), so the stub
+        below mirrors what Experiment.prepare_episodes writes at startup.
+        """
+        traj_id = f"{task_id}_ep0"
+        ep_dir = exp_dir / "episodes" / traj_id
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        (ep_dir / "episode_config.json").write_text("{}")
+        EpisodeStatus(
+            status="RUNNING",
+            task_id=task_id,
+            episode_id=0,
+            started_at=0.0,
+            last_heartbeat_at=0.0,  # ancient — well past step_timeout
+        ).write(ep_dir / "status.json")
+        return traj_id
+
+    def test_sweep_converts_dead_running_to_stale(self, tmp_path: Path) -> None:
+        """A RUNNING episode with a stale heartbeat must roll into n_system_error."""
+        from cube_harness.reproducibility.scan import sweep_stale_in_dir
+
+        exp_dir = tmp_path / "sweep"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, n_tasks=4)
+        traj_id = self._write_dead_worker_episode(exp_dir)
+
+        swept = sweep_stale_in_dir(exp_dir)
+        assert traj_id in swept, f"sweep should have caught the dead worker: {swept}"
+
+    def test_classify_with_sweep_disabled_keeps_in_flight_signal(self, tmp_path: Path) -> None:
+        """--no-sweep-stale leaves the on-disk status as-is."""
+        exp_dir = tmp_path / "no_sweep"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, n_tasks=4)
+        _add_status(exp_dir, "t3", "RUNNING")  # stays RUNNING when sweep skipped
+        result = classify(exp_dir, sweep_stale=False)
+        assert result.category is ScanCategory.unfinished
+
+    def test_classify_with_sweep_promotes_dead_to_broken(self, tmp_path: Path) -> None:
+        """With sweep on, a dead RUNNING episode becomes STALE and (when its rate
+        crosses the threshold) the experiment goes BROKEN."""
+        exp_dir = tmp_path / "swept"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, n_tasks=4)
+        self._write_dead_worker_episode(exp_dir)
+        # With 1 swept STALE among 4 terminal = 25% system error → > 10% threshold.
+        result = classify(exp_dir, sweep_stale=True, system_error_threshold=0.10)
+        assert result.category is ScanCategory.broken
+        assert result.n_system_error >= 1
+
+
+class TestArchive:
+    def test_archive_renames_with_marker(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility.scan import archive_experiment_dir
+        from cube_harness.storage import ARCHIVED_MARKER
+
+        exp_dir = tmp_path / "to_archive"
+        exp_dir.mkdir()
+        new_path = archive_experiment_dir(exp_dir)
+        assert ARCHIVED_MARKER in new_path.name
+        assert new_path.exists()
+        assert not exp_dir.exists()
+
+    def test_archive_is_idempotent_on_already_archived(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility.scan import archive_experiment_dir
+        from cube_harness.storage import ARCHIVED_MARKER
+
+        archived = tmp_path / f"already{ARCHIVED_MARKER}1234.5"
+        archived.mkdir()
+        new_path = archive_experiment_dir(archived)
+        # No double-archive: returned path is the same.
+        assert new_path == archived
+
+    def test_walk_skips_archived_dirs(self, tmp_path: Path) -> None:
+        from cube_harness.storage import ARCHIVED_MARKER
+
+        _populate_clean_run(tmp_path / "live")
+        _populate_clean_run(tmp_path / f"old{ARCHIVED_MARKER}9999.0")
+        results = walk(tmp_path)
+        names = {r.experiment_dir.name for r in results}
+        assert names == {"live"}, f"archived dir should be skipped: {names}"

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,232 @@
+"""Tests for cube_harness.reproducibility.scan + submissions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cube_harness.episode_status import Status
+from cube_harness.eval_log import EvalLog
+from cube_harness.reproducibility import submissions
+from cube_harness.reproducibility.scan import (
+    ScanCategory,
+    classify,
+    walk,
+)
+
+# Reuse the helpers from the reproducibility test module.
+from tests.test_reproducibility import _ep_record, _exp_record, _write_status
+
+# ──────────────────────────────────────────────────────────────────────────
+# Submissions helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestSubmissions:
+    def test_read_missing_returns_empty(self, tmp_path: Path) -> None:
+        assert submissions.read(tmp_path) == {}
+
+    def test_has_decision_false_when_no_file(self, tmp_path: Path) -> None:
+        assert not submissions.has_decision(tmp_path, "journal")
+
+    def test_record_submitted_roundtrip(self, tmp_path: Path) -> None:
+        submissions.record_submitted(
+            tmp_path,
+            "journal",
+            evaluation_id="alacoste/run_1",
+            schema_version="1.0",
+            submitted_by="alacoste",
+            pr_url="https://example/pr/1",
+            local_path="/tmp/x.json",
+        )
+        assert submissions.has_decision(tmp_path, "journal")
+        data = submissions.read(tmp_path)
+        assert data["journal"]["status"] == "submitted"
+        assert data["journal"]["evaluation_id"] == "alacoste/run_1"
+        assert "submitted_at" in data["journal"]
+
+    def test_record_rejected_preserves_initial_timestamp(self, tmp_path: Path) -> None:
+        submissions.record_rejected(tmp_path, "journal", reason="broken: errors")
+        first = submissions.read(tmp_path)["journal"]["decided_at"]
+        # Re-rejecting must keep the original timestamp so history isn't lost.
+        submissions.record_rejected(tmp_path, "journal", reason="broken: errors")
+        second = submissions.read(tmp_path)["journal"]["decided_at"]
+        assert first == second
+
+    def test_journal_and_eee_coexist(self, tmp_path: Path) -> None:
+        submissions.record_submitted(
+            tmp_path,
+            "journal",
+            evaluation_id="j/1",
+            schema_version="1.0",
+        )
+        submissions.record_submitted(
+            tmp_path,
+            "eee",
+            evaluation_id="e/1",
+            schema_version="0.2.2",
+        )
+        data = submissions.read(tmp_path)
+        assert set(data) == {"journal", "eee"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Scan fixtures
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _populate_clean_run(exp_dir: Path, n_tasks: int = 3, n_success: int = 3) -> None:
+    """An experiment dir with n_tasks tasks, all COMPLETED with reward 1/0."""
+    exp_dir.mkdir(parents=True, exist_ok=True)
+    exp = _exp_record(n_tasks=n_tasks)
+    EvalLog(experiment=exp, episodes=[_ep_record(f"t{i}", 1.0) for i in range(n_tasks)]).save(exp_dir)
+    for i in range(n_tasks):
+        reward = 1.0 if i < n_success else 0.0
+        _write_status(exp_dir, f"t{i}", "COMPLETED", reward=reward)
+
+
+def _set_record_field(exp_dir: Path, **kwargs) -> None:
+    """Patch experiment_record.json with the supplied top-level fields."""
+    path = exp_dir / "experiment_record.json"
+    data = json.loads(path.read_text())
+    data.update(kwargs)
+    path.write_text(json.dumps(data))
+
+
+def _set_subset_field(exp_dir: Path, **kwargs) -> None:
+    path = exp_dir / "experiment_record.json"
+    data = json.loads(path.read_text())
+    data["benchmark_subset"].update(kwargs)
+    path.write_text(json.dumps(data))
+
+
+def _add_status(exp_dir: Path, task_id: str, status: Status, reward: float | None = None) -> None:
+    _write_status(exp_dir, task_id, status, reward=reward)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Classifier
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestClassifierHappyPath:
+    def test_clean_full_subset_is_submittable(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "clean"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.submittable
+        assert result.reasons == ()
+
+
+class TestClassifierBroken:
+    def test_missing_record_is_broken(self, tmp_path: Path) -> None:
+        # No experiment_record.json at all.
+        d = tmp_path / "ghost"
+        d.mkdir()
+        result = classify(d)
+        assert result.category is ScanCategory.broken
+        assert "missing" in result.reasons[0] or "unparseable" in result.reasons[0]
+
+    def test_corrupt_record_is_broken(self, tmp_path: Path) -> None:
+        d = tmp_path / "corrupt"
+        d.mkdir()
+        (d / "experiment_record.json").write_text("{not valid json")
+        result = classify(d)
+        assert result.category is ScanCategory.broken
+
+    def test_high_system_error_rate_is_broken(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "errored"
+        _populate_clean_run(exp_dir, n_tasks=4, n_success=0)
+        # Replace 2 of 4 COMPLETED statuses with FAILED.
+        for i in (0, 1):
+            _add_status(exp_dir, f"t{i}", "FAILED")
+        result = classify(exp_dir, system_error_threshold=0.10)
+        assert result.category is ScanCategory.broken
+        assert "errored" in result.reasons[0]
+
+    def test_no_terminal_episodes_is_broken(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "empty"
+        exp_dir.mkdir()
+        exp = _exp_record(n_tasks=3)
+        EvalLog(experiment=exp, episodes=[]).save(exp_dir)
+        # No status.json files written at all.
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.broken
+
+
+class TestClassifierUnfinished:
+    def test_in_flight_episode_is_unfinished(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "running"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        # Add a 4th status that's still RUNNING.
+        _set_subset_field(exp_dir, n_tasks=4)
+        _add_status(exp_dir, "t3", "RUNNING")
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.unfinished
+        assert "QUEUED/RUNNING" in result.reasons[0]
+
+    def test_missing_status_files_is_unfinished(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "partial"
+        _populate_clean_run(exp_dir, n_tasks=5, n_success=3)
+        # Bump n_tasks to 10 — 5 tasks have no status file at all.
+        _set_subset_field(exp_dir, n_tasks=10)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.unfinished
+        assert "have no status file" in result.reasons[0]
+
+
+class TestClassifierSubsetReview:
+    def test_debug_limit_flagged(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "debug"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_record_field(exp_dir, debug_limit=3)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.subset_review
+        assert any("debug_limit" in r for r in result.reasons)
+
+    def test_explicit_task_list_flagged(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "handpicked"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, task_ids=["t0", "t1", "t2"])
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.subset_review
+        assert any("hand-picked" in r for r in result.reasons)
+
+
+class TestClassifierIdempotency:
+    def test_already_submitted_takes_priority(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "submitted"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        submissions.record_submitted(
+            exp_dir,
+            "journal",
+            evaluation_id="alice/run1",
+            schema_version="1.0",
+        )
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.already_submitted
+        assert "alice/run1" in result.reasons[0]
+
+    def test_rejected_also_blocks(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "rejected"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        submissions.record_rejected(exp_dir, "journal", reason="broken: test")
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.already_submitted
+
+
+class TestWalk:
+    def test_walk_skips_non_experiment_dirs(self, tmp_path: Path) -> None:
+        # Real experiment dir
+        _populate_clean_run(tmp_path / "real")
+        # Random non-experiment dir
+        (tmp_path / "junk").mkdir()
+        (tmp_path / "junk" / "readme.txt").write_text("hi")
+        # Stray file at root — must be ignored
+        (tmp_path / "loose_file.json").write_text("{}")
+
+        results = walk(tmp_path)
+        assert {r.experiment_dir.name for r in results} == {"real"}
+
+    def test_walk_returns_empty_for_missing_root(self, tmp_path: Path) -> None:
+        assert walk(tmp_path / "does_not_exist") == []


### PR DESCRIPTION
## Summary

- New `cube_harness.reproducibility` package: two pure converters that read an existing `EvalLog` and emit records for two independent destinations — the cube-registry community journal (cube-native, drives the per-cube UI) and Every Eval Ever / EvalEval (community-scale HF dataset). Both share the same source of truth; neither depends on the other.
- Two Typer CLIs (`scripts/submit_to_journal.py`, `scripts/submit_to_eee.py`) — one-line submissions from any experiment directory, with `--auto-pr` for the journal path.
- 28 unit tests + end-to-end cross-validation against both authoritative schemas.

Companion PR on cube-registry: [#49](https://github.com/The-AI-Alliance/cube-registry/pull/49).

## The outcome breakdown

Maps cube-harness's 8 `EpisodeStatus` values into the 5 mutually-exclusive, exhaustive buckets the cube-registry schema requires (summing to `benchmark_subset.n_tasks`):

| cube-harness status | journal bucket |
|---|---|
| `COMPLETED` + reward > 0 | `n_success` |
| `COMPLETED` + reward == 0 | `n_failure` |
| `MAX_STEPS_REACHED` | `n_max_steps` |
| `FAILED` / `STALE` / `INVALID_CONFIG` | `n_system_error` |
| `CANCELLED` / `QUEUED` / `RUNNING` / no status file | `n_missing` |

This lets the registry UI distinguish "low score because hard" from "low score because the runner crashed on most tasks" — see `cube-registry/openspec/changes/results-journal/proposal.md`.

## EEE schema accommodations

EEE's top-level is `additionalProperties: false`, so cube-specific provenance (`git_commit`, `cube_standard_git_commit`, `agent_id`, `git_is_dirty`, `dep:*` versions) lives in `source_metadata.additional_details` as string KVs. The aggregate score + uncertainty (analytic std_err, num_samples) goes into one `evaluation_results[]` entry; per-episode data is intentionally not emitted in V1 (EEE has `detailed_evaluation_results` for that — easy to add later).

## Files

- `src/cube_harness/reproducibility/__init__.py`
- `src/cube_harness/reproducibility/journal.py` — cube-registry converter (~210 lines)
- `src/cube_harness/reproducibility/eee.py` — EEE converter (~155 lines)
- `scripts/submit_to_journal.py` — Typer CLI (~180 lines)
- `scripts/submit_to_eee.py` — Typer CLI (~85 lines)
- `tests/test_reproducibility.py` — 28 unit tests including end-to-end build

## Test plan

- [x] `pytest tests/test_reproducibility.py` — 28 passed
- [x] `pytest tests/test_eval_log.py tests/test_inspect_results.py tests/test_experiment.py` — 122 passed (no regressions in the area I touched)
- [x] `make lint` clean
- [x] Cross-validation: journal output passes `cube-registry/results-schema.json` via `jsonschema.Draft7Validator`
- [x] Cross-validation: EEE output passes `eval.schema.json` v0.2.2 via the same validator
- [ ] End-to-end: run `submit_to_journal.py` on a real `~/cube_harness_results/<exp_dir>` once cube-registry#49 merges; expected output is a PR that auto-merges (validator + auto-merge gated on cube-registry#49)
- [ ] End-to-end: run `submit_to_eee.py` on the same dir; produces an EEE-shaped JSON ready for `huggingface-cli upload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)