### PR TITLE
fix(eval_log): record selected task count in BenchmarkSubset

### DIFF
--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -434,9 +434,11 @@ class AgentInfo(TypedBaseModel):
 class BenchmarkSubset(TypedBaseModel):
     """Benchmark subset descriptor for MNAR propensity correction.
 
-    Automatically derived from the benchmark object. The name field captures any subset
-    suffix applied via subset_from_glob (e.g., "[level=l1]") or subset_from_list.
-    n_tasks is the denominator for computing completion rate without requiring the benchmark.
+    Automatically derived from the benchmark config. ``n_tasks`` is the size of the
+    selected view (the denominator for completion rate), and ``task_ids`` carries the
+    explicit selection when the config was subset. ``BenchmarkConfig`` does not retain
+    the glob/suffix used to build a subset, so ``name`` is the plain benchmark name and
+    ``filter`` stays None until that is threaded through cube-standard.
     """
 
     name: str = Field(description="Benchmark name including any subset suffix (benchmark_metadata.name).")
@@ -457,10 +459,18 @@ class BenchmarkSubset(TypedBaseModel):
 
     @classmethod
     def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset":
-        """Derive BenchmarkSubset from a cube BenchmarkConfig object."""
+        """Derive BenchmarkSubset from a cube BenchmarkConfig object.
+
+        ``n_tasks`` reflects the *selected* view (``num_tasks``), not the full
+        class-level ``task_metadata`` registry. A subset config narrowed via
+        ``subset_from_list`` / ``subset_from_glob`` / ``named_subset`` carries its
+        selection in ``task_ids``; recording the full registry size here made the
+        reproducibility scan compute a bogus ``n_missing`` and flag every subset
+        run as unfinished. ``task_ids`` is threaded through so the scan can tell a
+        hand-picked subset (``subset_review``) from a full run (``submittable``).
+        """
         name = benchmark_config.benchmark_metadata.name
-        n_tasks = len(benchmark_config.task_metadata)
-        return cls(name=name, n_tasks=n_tasks)
+        return cls(name=name, n_tasks=benchmark_config.num_tasks, task_ids=benchmark_config.task_ids)
 
 
 class InvestigatorLLMConfig(TypedBaseModel):

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -375,6 +375,18 @@ def test_benchmark_subset_from_benchmark(mock_cube_benchmark_config) -> None:
     assert subset.name == "mock-cube"
     assert subset.n_tasks == 2
     assert subset.filter is None
+    # Full benchmark: no explicit task list, so the scan treats it as submittable.
+    assert subset.task_ids is None
+
+
+def test_benchmark_subset_reflects_subset_selection(mock_cube_benchmark_config) -> None:
+    # A subset config narrows task_ids; the descriptor must record the *selected*
+    # count (1), not the full registry size (2) — otherwise the scan computes a
+    # bogus n_missing and flags the run as unfinished.
+    subset_config = mock_cube_benchmark_config.subset_from_list(["mock_cube_task_1"])
+    subset = BenchmarkSubset.from_benchmark_config(subset_config)
+    assert subset.n_tasks == 1
+    assert subset.task_ids == ["mock_cube_task_1"]
 
 
 def test_benchmark_subset_unknown_benchmark() -> None:


### PR DESCRIPTION
## Problem

`BenchmarkSubset.from_benchmark_config()` recorded `n_tasks = len(benchmark_config.task_metadata)` — the **full** class-level task registry — and never populated `task_ids`.

A subset config (built via `subset_from_list` / `subset_from_glob` / `named_subset`) keeps its selection in `BenchmarkConfig.task_ids` while `task_metadata` stays the full set. So a 223-of-1895 run recorded `n_tasks=1895, task_ids=None`. The reproducibility scan then computes `n_missing = 1895 − 223 = 1672` and flags **every subset run as `unfinished`** ("experiment may have stopped early"), even when it ran exactly the tasks it intended to.

## Fix

Derive the descriptor from the *selected* view:
- `n_tasks` ← `benchmark_config.num_tasks` (the subset count, not the registry size)
- `task_ids` ← `benchmark_config.task_ids` (threaded through)

A full run is unchanged (`num_tasks == len(task_metadata)`, `task_ids is None`), so it stays `submittable`. A subset run now records `n_missing=0` and the scan classifies it as `subset_review` (submittable with `--yes`) via the existing `has_explicit_task_list` gate, instead of the bogus `unfinished`.

## Scope

This is the root-cause fix from the named-subset handoff (`named-subset-work.md`, step 1) — the prerequisite for everything else. The `filter` field and a subset name suffix stay unset because `BenchmarkConfig` **drops** the glob/suffix when building a subset (`subset_from_glob` discards it); retaining it, and registering an official `lite`/gold-solvable named subset so those runs classify as fully `submittable` (steps 2–4), is a separate cross-repo change in cube-standard.

## Tests

- `test_benchmark_subset_from_benchmark` — full run records `task_ids=None`.
- `test_benchmark_subset_reflects_subset_selection` (new) — a 1-of-2 subset records `n_tasks=1`, `task_ids=["mock_cube_task_1"]`.
- Existing `test_scan.py` already covers the downstream classification (`task_ids` set + `n_missing==0` → `subset_review`).

`test_eval_log.py` / `test_scan.py` / `test_reproducibility.py`: 121 passed. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)