### PR TITLE
fix(browsercomp): drop eager default config so import succeeds (#479)

### DIFF
--- a/cubes/browsercomp/src/browsercomp_cube/configs.py
+++ b/cubes/browsercomp/src/browsercomp_cube/configs.py
@@ -1,19 +1,15 @@
 """Canonical BrowseComp benchmark configs.
 
-    from browsercomp_cube import BROWSECOMP_CONFIGS
-    benchmark = BROWSECOMP_CONFIGS["default"]
+    from browsercomp_cube import BrowseCompBenchmarkConfig
+    benchmark = BrowseCompBenchmarkConfig(scorer_model="openai/gpt-4o")
 
-The cube's intrinsic tool is answer submission; richer browsing tools are a
-recipe-side concern (clone the recipe and extend the ToolboxConfig).
+``scorer_model`` is required — the judge model used to grade answers — and has no
+sensible default, so the cube ships no pre-built default config. The cube's
+intrinsic tool is answer submission; richer browsing tools are a recipe-side
+concern (clone the recipe and extend the ToolboxConfig).
 """
 
 from cube.core import ConfigRegistry
-from cube.tool import ToolboxConfig
 from browsercomp_cube.benchmark import BrowseCompBenchmarkConfig
-from browsercomp_cube.tool import SubmitAnswerToolConfig
 
-BROWSECOMP_CONFIGS: ConfigRegistry[BrowseCompBenchmarkConfig] = ConfigRegistry(
-    {
-        "default": BrowseCompBenchmarkConfig(tool_config=ToolboxConfig(tool_configs=[SubmitAnswerToolConfig()])),
-    }
-)
+BROWSECOMP_CONFIGS: ConfigRegistry[BrowseCompBenchmarkConfig] = ConfigRegistry({})


### PR DESCRIPTION
Fixes #479.

## Problem

`import browsercomp_cube` raised a `pydantic.ValidationError` at module-load time:

```
scorer_model
  Field required [type=missing, input_value={'tool_config': ToolboxConfig(...)}, input_type=dict]
```

`BROWSECOMP_CONFIGS["default"]` instantiated `BrowseCompBenchmarkConfig(...)` eagerly at import, but `scorer_model` is a required field. As a result the cube could not be imported by anything (cube-registry `quick_check.py` Step 3, recipes, smoke tests).

## Fix

`scorer_model` is required **by design** — there is no sensible default judge model, so the user/recipe must pick one. Rather than fabricate a default `scorer_model`, this PR removes the pre-built `"default"` registry value (the entry that wrapped the `ToolboxConfig`). The registry is now empty; callers construct a config explicitly:

```python
from browsercomp_cube import BrowseCompBenchmarkConfig
benchmark = BrowseCompBenchmarkConfig(scorer_model="openai/gpt-4o")
```

No tool behaviour is lost: the task `make()` path already falls back to a default toolbox when `tool_config` is `None` (`task.py:165`).

## Verification

- `import browsercomp_cube` now succeeds (verified against `cube-standard` `dev`).
- `pytest cubes/browsercomp/tests/` → 28 passed. The suite already builds configs with an explicit `scorer_model`, so it never depended on the removed `"default"` entry.
- `ruff check` / `ruff format --check` clean.

Depends-on: cube-standard/dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)