### PR TITLE
fix(resume): reclaim orphaned QUEUED claims by driver identity, not age

### DIFF
--- a/src/cube_harness/episode_status.py
+++ b/src/cube_harness/episode_status.py
@@ -132,6 +132,38 @@ def should_sweep_running_to_stale(
     return now - status.last_heartbeat_at > step_timeout_s + cancel_grace_s
 
 
+def should_sweep_queued_to_stale(
+    status: EpisodeStatus,
+    *,
+    now: float,
+    orphan_threshold_s: float,
+    process_start_s: float | None = None,
+) -> bool:
+    """Return True iff a QUEUED episode is orphaned and should become STALE.
+
+    A QUEUED claim has no heartbeat (the worker never entered `_run_loop`), so
+    liveness is judged from `started_at`:
+
+    - `started_at` predates `process_start_s` — the claim is from a prior,
+      now-dead driver process. A freshly started driver owns the output dir
+      exclusively, so any QUEUED it finds at round start was claimed before it
+      existed → reclaim regardless of age. This is the QUEUED analogue of
+      `should_sweep_running_to_stale`'s `process_start_s` check, and is what
+      makes a crash-then-resume pick the episode up instead of skipping it.
+    - `started_at` older than `orphan_threshold_s` — within the *same* driver,
+      Ray never picked the task up (dead / unschedulable worker). Bounded fallback.
+
+    This predicate is only consulted by the round-boundary `sweep_stale_statuses`,
+    never in the live `_poll_ray` loop, so it cannot false-cancel a task that is
+    legitimately waiting its turn behind busy workers — the failure mode that got
+    the live-loop time-based QUEUED timeout reverted (#445 → #458, fixed live by
+    the capacity gate in #459). Driver-identity, not elapsed time, is the signal.
+    """
+    if process_start_s is not None and status.started_at < process_start_s:
+        return True
+    return now - status.started_at > orphan_threshold_s
+
+
 def next_retry_count(prior: "EpisodeStatus | None") -> int:
     """Return the retry_count for a new attempt, given the prior status (if any).
 

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -16,7 +16,12 @@ from cube_harness.agent import AgentConfig
 from cube_harness.core import Trajectory
 from cube_harness.episode import MAX_STEPS, Episode
 from cube_harness.episode_logs import trajectory_log_id
-from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus, should_sweep_running_to_stale
+from cube_harness.episode_status import (
+    RETRIABLE_STATUSES,
+    EpisodeStatus,
+    should_sweep_queued_to_stale,
+    should_sweep_running_to_stale,
+)
 from cube_harness.eval_log import EvalLog, ExperimentRecord
 from cube_harness.storage import FileStorage
 
@@ -148,8 +153,12 @@ class Experiment(TypedBaseModel):
             except Exception:
                 logger.exception(f"Failed to load episode config {config_file}")
                 continue
-            # Existing trajectory (if any) will be archived on the next save_trajectory.
-            episode.allow_overwrite = status is not None
+            # A resume-selected episode is being re-run, so any existing trajectory
+            # (a partial from a crashed/killed/orphaned attempt) must be archived on
+            # the next save_trajectory. Deriving this from `status is not None` instead
+            # silently FileExistsErrors whenever a status file is absent but trajectory
+            # data remains — selection already means "re-run this", so always allow it.
+            episode.allow_overwrite = True
             episodes.append(episode)
 
         logger.info(f"Selected {len(episodes)} episode(s) to run (out of {len(config_files)} total) with resume=True")
@@ -317,8 +326,12 @@ def sweep_stale_statuses(
                 process_start_s=process_start_s,
             )
         elif status.status == "QUEUED":
-            if now - status.started_at > orphan_threshold_s:
-                is_stale = True
+            is_stale = should_sweep_queued_to_stale(
+                status,
+                now=now,
+                orphan_threshold_s=orphan_threshold_s,
+                process_start_s=process_start_s,
+            )
         if not is_stale:
             continue
         prior_state = status.status

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -510,6 +510,73 @@ class TestStatusBasedSelection:
             assert storage.read_episode_status(traj_id).status == initial_status
 
     # ------------------------------------------------------------------
+    # QUEUED orphan reclamation by driver identity (process_start_s)
+    # ------------------------------------------------------------------
+
+    def _seed_queued(self, tmp_dir: "Path", mock_agent_config: "MockAgentConfig", started_age: float) -> tuple:
+        """Seed a single QUEUED episode aged `started_age` seconds; return (storage, traj_id, now)."""
+        benchmark_config = _make_benchmark(1)
+        exp = Experiment(
+            name="test_q_orphan", output_dir=tmp_dir, agent_config=mock_agent_config, benchmark_config=benchmark_config
+        )
+        with benchmark_config.make() as benchmark:
+            episodes = exp.get_episodes_to_run(benchmark)
+        traj_id = f"{episodes[0].config.task_config.task_id}_ep{episodes[0].config.id}"
+        storage = FileStorage(tmp_dir)
+        now = time.time()
+        storage.write_episode_status(
+            traj_id,
+            EpisodeStatus(
+                status="QUEUED",
+                task_id=episodes[0].config.task_config.task_id,
+                episode_id=episodes[0].config.id,
+                started_at=now - started_age,
+                last_heartbeat_at=None,
+                current_step=0,
+            ),
+        )
+        return storage, traj_id, now
+
+    def test_sweep_queued_orphan_by_process_start(self, tmp_dir: "Path", mock_agent_config: "MockAgentConfig") -> None:
+        """A QUEUED claim from a prior, now-dead driver is reclaimed on resume.
+
+        The claim is only 30s old — far under the 3600s orphan_threshold — but it
+        predates `process_start_s` (this driver started 10s ago). Before the fix the
+        age-only QUEUED rule left it QUEUED; QUEUED is not in RETRIABLE_STATUSES, so a
+        crash-then-prompt-resume silently dropped it. Identity (predates this driver),
+        not age, is the signal.
+        """
+        storage, traj_id, now = self._seed_queued(tmp_dir, mock_agent_config, started_age=30.0)
+        swept = sweep_stale_statuses(
+            storage,
+            step_timeout_s=1800.0,
+            cancel_grace_s=120.0,
+            orphan_threshold_s=3600.0,
+            process_start_s=now - 10.0,  # claim's started_at (now-30) predates this driver
+        )
+        assert swept == [traj_id]
+        assert storage.read_episode_status(traj_id).status == "STALE"
+
+    def test_sweep_queued_live_claim_not_swept(self, tmp_dir: "Path", mock_agent_config: "MockAgentConfig") -> None:
+        """A QUEUED claim made by THIS driver is left alone (no #458-style false-cancel).
+
+        started_at (now-5) is AFTER process_start_s (now-10), i.e. the current driver
+        pre-claimed it this round and Ray simply hasn't dispatched it yet. It is under
+        orphan_threshold, so it must NOT be swept — the legitimately-waiting-behind-busy-
+        workers case that got the live-loop time timeout reverted (#445 → #458).
+        """
+        storage, traj_id, now = self._seed_queued(tmp_dir, mock_agent_config, started_age=5.0)
+        swept = sweep_stale_statuses(
+            storage,
+            step_timeout_s=1800.0,
+            cancel_grace_s=120.0,
+            orphan_threshold_s=3600.0,
+            process_start_s=now - 10.0,  # this driver started before the claim → live
+        )
+        assert swept == []
+        assert storage.read_episode_status(traj_id).status == "QUEUED"
+
+    # ------------------------------------------------------------------
     # Parametrized table: resume=True selection by status
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
# Fix Report — resume QUEUED-orphan reclamation

**Class**: L1 (correct; touches the shared resume/sweep path, no contract change)
**Context fingerprint**: `daytona/genny-swe/{gpt-5.4-mini,claude-haiku-4-5}/swebench-verified+terminalbench2`

Surfaced while collecting reference baselines (4× full runs, 2 benchmarks) on a laptop that slept/crashed mid-run. A plain `resume=True` after the crash selected ~10 of 500 episodes and silently reported a number over a fraction of the benchmark.

## Invariant violated
On `resume=True`, every episode that is not in a terminal state (COMPLETED / MAX_STEPS_REACHED) must be re-run — including in-flight claims (QUEUED / RUNNING) left behind by a prior, now-dead driver.

## Root cause
`sweep_stale_statuses` reclaims orphaned in-flight claims at round start, but treats the two in-flight states asymmetrically:
- **RUNNING** uses a driver-identity check — `last_heartbeat_at < process_start_s` ⇒ "from a prior, now-dead process" ⇒ reclaim (added in #365).
- **QUEUED** used an **age-only** check — `now - started_at > orphan_threshold_s` (default **3600s**).

A QUEUED claim has no heartbeat, so after a crash-then-prompt-resume the claim is only seconds/minutes old — far under 3600s — and is left QUEUED. `QUEUED ∉ RETRIABLE_STATUSES`, so `_should_relaunch` returns False and the episode is **silently dropped**. With ~460 done + ~40 fresh-but-orphaned QUEUED, resume selected ~10 and exited "complete."

Second, latent: `episode.allow_overwrite = (status is not None)` conflated "should I archive the old trajectory" with "does a status file happen to exist." Any reclaimed episode that left partial trajectory data on disk but whose status was absent then `FileExistsError`'d — and the in-run retry loop cached `allow_overwrite=False`, so it could not self-heal.

## Why this fix / why this layer
- Mirrors the RUNNING branch's existing `process_start_s` identity check for QUEUED via a new `should_sweep_queued_to_stale` helper, next to `should_sweep_running_to_stale` — the function that already owns "is this in-flight worker dead?". Centralization, not a new mechanism.
- **Driver-identity, not elapsed time.** This is deliberately *not* the reverted live-loop approach (#445 timed out QUEUED on `now - started_at` and false-cancelled 141/300 legitimately-waiting tasks → reverted in #458; fixed live by the capacity gate in #459). This predicate runs **only at round-boundary** `sweep_stale_statuses`, never in the live `_poll_ray` loop, so it cannot false-cancel a task waiting its turn behind busy workers: at round start the only QUEUED present were claimed before this round began.
- `allow_overwrite = True` for resume-selected episodes is the correct predicate: selection *means* "re-run this," and archiving nothing is a no-op.

## Blast radius
```
src/cube_harness/episode_status.py  +should_sweep_queued_to_stale (new helper, mirrors should_sweep_running_to_stale)
src/cube_harness/experiment.py:319  QUEUED branch now calls the helper (was age-only)
src/cube_harness/experiment.py:152  allow_overwrite = True  (was: status is not None)
```
`git grep sweep_stale_statuses origin/dev` → 2 callers, both round-boundary sweeps (`experiment.py:127` resume, `exp_runner.py:464` round shutdown); neither is the live poll loop. No behavior change for runs without orphaned QUEUED.

## Adversarial: the opposite user
A deep-queue live run (tasks ≫ workers) where many episodes sit QUEUED for hours — the exact case #458 protects. Ruled out: those claims have `started_at > process_start_s` (claimed by the *current* driver this round), so the identity check leaves them untouched; and the sweep never runs mid-round. The age fallback (`> orphan_threshold_s`) is unchanged from prior behavior.

## Registry lookup
No existing `auto-fix` footnotes in `experiment.py` / `episode_status.py` — first patch in this area, not an Nth band-aid.

## Test
- `test_sweep_queued_orphan_by_process_start` — QUEUED aged 30s (≪ 3600s threshold) but `started_at < process_start_s` ⇒ swept to STALE. (This is the cold-resume case that was silently skipped; it would have failed before the fix.)
- `test_sweep_queued_live_claim_not_swept` — QUEUED `started_at > process_start_s` (current driver's claim), under threshold ⇒ NOT swept. (Pins the #458 no-false-cancel guarantee.)
- Full `tests/test_experiment.py` (62) + `tests/test_xray_promote_ghost.py` green; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
