### PR TITLE
fix(episode/tool): don't clobber the task's tool under monitoring (+ STOP dedup)

### DIFF
--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -20,7 +20,7 @@ from cube_harness.llm import is_permanent_llm_error
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import FileStorage, Storage, TrajectoryView
 from cube_harness.streamer import EventStreamer, EventStreamerConfig
-from cube_harness.tool import Budget, BudgetExceeded, TaskDone, install_monitoring
+from cube_harness.tool import Budget, BudgetExceeded, TaskDone, build_monitored_env_tool
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +154,8 @@ class Episode:
 
         Flow:
             1. setup (status, task, action_set, agent, trajectory, dirs).
-            2. wrap task.toolbox with MonitoredTool (install_monitoring).
+            2. build the monitored env_tool the agent drives
+               (build_monitored_env_tool) — task keeps its concrete tool.
             3. build EventStreamer bound to trajectory + storage + summary.
             4. record initial obs (streamer.record_reset).
             5. agent.run(initial.obs, env_tool) — sync dispatch. For
@@ -238,23 +239,18 @@ class Episode:
                     budget=budget,
                     metadata_updates=metadata_updates,
                 )
-                install_monitoring(task, streamer)
-
-                # 4. The env-tool the agent will see is the task's
-                # (now-monitored) tool. `Agent.run` is the dispatcher;
-                # it picks `_run` (sync, no await) or `_arun` (async,
-                # gather) based on `AgentConfig.parallel_actions` and
-                # converts the env_tool's sync/async shape internally
-                # if needed (sync inner is wrapped in `AsyncToolbox`
-                # for `_arun`). Agent-private tools (memory, scratchpad,
-                # …) live on the agent itself.
-                # MUST match install_monitoring's lookup order (toolbox
-                # first) — otherwise when a task exposes both attrs the
-                # agent ends up with an UNMONITORED env_tool while the
-                # monitoring wrappers are installed on the other one.
-                # See tool.install_monitoring: `container = getattr(task,
-                # "toolbox", None) or getattr(task, "tool", None)`.
-                env_tool = getattr(task, "toolbox", None) or getattr(task, "tool", None)
+                # 4. Build the monitored env-tool the agent drives. This does
+                # NOT mutate `task.tool` / `task.toolbox`: the task keeps its
+                # concrete tool so its own setup/reset/evaluate/finished reach
+                # concrete methods (`bash`, `evaluate_js`), private attrs
+                # (`_container`, `_config`), and type checks (`isinstance`,
+                # `find_tool`). The agent's monitored view shares the same
+                # inner tool instance(s), so env state is shared. `Agent.run`
+                # picks `_run` (sync) or `_arun` (async gather) by
+                # `AgentConfig.parallel_actions` and applies `as_async` to the
+                # env_tool when needed. The `task` reference never reaches the
+                # agent. Agent-private tools live on the agent itself.
+                env_tool = build_monitored_env_tool(task, streamer)
 
                 # 5. Record the initial obs as a synthetic ToolCallEvent
                 # whose parent is the RESET sentinel.

--- a/src/cube_harness/tool.py
+++ b/src/cube_harness/tool.py
@@ -27,6 +27,7 @@ async leaves (see cube-standard PR #152).
 """
 
 import asyncio
+import copy
 import logging
 import time
 from typing import Any, Callable
@@ -129,7 +130,7 @@ def _record_step_evaluation(
 
 
 class _MonitorState:
-    """State shared between a MonitoredTool wrapper and install_monitoring.
+    """State shared between a MonitoredTool wrapper and its build helper.
 
     Carries the streamer's `emit` callable, budget, parent-event-id
     getter (late-bound to the streamer's current parent), and an
@@ -412,7 +413,7 @@ class MonitoredTool(AbstractTool):
 
 
 # ---------------------------------------------------------------------------
-# install_monitoring helper
+# build_monitored_env_tool helper
 # ---------------------------------------------------------------------------
 
 
@@ -433,79 +434,63 @@ def wrap_tool(
     return MonitoredTool(inner, emit, budget, parent_event_id_getter, task)
 
 
-def install_monitoring(task: Any, streamer: Any) -> None:
-    """Wrap every leaf tool of `task`'s toolbox in place + bake the
-    task reference into each wrapper for cube-standard Task.step semantics.
+def build_monitored_env_tool(task: Any, streamer: Any) -> AbstractTool | AbstractAsyncTool | None:
+    """Build the monitored ``env_tool`` the agent drives — WITHOUT mutating
+    the task's own tool.
 
-    `streamer` is an `EventStreamer` instance — we read three pieces
-    from it: `streamer.emit` (the single fan-out callable),
-    `streamer.budget` (the per-episode Budget), and
-    `streamer.current_parent_event_id` (the late-bound getter for
-    ToolCallEvent.parent_event_id).
+    The agent sees a `MonitoredTool` (single tool) or a shallow copy of the
+    task's toolbox whose leaves are `MonitoredTool`-wrapped. Crucially the
+    wrappers share the SAME inner tool instances as the task, so browser /
+    container state is shared between the agent's calls and the task's own.
 
-    After this call, any path through the toolbox emits monitoring +
-    triggers the task.step wrapping inline:
+    The task keeps its concrete `tool` / `toolbox`, so `task.setup` / `reset`
+    / `evaluate` / `finished` still reach concrete-tool methods (`bash`,
+    `evaluate_js`), private attrs (`_container`, `_config`), and type checks
+    (`isinstance` / `Toolbox.find_tool`). Previously these were wrapped in
+    place, which broke every cube whose lifecycle code touched its own tool.
+    The RFC's contract is "the agent receives only env_tool; the task
+    reference never leaks" — the wrapper still absorbs `Task.step` semantics
+    (STOP_ACTION, obs_postprocess, validate_per_step, finished) via the
+    baked-in task ref, but the task's tool is no longer clobbered.
 
-      - STOP_ACTION short-circuit → raises TaskDone.
-      - obs_postprocess on every Observation result.
-      - Step-wise evaluate when task.validate_per_step=True, recorded
-        as an EvaluationEvent (no bleed to the agent).
-      - task.finished() check after every tool call → raises TaskDone.
-
-    The function mutates `task.toolbox.tools` / `task.tool` so call
-    sites that hold the original reference see the wrappers.
-
-    Nested `Toolbox` / `AsyncToolbox` instances are recursively
-    flattened. Already-wrapped tools pass through (idempotent).
-
-    Looks up the toolbox via `task.toolbox` first, then `task.tool` —
-    cube-standard `Task` exposes the latter (a single Toolbox usually).
+    `streamer` is an `EventStreamer`; we read `.emit`, `.budget`, and
+    `.current_parent_event_id`. Looks up the env tool via `task.toolbox`
+    first, then `task.tool`. Returns None when the task exposes neither.
     """
     emit = streamer.emit
     budget = streamer.budget
     parent_event_id_getter = streamer.current_parent_event_id
     container = getattr(task, "toolbox", None) or getattr(task, "tool", None)
     if container is None:
-        return
-
-    if isinstance(container, (Toolbox, AsyncToolbox)):
-        _wrap_toolbox_in_place(container, emit, budget, parent_event_id_getter, task)
-        return
-
-    # Single tool. Wrap and stash it back on the attribute it came from.
-    wrapped = wrap_tool(container, emit, budget, parent_event_id_getter, task)
-    if hasattr(task, "toolbox") and getattr(task, "toolbox", None) is container:
-        task.toolbox = wrapped
-    elif hasattr(task, "tool") and getattr(task, "tool", None) is container:
-        # cube.task.Task stores the live tool on _tool (Pydantic
-        # PrivateAttr) and exposes it via the `tool` property. We
-        # write _tool when present so the property returns the wrapper.
-        if hasattr(task, "_tool"):
-            task._tool = wrapped
-        else:
-            task.tool = wrapped
+        return None
+    return _monitored_view(container, emit, budget, parent_event_id_getter, task)
 
 
-def _wrap_toolbox_in_place(
-    toolbox: Toolbox | AsyncToolbox,
+def _monitored_view(
+    container: AbstractTool | AbstractAsyncTool,
     emit: "Callable[[TrajectoryEvent], str]",
     budget: Budget,
     parent_event_id_getter: Callable[[], str] | None,
     task: Any | None = None,
-) -> None:
-    """Recursively wrap each leaf tool of a Toolbox / AsyncToolbox with
-    `MonitoredTool`, rebuilding the dispatch index so action-name
-    lookups resolve to the wrappers."""
-    new_tools: list = []
-    for tool in toolbox.tools:
-        if isinstance(tool, (Toolbox, AsyncToolbox)):
-            _wrap_toolbox_in_place(tool, emit, budget, parent_event_id_getter, task)
-            new_tools.append(tool)
-        else:
-            new_tools.append(wrap_tool(tool, emit, budget, parent_event_id_getter, task))
-    toolbox.tools = new_tools
-    # Rebuild action-name → tool index so dispatch resolves to the wrappers.
-    toolbox._action_name_to_tool = {action.name: tool for tool in toolbox.tools for action in tool.action_set}
+) -> AbstractTool | AbstractAsyncTool:
+    """Return a monitored view of `container` sharing its inner instances,
+    without mutating it. A `Toolbox` / `AsyncToolbox` is shallow-copied with
+    `MonitoredTool` leaves (nested toolboxes copied recursively); a single
+    tool is wrapped directly. Idempotent via `wrap_tool`."""
+    if isinstance(container, (Toolbox, AsyncToolbox)):
+        view = copy.copy(container)  # same type + attrs; we replace tools below
+        view.tools = [
+            _monitored_view(leaf, emit, budget, parent_event_id_getter, task)
+            if isinstance(leaf, (Toolbox, AsyncToolbox))
+            else wrap_tool(leaf, emit, budget, parent_event_id_getter, task)
+            for leaf in container.tools
+        ]
+        # Rebuild the dispatch index so action-name lookups resolve to the
+        # wrappers. Overwrite-style (last wins) — tolerant of leaves that each
+        # surface STOP_ACTION, matching the prior in-place behavior.
+        view._action_name_to_tool = {action.name: tool for tool in view.tools for action in tool.action_set}
+        return view
+    return wrap_tool(container, emit, budget, parent_event_id_getter, task)
 
 
 # ---------------------------------------------------------------------------
@@ -517,7 +502,7 @@ def as_async(tool: AbstractTool | AbstractAsyncTool) -> AbstractAsyncTool:
     """Return `tool` as an `AbstractAsyncTool` for `Agent.run`.
 
     `AbstractAsyncTool` instance passes through unchanged. A sync
-    `Toolbox` (post-`install_monitoring`, with `MonitoredTool` leaves)
+    `Toolbox` (post-`build_monitored_env_tool`, with `MonitoredTool` leaves)
     is rebuilt as an `AsyncToolbox` containing the same leaves —
     `AsyncToolbox` now accepts mixed sync + async leaves (cube-standard
     PR #152) and dispatches each through `async_execute_action`,

--- a/src/cube_harness/tool.py
+++ b/src/cube_harness/tool.py
@@ -268,6 +268,11 @@ class MonitoredTool(AbstractTool):
         self.inner = inner
         self._inner_is_async = isinstance(inner, AbstractAsyncTool)
         self._state = _MonitorState(emit, budget, parent_event_id_getter, task)
+        # TEMP (F4 / design-debt): when set, this leaf does NOT surface
+        # STOP_ACTION. `_dedup_stop_actions` flips it on every monitored leaf
+        # but one so a multi-leaf toolbox surfaces `stop` exactly once. See
+        # `_dedup_stop_actions` for why and the proper fix.
+        self._suppress_stop = False
 
     # --- delegation ---
 
@@ -286,7 +291,7 @@ class MonitoredTool(AbstractTool):
         """
         actions = list(self.inner.action_set)
         task = self._state.task
-        if task is not None and getattr(task, "accept_agent_stop", False):
+        if task is not None and getattr(task, "accept_agent_stop", False) and not self._suppress_stop:
             if not any(a.name == STOP_ACTION.name for a in actions):
                 actions.append(STOP_ACTION)
         return actions
@@ -463,7 +468,36 @@ def build_monitored_env_tool(task: Any, streamer: Any) -> AbstractTool | Abstrac
     container = getattr(task, "toolbox", None) or getattr(task, "tool", None)
     if container is None:
         return None
-    return _monitored_view(container, emit, budget, parent_event_id_getter, task)
+    env_tool = _monitored_view(container, emit, budget, parent_event_id_getter, task)
+    _dedup_stop_actions(env_tool)
+    return env_tool
+
+
+def _dedup_stop_actions(env_tool: AbstractTool | AbstractAsyncTool) -> None:
+    """TEMP (F4 / design-debt): surface STOP_ACTION on exactly one monitored leaf.
+
+    `MonitoredTool.action_set` appends `STOP_ACTION` per leaf, so a multi-leaf
+    monitored toolbox advertises `stop` N times — which both trips
+    `AsyncToolbox.__init__`'s duplicate-name guard (crashing `parallel_actions`
+    on multi-tool cubes) and sends duplicate `stop` tool schemas to the LLM.
+    Keep STOP on the first monitored leaf and suppress it on the rest.
+
+    Proper fix (deferred): STOP is a task/container-level action, not a per-leaf
+    one — surface it once at the toolbox boundary (or have the toolbox treat
+    STOP_ACTION as a shared sentinel) and drop both this pass and the per-leaf
+    append. Tracked as design-debt F4.
+    """
+    seen_stop = False
+    stack: list = [env_tool]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (Toolbox, AsyncToolbox)):
+            stack.extend(node.tools)
+        elif isinstance(node, MonitoredTool):
+            if seen_stop:
+                node._suppress_stop = True
+            else:
+                seen_stop = True
 
 
 def _monitored_view(

--- a/tests/test_default_agent_run.py
+++ b/tests/test_default_agent_run.py
@@ -16,7 +16,7 @@ from cube.tool import AbstractTool
 from cube_harness.agent import Agent, AgentConfig
 from cube_harness.core import AgentOutput, LLMCallEvent, ToolCallEvent, TrajectoryEvent
 from cube_harness.streamer import EventStreamer
-from cube_harness.tool import Budget, BudgetExceeded, TaskDone, install_monitoring
+from cube_harness.tool import Budget, BudgetExceeded, TaskDone, build_monitored_env_tool
 
 # ---------------------------------------------------------------------------
 # Mock pieces: a tiny "task" with a sync step that increments a counter
@@ -107,13 +107,15 @@ class _FakeStorage:
         return [te.output for _, _, te in self.events]
 
 
-def _setup(task, budget: Budget) -> tuple[EventStreamer, _FakeStorage]:
-    """Build EventStreamer + storage + install monitoring — the way
-    Episode does it. Storage owns event numbering; nothing to thread."""
+def _setup(task, budget: Budget) -> tuple[EventStreamer, _FakeStorage, object]:
+    """Build EventStreamer + storage + the monitored env_tool — the way
+    Episode does it. Storage owns event numbering; nothing to thread. The
+    returned env_tool is what the agent drives (task's own tool is left
+    concrete)."""
     storage = _FakeStorage()
     streamer = EventStreamer(trajectory_id="t", storage=storage, budget=budget)
-    install_monitoring(task, streamer)
-    return streamer, storage
+    env_tool = build_monitored_env_tool(task, streamer)
+    return streamer, storage, env_tool
 
 
 # ---------------------------------------------------------------------------
@@ -128,12 +130,12 @@ def test_default_run_completes_when_task_signals_done() -> None:
 
     task = _MockTask(done_after_n=3)
     budget = Budget(max_agent_steps=100)
-    recorder, storage = _setup(task, budget)
+    recorder, storage, env_tool = _setup(task, budget)
 
     agent = _CounterAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
     try:
-        agent.run(initial_obs=Observation(), env_tool=task.toolbox)
+        agent.run(initial_obs=Observation(), env_tool=env_tool)
     except TaskDone:
         pass  # expected: task.finished() returned True after 3 counter increments
 
@@ -161,10 +163,10 @@ def test_default_run_terminates_on_empty_actions() -> None:
 
     task = _MockTask(done_after_n=100)
     budget = Budget(max_agent_steps=10)
-    recorder, storage = _setup(task, budget)
+    recorder, storage, env_tool = _setup(task, budget)
     agent = _NoopAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
-    agent.run(initial_obs=Observation(), env_tool=task.toolbox)
+    agent.run(initial_obs=Observation(), env_tool=env_tool)
     outputs = storage.outputs()
     # No LLM call + empty actions => nothing was emitted by the agent
     # loop (LLM auto-emit doesn't fire; ToolCallEvent dispatch doesn't fire).
@@ -179,11 +181,11 @@ def test_default_run_records_parent_event_id_on_tool_calls() -> None:
 
     task = _MockTask(done_after_n=2)
     budget = Budget(max_agent_steps=10)
-    recorder, storage = _setup(task, budget)
+    recorder, storage, env_tool = _setup(task, budget)
     agent = _CounterAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
     try:
-        agent.run(Observation(), task.toolbox)
+        agent.run(Observation(), env_tool)
     except TaskDone:
         pass
 
@@ -203,14 +205,14 @@ def test_default_run_propagates_budget_exceeded() -> None:
 
     task = _MockTask(done_after_n=100)
     budget = Budget(max_agent_steps=100, max_tool_calls=1)
-    recorder, storage = _setup(task, budget)
+    recorder, storage, env_tool = _setup(task, budget)
 
     agent = _CounterAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
     # The second tool call (turn 2) raises.
     raised: list[BaseException] = []
     try:
-        agent.run(initial_obs=Observation(), env_tool=task.toolbox)
+        agent.run(initial_obs=Observation(), env_tool=env_tool)
     except BaseException as e:  # noqa: BLE001
         raised.append(e)
     assert any(isinstance(e, BudgetExceeded) for e in raised)

--- a/tests/test_monitored_tool_compat.py
+++ b/tests/test_monitored_tool_compat.py
@@ -16,6 +16,7 @@ from typing import Callable
 
 import pytest
 from cube.core import Action, ActionSchema, Observation, StepError
+from cube.task import STOP_ACTION
 from cube.tool import AbstractAsyncTool, AbstractTool, AsyncToolbox, Toolbox
 
 from cube_harness.core import ToolCallEvent, TrajectoryEvent
@@ -23,6 +24,7 @@ from cube_harness.tool import (
     Budget,
     BudgetExceeded,
     MonitoredTool,
+    as_async,
     build_monitored_env_tool,
     wrap_tool,
 )
@@ -415,6 +417,26 @@ def test_build_monitored_env_tool_recurses_into_nested_toolboxes() -> None:
     # Original toolbox tree is untouched (concrete leaves).
     assert isinstance(outer_box.tools[0].tools[0], _SyncEchoTool)
     assert isinstance(outer_box.tools[1], _SyncOtherTool)
+
+
+def test_build_monitored_env_tool_surfaces_stop_once_for_multi_leaf() -> None:
+    """F4: a multi-leaf monitored toolbox must advertise STOP_ACTION exactly
+    once. Otherwise AsyncToolbox (parallel_actions path) raises on the
+    duplicate 'stop', and the LLM gets duplicate stop tool schemas."""
+
+    class _StopTask:
+        accept_agent_stop = True
+
+        def __init__(self) -> None:
+            self.toolbox = Toolbox([_SyncEchoTool(), _SyncOtherTool()])
+
+    task = _StopTask()
+    env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5)))
+    stop_count = sum(a.name == STOP_ACTION.name for a in env_tool.action_set)
+    assert stop_count == 1, f"expected exactly one STOP_ACTION, got {stop_count}"
+    # Parallel path: converting to AsyncToolbox must not trip its duplicate
+    # action-name guard.
+    as_async(env_tool)
 
 
 def test_build_monitored_env_tool_with_parent_event_id_getter() -> None:

--- a/tests/test_monitored_tool_compat.py
+++ b/tests/test_monitored_tool_compat.py
@@ -1,5 +1,5 @@
 """Tests for MonitoredTool — drop-in compatibility,
-mixed toolbox dispatch, budget enforcement, and install_monitoring.
+mixed toolbox dispatch, budget enforcement, and build_monitored_env_tool.
 
 Design note: the RFC originally specified a single async wrapper, but in
 practice every in-tree cube uses sync `Tool` subclasses (and
@@ -23,7 +23,7 @@ from cube_harness.tool import (
     Budget,
     BudgetExceeded,
     MonitoredTool,
-    install_monitoring,
+    build_monitored_env_tool,
     wrap_tool,
 )
 
@@ -316,7 +316,7 @@ def test_wrap_tool_is_idempotent() -> None:
 
 
 # ---------------------------------------------------------------------------
-# install_monitoring
+# build_monitored_env_tool
 # ---------------------------------------------------------------------------
 
 
@@ -331,7 +331,7 @@ def _make_streamer(
     parent_event_id_getter: Callable[[], str] | None = None,
 ) -> object:
     """Lightweight streamer stand-in matching the duck-typed surface
-    `install_monitoring` reads: `.emit`, `.budget`,
+    `build_monitored_env_tool` reads: `.emit`, `.budget`,
     `.current_parent_event_id`. Avoids importing EventStreamer to
     keep this test module agnostic of streamer wiring."""
 
@@ -352,34 +352,53 @@ def _make_streamer(
     return s
 
 
-def test_install_monitoring_wraps_each_member_in_place() -> None:
+def test_build_monitored_env_tool_wraps_each_member() -> None:
     task = _FakeTask([_SyncEchoTool()])
-    install_monitoring(task, _make_streamer(Budget(max_agent_steps=5)))
-    assert all(isinstance(t, MonitoredTool) for t in task.toolbox.tools)
-    assert "sync_echo" in task.toolbox._action_name_to_tool
+    env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5)))
+    assert all(isinstance(t, MonitoredTool) for t in env_tool.tools)
+    assert "sync_echo" in env_tool._action_name_to_tool
 
 
-def test_install_monitoring_is_idempotent() -> None:
+def test_build_monitored_env_tool_does_not_mutate_task_tool() -> None:
+    """The task keeps its concrete tool — only the returned env_tool is
+    monitored. This is the contract that lets task.evaluate/setup reach
+    concrete-tool methods, private attrs, and isinstance/find_tool."""
+    task = _FakeTask([_SyncEchoTool()])
+    original_leaves = list(task.toolbox.tools)
+    env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5)))
+    # task's toolbox is untouched: same object, same concrete leaves.
+    assert task.toolbox.tools == original_leaves
+    assert all(not isinstance(t, MonitoredTool) for t in task.toolbox.tools)
+    # env_tool is a distinct toolbox whose wrappers share the SAME inner.
+    assert env_tool is not task.toolbox
+    assert env_tool.tools[0].inner is task.toolbox.tools[0]
+    # find_tool by concrete type still resolves on the task's toolbox.
+    assert task.toolbox.find_tool(_SyncEchoTool) is task.toolbox.tools[0]
+
+
+def test_build_monitored_env_tool_is_idempotent() -> None:
     task = _FakeTask([_SyncEchoTool()])
     budget = Budget(max_agent_steps=5)
-    install_monitoring(task, _make_streamer(budget))
-    install_monitoring(task, _make_streamer(budget))
-    assert len(task.toolbox.tools) == 1
-    assert isinstance(task.toolbox.tools[0], MonitoredTool)
-    assert not isinstance(task.toolbox.tools[0].inner, MonitoredTool)
+    env_tool = build_monitored_env_tool(task, _make_streamer(budget))
+    assert len(env_tool.tools) == 1
+    assert isinstance(env_tool.tools[0], MonitoredTool)
+    assert not isinstance(env_tool.tools[0].inner, MonitoredTool)
 
 
-def test_install_monitoring_dispatch_records_event() -> None:
-    """After install_monitoring, calling task.toolbox.execute_action
-    transitively writes a ToolCallEvent."""
+def test_build_monitored_env_tool_dispatch_records_event() -> None:
+    """Calling execute_action on the returned env_tool writes a
+    ToolCallEvent; the task's own concrete toolbox does NOT record."""
     task = _FakeTask([_SyncEchoTool()])
     storage = _FakeStorage()
-    install_monitoring(task, _make_streamer(Budget(max_agent_steps=5), storage=storage))
+    env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5), storage=storage))
+    env_tool.execute_action(_action("sync_echo", msg="hi"))
+    assert len(storage.tool_call_events()) == 1
+    # The task's own concrete tool calls are NOT monitored.
     task.toolbox.execute_action(_action("sync_echo", msg="hi"))
     assert len(storage.tool_call_events()) == 1
 
 
-def test_install_monitoring_recurses_into_nested_toolboxes() -> None:
+def test_build_monitored_env_tool_recurses_into_nested_toolboxes() -> None:
     inner_box = Toolbox([_SyncEchoTool()])
     outer_box = Toolbox([inner_box, _SyncOtherTool()])
 
@@ -388,26 +407,29 @@ def test_install_monitoring_recurses_into_nested_toolboxes() -> None:
             self.toolbox = outer_box
 
     task = _Task()
-    install_monitoring(task, _make_streamer(Budget(max_agent_steps=5)))
-    # Every leaf is wrapped; toolboxes stay as toolboxes.
-    assert isinstance(outer_box.tools[0], Toolbox)
-    assert isinstance(outer_box.tools[0].tools[0], MonitoredTool)
-    assert isinstance(outer_box.tools[1], MonitoredTool)
+    env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5)))
+    # Returned env_tool: every leaf wrapped; toolboxes stay as toolboxes.
+    assert isinstance(env_tool.tools[0], Toolbox)
+    assert isinstance(env_tool.tools[0].tools[0], MonitoredTool)
+    assert isinstance(env_tool.tools[1], MonitoredTool)
+    # Original toolbox tree is untouched (concrete leaves).
+    assert isinstance(outer_box.tools[0].tools[0], _SyncEchoTool)
+    assert isinstance(outer_box.tools[1], _SyncOtherTool)
 
 
-def test_install_monitoring_with_parent_event_id_getter() -> None:
+def test_build_monitored_env_tool_with_parent_event_id_getter() -> None:
     """parent_event_id_getter is late-bound to the streamer's current turn.
     Recorded events carry the value the getter returns at call time."""
     task = _FakeTask([_SyncEchoTool()])
     storage = _FakeStorage()
     current_turn = {"v": "agent-001"}
-    install_monitoring(
+    env_tool = build_monitored_env_tool(
         task,
         _make_streamer(Budget(max_agent_steps=5), storage=storage, parent_event_id_getter=lambda: current_turn["v"]),
     )
-    task.toolbox.execute_action(_action("sync_echo"))
+    env_tool.execute_action(_action("sync_echo"))
     current_turn["v"] = "agent-002"
-    task.toolbox.execute_action(_action("sync_echo"))
+    env_tool.execute_action(_action("sync_echo"))
     events = storage.tool_call_events()
     assert events[0].parent_event_id == "agent-001"
     assert events[1].parent_event_id == "agent-002"


### PR DESCRIPTION
## Problem

`#386` (agent-owns-loop) broke the task lifecycle path for **nearly every cube** on the new event-stream loop. Found via an Auto-CUBE debug session validating `dev` before the dev→main cut (`#386` had merged ~2h earlier with no end-to-end cube test).

`install_monitoring` wrapped the task's tool **in place** (`task._tool = MonitoredTool(...)` / replaced toolbox leaves). The agent's monitored dispatch worked, but the task's **own** `setup()`/`reset()`/`evaluate()`/`finished()` then saw the wrapper. `MonitoredTool.__getattr__` delegates public methods but cannot expose private attrs or fake type identity, so:

| Symptom | Cubes hit |
|---|---|
| `self.tool._container` / `self.tool._config` → `AttributeError` | swebench-verified, swebench-live |
| `isinstance(self.tool, X)` / `Toolbox.find_tool(X)` → assert/None | arithmetic, browsercomp, workarena |

**CI missed it** because browser/e2e cube paths are `@integration` (excluded from the default selection) and no unit test does type-/private-attr tool access post-monitoring.

## Fix (commit 1 — the linchpin)

`install_monitoring` → **`build_monitored_env_tool`**: it **returns** the monitored `env_tool` for the agent and **does not mutate** `task.tool`/`task.toolbox`. The wrapper shares the **same inner tool instance(s)** (so env state — browser page, container handle — is shared), still absorbs `Task.step` semantics (STOP_ACTION, obs_postprocess, validate_per_step, finished) via the baked-in task ref, but the task keeps its concrete tool. This matches the RFC's stated contract — *"the agent receives only `env_tool`; the task reference never leaks"* — the in-place mutation was the implementation bug.

## Fix (commit 2 — STOP dedup, **temp/band-aid**)

Each `MonitoredTool` leaf appended `STOP_ACTION` to its `action_set`, so a multi-leaf monitored toolbox advertised `stop` N times → crashed `as_async`/`parallel_actions` on multi-tool cubes (browsercomp/workarena) on `AsyncToolbox.__init__`'s duplicate-name guard, and sent duplicate `stop` tool schemas to the LLM. `_dedup_stop_actions` surfaces STOP on exactly one leaf. **Band-aid** — STOP is a container-level action; the proper fix (surface it once at the toolbox boundary) is deferred as design-debt.

## Verification (on the new loop)

- arithmetic **3/3, reward 1.0** (was crashing on `isinstance`)
- swebench-verified gold-patch on Daytona **1/1, reward 1.0** (was crashing at `_container`)
- terminalbench2 on Daytona **1/1** — episode completed clean, verifier ran (reward 0.0 = unsolved, not a crash)
- **unit suite: 958 passed**, lint clean, smokes green (`agent_owns_loop_events`, `streaming_trajectory`, `genny_parallel_recorder`, `tool_api`)
- code-reviewed (independent pass): SHIP — verified the original toolbox is not mutated, shared-inner identity holds, last-wins dispatch is safe

## Not in this PR (follow-ups)

- **F1 (separate PR):** browser cubes (miniwob/workarena/browsercomp) still can't run on the async loop — sync Playwright can't run on the asyncio event-loop thread. Needs a threading-model change (dedicated env-thread, or finish AsyncPlaywrightTool). Going to the `#386` author.
- **F3:** `PydanticSerializationUnexpectedValue` warnings on the `TrajectoryEvent.output` union (cosmetic; likely missing discriminator).
- **CI gap:** add an e2e cube smoke that does type-/private-attr tool access in `evaluate()` so this class can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)