### PR TITLE
feat(terminalbench2): benchmark_clarifications.py — verify-before-submit + install-don't-reinvent

### DIFF
--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/benchmark_clarifications.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/benchmark_clarifications.py
@@ -1,0 +1,50 @@
+"""Benchmark-wide prompt overlay for terminalbench2-cube.
+
+Loaded by `BenchmarkConfig.load_benchmark_clarifications()` and folded into
+the agent config at recipe time via
+`GennyConfig.with_benchmark_clarifications(benchmark_config)`. The framework
+only carries this; nothing is delivered to the agent automatically.
+
+`BENCHMARK_HINT` is appended to the system prompt; `TASK_CLARIFICATION` (per
+task id) is injected as part of the goal. Keep both terse — they compete for
+the LLM's attention with the task description itself.
+
+The two patches below address the two highest-leverage failure buckets the
+investigator surfaced on the gpt-5.4-mini × Daytona reference run (run
+`20260603_114932…215cc0e7`, meta-analysis at
+`~/auto_cube/tb2-r0-investigator/journal/`):
+
+  1. `submits-without-verification` (15 episodes) — agent reaches `final_step`
+     without ever running the canonical test command. Examples: ran pytest file
+     with `python` (silent → assumed pass); observed 0/100 wins against every
+     opponent and submitted anyway; hardcoded the example FEN and called it
+     done.
+  2. `missing-tool-not-installed` (≥8 episodes) — model has root and (mostly)
+     network but pivots to hand-rolling instead of `apt-get install` / `pip
+     install`. Reference solutions for several of these tasks are literally
+     a few install commands.
+
+`TASK_CLARIFICATION` is left empty here; the meta-analysis also identified
+~13 subtle-implementation-bug tasks (one specific knowledge gap each), but
+those are best addressed with reasoning_effort tuning or per-task hints
+landed in a separate, narrower change.
+"""
+
+BENCHMARK_HINT = """\
+TerminalBench-2 guidance:
+
+VERIFY BEFORE SUBMIT. Every task is graded by a pytest suite. Before \
+emitting `final_step`, run the project's tests yourself (look for `tests/`, \
+`pytest.ini`, `pyproject.toml`, or `test*.sh` / `run_tests.sh`). If they \
+fail, fix the failure and re-run — do NOT submit on a "should be right" \
+guess. A surprising result (e.g. 0/N succeeded when you expected to win) \
+is a real bug, not verification you can skip.
+
+INSTALL, DON'T REINVENT. You have root and (usually) network access. If a \
+task needs a missing library or compiler, run `apt-get install` or \
+`pip install` first instead of hand-rolling a workaround. Common examples \
+that ship as standard packages: stockfish, PIL/Pillow, primer3, \
+gcc-mips-linux-gnu, requests — install them rather than reimplementing.\
+"""
+
+TASK_CLARIFICATION: dict[str, str] = {}

--- a/cubes/terminalbench2-cube/src/terminalbench2_cube/benchmark_clarifications.py
+++ b/cubes/terminalbench2-cube/src/terminalbench2_cube/benchmark_clarifications.py
@@ -1,50 +1,23 @@
 """Benchmark-wide prompt overlay for terminalbench2-cube.
 
-Loaded by `BenchmarkConfig.load_benchmark_clarifications()` and folded into
-the agent config at recipe time via
-`GennyConfig.with_benchmark_clarifications(benchmark_config)`. The framework
-only carries this; nothing is delivered to the agent automatically.
+Loaded by `BenchmarkConfig.load_benchmark_clarifications()`; fold in at
+recipe time with `GennyConfig.with_benchmark_clarifications(benchmark)`.
 
-`BENCHMARK_HINT` is appended to the system prompt; `TASK_CLARIFICATION` (per
-task id) is injected as part of the goal. Keep both terse — they compete for
-the LLM's attention with the task description itself.
-
-The two patches below address the two highest-leverage failure buckets the
-investigator surfaced on the gpt-5.4-mini × Daytona reference run (run
-`20260603_114932…215cc0e7`, meta-analysis at
-`~/auto_cube/tb2-r0-investigator/journal/`):
-
-  1. `submits-without-verification` (15 episodes) — agent reaches `final_step`
-     without ever running the canonical test command. Examples: ran pytest file
-     with `python` (silent → assumed pass); observed 0/100 wins against every
-     opponent and submitted anyway; hardcoded the example FEN and called it
-     done.
-  2. `missing-tool-not-installed` (≥8 episodes) — model has root and (mostly)
-     network but pivots to hand-rolling instead of `apt-get install` / `pip
-     install`. Reference solutions for several of these tasks are literally
-     a few install commands.
-
-`TASK_CLARIFICATION` is left empty here; the meta-analysis also identified
-~13 subtle-implementation-bug tasks (one specific knowledge gap each), but
-those are best addressed with reasoning_effort tuning or per-task hints
-landed in a separate, narrower change.
+Targets the two highest-leverage failure buckets from the gpt-5.4-mini
+reference run (15 + 8 of 55 investigated episodes).
 """
 
 BENCHMARK_HINT = """\
 TerminalBench-2 guidance:
 
-VERIFY BEFORE SUBMIT. Every task is graded by a pytest suite. Before \
-emitting `final_step`, run the project's tests yourself (look for `tests/`, \
-`pytest.ini`, `pyproject.toml`, or `test*.sh` / `run_tests.sh`). If they \
-fail, fix the failure and re-run — do NOT submit on a "should be right" \
-guess. A surprising result (e.g. 0/N succeeded when you expected to win) \
-is a real bug, not verification you can skip.
+VERIFY BEFORE SUBMIT. Every task is graded by a pytest suite. Run the \
+project's tests yourself (`tests/`, `pytest.ini`, `test*.sh`) before \
+`final_step`. A surprising result (e.g. 0/N when expecting wins) is a \
+real bug, not skippable verification.
 
-INSTALL, DON'T REINVENT. You have root and (usually) network access. If a \
-task needs a missing library or compiler, run `apt-get install` or \
-`pip install` first instead of hand-rolling a workaround. Common examples \
-that ship as standard packages: stockfish, PIL/Pillow, primer3, \
-gcc-mips-linux-gnu, requests — install them rather than reimplementing.\
+INSTALL, DON'T REINVENT. You have root and (usually) network. If a \
+library or compiler is missing, `apt-get install` / `pip install` it \
+rather than hand-rolling a workaround.\
 """
 
 TASK_CLARIFICATION: dict[str, str] = {}


### PR DESCRIPTION
## Summary

Adds the first `benchmark_clarifications.py` sidecar to terminalbench2-cube, surfacing two benchmark-wide prompt patches targeted at the highest-leverage failure buckets the investigator surfaced on the gpt-5.4-mini × Daytona reference run.

The sidecar is loaded by `BenchmarkConfig.load_benchmark_clarifications()` and folded into the agent at recipe time:

```python
benchmark = TERMINALBENCH2_CONFIGS["default"]
agent = GENNY_CONFIGS["swe"].with_benchmark_clarifications(benchmark)
```

`BENCHMARK_HINT` (~125 words) is appended to the system prompt; `TASK_CLARIFICATION` is left empty in this PR.

## The two patches

Both target failure buckets from the meta-analysis on run `20260603_114932…215cc0e7` (mirror at `~/auto_cube/tb2-r0-investigator/journal/`):

| Bucket | Episodes | Example failure |
|---|---|---|
| `submits-without-verification` | 15 of 55 investigated | ran a pytest file with `python` (silent → assumed pass, ep2); observed 0/100 wins against every opponent and submitted anyway (ep87); hardcoded the example FEN and called it done (ep71) |
| `missing-tool-not-installed` | ≥8 episodes | ep8 needed stockfish, ep11 PIL, ep20 primer3, ep44 gcc-mips-linux-gnu, ep62 requests — reference solutions are literally a few install commands |

Patch 1 — **VERIFY BEFORE SUBMIT**: agent must run the project's pytest suite before emitting `final_step`. Surprising results (0/N when expecting wins) are a real bug, not skippable verification.

Patch 2 — **INSTALL, DON'T REINVENT**: model has root + network, use `apt-get install` / `pip install` for missing libs/compilers instead of hand-rolling.

## What's NOT in this PR

- `TASK_CLARIFICATION` entries for the ~13 subtle-implementation-bug tasks the meta-analysis flagged (one specific knowledge gap each). Better addressed in a separate narrower change.
- The `reasoning_effort=medium` bump suggestion from the meta-analysis (changes the run cost; needs its own measurement).
- The 11 infra-broken tasks (Daytona disk / dpkg lock / dataset pre-bake) — separate workstream.

## Expected effect

Per the meta-analysis's conservative read: ~15-25 of these failing episodes plausibly flip to passing without raising model capability. At the current 29/89 baseline, that's a path toward 44-54 / 89 (49-61%) if all the cheap fixes land. This PR addresses the bulk of the prompt-fixable bucket; revisit empirically with a rerun.

## Test plan

- [x] `BenchmarkConfig.load_benchmark_clarifications()` picks the sidecar up (`benchmark_hint set?: True`, length 787 chars, 0 task clarifications)
- [x] `GennyConfig.with_benchmark_clarifications()` overlays correctly (original config untouched, copy has `benchmark_hint_prompt` set)
- [x] `make lint` clean
- [ ] Rerun TB2 reference baseline with this overlay — expect headline number to move from 29/89 toward 35-45/89; measurement is a separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)