### PR TITLE
fix(episode): run sync env interaction off the event-loop thread (temp, F1)

### DIFF
--- a/src/cube_harness/agent.py
+++ b/src/cube_harness/agent.py
@@ -191,7 +191,13 @@ class Agent(ABC):
                     f"`AgentConfig.parallel_actions=True` to use the async `_arun` body, "
                     f"or override `run` to customize dispatch for async-only tools."
                 )
-            self._run(initial_obs, env_tool)
+            # Run the sync loop OFF the event-loop thread. asyncio.run (in
+            # Episode.run) puts a running loop on the calling thread; some sync
+            # tools (Playwright) refuse to operate there. to_thread runs _run
+            # on a worker thread with no loop, and for a sequential episode the
+            # same worker is reused for every sync env call (reset/steps/
+            # evaluate), preserving thread-affine tools. [F1 temp — see episode]
+            await asyncio.to_thread(self._run, initial_obs, env_tool)
 
     def _run(
         self,

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -189,7 +189,7 @@ class Episode:
                 agent = self.config.agent_config.make(action_set, task_id=task_id)
 
                 # 2. Reset the env to get the initial observation.
-                obs, info = task.reset()
+                obs, info = await asyncio.to_thread(task.reset)
                 initial = EnvironmentOutput(obs=obs, info=info)
 
                 agent_name = self.config.agent_config.agent_name
@@ -295,7 +295,7 @@ class Episode:
                 # the outer except below tags status and propagates to the
                 # runner.
                 try:
-                    reward, info = task.evaluate()
+                    reward, info = await asyncio.to_thread(task.evaluate)
                 except Exception as e:
                     streamer.record_failure(e)
                     raise
@@ -370,7 +370,7 @@ class Episode:
             # task.close is best-effort; avoid masking the real exception.
             try:
                 if "task" in locals():
-                    task.close()
+                    await asyncio.to_thread(task.close)
             except Exception:
                 logger.exception("Failed to close task")
             tracer.shutdown()


### PR DESCRIPTION
## Problem

`#386` made `Episode.run` async (`asyncio.run(_arun())`). Sync-Playwright browser cubes (**miniwob / workarena / browsercomp**) drive their tool on the event-loop thread — `task.reset()`, the sequential agent loop, `task.evaluate()`/`close()` — and sync Playwright refuses to start when there's a running asyncio loop in the current thread:

> `playwright._impl._errors.Error: It looks like you are using Playwright Sync API inside the asyncio loop.`

So every browser cube crashed at `task.reset()` on the new loop. Found in the Auto-CUBE pre-merge sweep (`#487` is the sibling fix).

## Fix (temp)

Route the sync env interaction through `asyncio.to_thread`:
- `Agent.run` sequential branch → `await asyncio.to_thread(self._run, ...)`
- `Episode`: `task.reset` / `task.evaluate` / `task.close` → `asyncio.to_thread`

`to_thread` runs them on a worker thread with no event loop. For a **sequential** episode the default executor reuses the **same** worker for every call, so a thread-affine sync Playwright session stays on one thread.

## Verification

- **miniwob on the new loop now runs end-to-end** — 3/3 episodes, 0 crashes, 1 solved (previously crashed instantly at `reset`). Re-confirmed standalone on this branch (1/1, clean).
- Non-browser cubes unaffected (arithmetic, swebench-verified, tb2).
- Unit suite green; `agent_owns_loop_events` + `genny_parallel_recorder` smokes pass; lint clean.

## Why "temp" (the `#386` author's design call)

- Affinity rests on the default `ThreadPoolExecutor` reusing one thread for sequential calls. **Robust hardening:** a dedicated per-episode single-thread executor.
- Does **not** cover `parallel_actions=True` + sync Playwright (`to_thread` rotates threads across the `gather`). Browser cubes run genny-default (sequential), so out of scope here.
- **Proper long-term fix:** finish the `AsyncPlaywrightTool` (Phase 2) wiring so browser cubes use a native async tool — no thread bridging.

Full writeup (reproduction, root cause, all three options with trade-offs): handed to the `#386` author.

## Relationship to #487

miniwob needs only this PR (public tool methods). **workarena / browsercomp also need #487** (their `evaluate()` uses `find_tool`/`isinstance`, which #487 restores by not clobbering the task's concrete tool). The two PRs are independent off `dev`; land both for full browser-cube support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)