### PR TITLE
feat(reproducibility): official lite-gold named subset + run-intent (subset_name / is_official)

### DIFF
--- a/cubes/swebench-live-cube/scripts/create_task_metadata.py
+++ b/cubes/swebench-live-cube/scripts/create_task_metadata.py
@@ -41,6 +41,7 @@ from swebench_live_cube.benchmark import (
     _SPLIT_PRIORITY,
     _merge_rows_by_split,
 )
+from swebench_live_cube.gold_subset import tag_lite_gold
 from swebench_live_cube.task import SWEBenchLiveTaskMetadata
 
 logger = logging.getLogger(__name__)
@@ -128,8 +129,14 @@ def generate_task_metadata(
 
     metadata = _build_task_metadata(rows_by_split)
 
+    rows = [tm.model_dump() for tm in metadata.values()]
+    # Stamp the official lite-gold marker from the committed gold-solvable id list so
+    # named_subset("lite-gold") survives regeneration.
+    tagged = tag_lite_gold(rows)
+    logger.info("Tagged %d tasks with the 'lite-gold' split", tagged)
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps([tm.model_dump() for tm in metadata.values()], indent=2))
+    output_path.write_text(json.dumps(rows, indent=2) + "\n")
     logger.info("Saved %d tasks to %s", len(metadata), output_path)
     return len(metadata)
 

--- a/cubes/swebench-live-cube/src/swebench_live_cube/benchmark.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/benchmark.py
@@ -157,6 +157,10 @@ class SWEBenchLiveBenchmarkConfig(BenchmarkConfig[SWEBenchLiveTaskMetadata]):
             "lite": ("splits", "*'lite'*"),
             "verified": ("splits", "*'verified'*"),
             "full": ("splits", "*'full'*"),
+            # Official gold-solvable subset: the 275 lite tasks whose gold patch resolves
+            # under the root (Daytona) oracle. Tag stamped by create_task_metadata.py from
+            # gold_subset.LITE_GOLD_SOLVABLE_JSON. NB: "*'lite'*" won't match "'lite-gold'".
+            "lite-gold": ("splits", "*'lite-gold'*"),
         },
     )
     task_config_class: ClassVar[type[TaskConfig]] = SWEBenchLiveTaskConfig

--- a/cubes/swebench-live-cube/src/swebench_live_cube/gold_subset.py
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/gold_subset.py
@@ -1,0 +1,43 @@
+"""Official ``lite-gold`` subset: the lite (300) tasks whose gold patch resolves
+under the root (Daytona) oracle.
+
+The committed id list (``lite_solvable_daytona_2026-05-25.json``, 275 tasks) is the
+source of truth. ``create_task_metadata.py`` stamps the ``lite-gold`` marker into each
+gold-solvable task's ``splits`` so ``named_subset("lite-gold")`` can glob it the same
+way as ``lite`` / ``verified`` / ``full``. No cube-harness dependency — pure metadata.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# Root/Daytona oracle result; supersedes the non-root EAI list (223). See the JSON header.
+LITE_GOLD_SOLVABLE_JSON = Path(__file__).parent / "lite_solvable_daytona_2026-05-25.json"
+LITE_GOLD_SPLIT = "lite-gold"
+
+
+def lite_gold_ids() -> set[str]:
+    """Task IDs of the gold-solvable lite subset (root/Daytona oracle)."""
+    return set(json.loads(LITE_GOLD_SOLVABLE_JSON.read_text())["task_ids"])
+
+
+def tag_lite_gold(rows: list[dict]) -> int:
+    """Append the ``lite-gold`` marker to the ``splits`` of each gold-solvable task.
+
+    Mutates ``rows`` (the list-of-dicts form of ``task_metadata.json``) in place and
+    returns the number of tasks newly tagged. Idempotent. Raises if a gold-solvable id
+    is absent from the registry.
+    """
+    gold = lite_gold_ids()
+    by_id = {r["id"]: r for r in rows}
+    missing = gold - by_id.keys()
+    if missing:
+        raise ValueError(f"{len(missing)} gold-solvable ids missing from task registry, e.g. {sorted(missing)[:5]}")
+    tagged = 0
+    for tid in gold:
+        splits = by_id[tid].setdefault("splits", [])
+        if LITE_GOLD_SPLIT not in splits:
+            splits.append(LITE_GOLD_SPLIT)
+            tagged += 1
+    return tagged

--- a/cubes/swebench-live-cube/src/swebench_live_cube/task_metadata.json
+++ b/cubes/swebench-live-cube/src/swebench_live_cube/task_metadata.json
@@ -2850,7 +2850,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -2875,7 +2876,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -2924,7 +2926,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -2948,7 +2951,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -2973,7 +2977,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3021,7 +3026,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3045,7 +3051,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3070,7 +3077,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3095,7 +3103,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3119,7 +3128,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3168,7 +3178,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3240,7 +3251,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3264,7 +3276,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3335,7 +3348,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3359,7 +3373,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3383,7 +3398,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3407,7 +3423,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3455,7 +3472,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3480,7 +3498,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3575,7 +3594,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3646,7 +3666,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3671,7 +3692,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3719,7 +3741,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3744,7 +3767,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3793,7 +3817,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3818,7 +3843,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3843,7 +3869,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3915,7 +3942,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3939,7 +3967,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -3963,7 +3992,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4011,7 +4041,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4036,7 +4067,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4085,7 +4117,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4110,7 +4143,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4134,7 +4168,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4159,7 +4194,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4232,7 +4268,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4256,7 +4293,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4281,7 +4319,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4354,7 +4393,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4379,7 +4419,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4404,7 +4445,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4428,7 +4470,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4477,7 +4520,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4501,7 +4545,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4597,7 +4642,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4621,7 +4667,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4646,7 +4693,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4671,7 +4719,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4742,7 +4791,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4767,7 +4817,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4816,7 +4867,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4841,7 +4893,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4939,7 +4992,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4964,7 +5018,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -4989,7 +5044,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5013,7 +5069,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5038,7 +5095,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5063,7 +5121,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5088,7 +5147,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5113,7 +5173,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5160,7 +5221,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5207,7 +5269,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5232,7 +5295,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5257,7 +5321,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5305,7 +5370,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5330,7 +5396,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5377,7 +5444,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5402,7 +5470,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5451,7 +5520,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5476,7 +5546,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5526,7 +5597,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5644,7 +5716,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5742,7 +5815,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5861,7 +5935,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5885,7 +5960,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5910,7 +5986,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5935,7 +6012,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -5960,7 +6038,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6008,7 +6087,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6197,7 +6277,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6222,7 +6303,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6246,7 +6328,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6317,7 +6400,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6411,7 +6495,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6482,7 +6567,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6600,7 +6686,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6625,7 +6712,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6649,7 +6737,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6698,7 +6787,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6793,7 +6883,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6841,7 +6932,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6890,7 +6982,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6938,7 +7031,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -6988,7 +7082,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7059,7 +7154,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7084,7 +7180,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7132,7 +7229,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7250,7 +7348,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7274,7 +7373,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7345,7 +7445,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7369,7 +7470,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7463,7 +7565,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7511,7 +7614,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7535,7 +7639,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7582,7 +7687,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7629,7 +7735,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7653,7 +7760,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7678,7 +7786,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7703,7 +7812,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7752,7 +7862,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7800,7 +7911,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7824,7 +7936,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7873,7 +7986,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -7992,7 +8106,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8040,7 +8155,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8088,7 +8204,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8136,7 +8253,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8184,7 +8302,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8233,7 +8352,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8258,7 +8378,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8305,7 +8426,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8329,7 +8451,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8353,7 +8476,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8474,7 +8598,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8498,7 +8623,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8546,7 +8672,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8641,7 +8768,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8690,7 +8818,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8737,7 +8866,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8784,7 +8914,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -8855,7 +8986,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9068,7 +9200,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9117,7 +9250,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9141,7 +9275,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9166,7 +9301,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9191,7 +9327,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9239,7 +9376,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9287,7 +9425,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9312,7 +9451,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9336,7 +9476,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9361,7 +9502,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9386,7 +9528,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9410,7 +9553,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9434,7 +9578,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9459,7 +9604,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9578,7 +9724,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9626,7 +9773,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9674,7 +9822,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9746,7 +9895,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9770,7 +9920,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9818,7 +9969,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9843,7 +9995,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9868,7 +10021,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9915,7 +10069,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -9985,7 +10140,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10009,7 +10165,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10058,7 +10215,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10130,7 +10288,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10201,7 +10360,8 @@
     "splits": [
       "verified",
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10321,7 +10481,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -10393,7 +10554,8 @@
       "verified",
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -11941,7 +12103,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12054,7 +12217,8 @@
     "base_commit": "4edefe3e56d1656298c3f9a767da2e5292551432",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12328,7 +12492,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12510,7 +12675,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12647,7 +12813,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12853,7 +13020,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -12967,7 +13135,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13013,7 +13182,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13059,7 +13229,8 @@
     "base_commit": "7186962a1607332682dc1dad4e2b0d7c97825b84",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13243,7 +13414,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13290,7 +13462,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13336,7 +13509,8 @@
     "base_commit": "719b3462b58bd5c4fc12d93cb978f824bc7a610b",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13450,7 +13624,8 @@
     "base_commit": "7405482fdf3eba989ceb27e6ea71968e356d0b33",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13678,7 +13853,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13837,7 +14013,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -13997,7 +14174,8 @@
     "base_commit": "3678ee1976d6a33af17462ddd0be2a8921077c8e",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -14226,7 +14404,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -14361,7 +14540,8 @@
     "base_commit": "b658ce261b56c02cb8635416d310ca8f30f4dc90",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -14384,7 +14564,8 @@
     "base_commit": "0ede84058e57a40260a93ae4f9abe08a572b23e0",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -14545,7 +14726,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -14681,7 +14863,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -15134,7 +15317,8 @@
     "base_commit": "d8db468afbac9410d0ba5209ac9c4a58224c3864",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -15293,7 +15477,8 @@
     "base_commit": "054f23363fd50efedaf54ee7fb0333824b0de41f",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -15317,7 +15502,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -15477,7 +15663,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -16155,7 +16342,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -16404,7 +16592,8 @@
     "base_commit": "c037052581a1caef3287332635ca73bcd3bb07ea",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -16698,7 +16887,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -16878,7 +17068,8 @@
     "base_commit": "59b23d379cfa8378490675021d20bf51dbee652d",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -17059,7 +17250,8 @@
     "base_commit": "9a834e069fd04cffadbb2d2e3ccc70342a872252",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -17510,7 +17702,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -17805,7 +17998,8 @@
     "base_commit": "fac5d8f740952485ce2c094e2826ed358fbe90fd",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -17874,7 +18068,8 @@
     "base_commit": "171f10ca1c2a73ea41a06e4c6ecf4de1f53523e7",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -18258,7 +18453,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -18462,7 +18658,8 @@
     "base_commit": "e9c3ef8d0de3080ca59f7f8dbabf9b52983adc7d",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -18732,7 +18929,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -18756,7 +18954,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -18872,7 +19071,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19303,7 +19503,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19327,7 +19528,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19394,7 +19596,8 @@
     "base_commit": "3cb44431288dd143bed6ba67e9b13afc2cde1aa9",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19417,7 +19620,8 @@
     "base_commit": "328b8dcaa5a5d69827a62c1062fdcaec91b3125e",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19554,7 +19758,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19871,7 +20076,8 @@
     "base_commit": "f1acb4f7c969b69a441da0c043fe5bbe6dbc3748",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -19987,7 +20193,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -20279,7 +20486,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -20640,7 +20848,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -21029,7 +21238,8 @@
     "base_commit": "2e3f51782056b6665560f9af6166e30d7c2801ab",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -21053,7 +21263,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -21619,7 +21830,8 @@
     "base_commit": "b5b5e10df55f0d153053f5e6fcb419dac89cd42d",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -21891,7 +22103,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -22029,7 +22242,8 @@
     "base_commit": "d8e988105fdff8c452e3cc73f7790db0b0b64c9d",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -22188,7 +22402,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -22618,7 +22833,8 @@
     "base_commit": "503d275ade85e04efed787ec421bdc55a5a77abf",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -22663,7 +22879,8 @@
     "base_commit": "bfe5f893f4f2bd7e8256fd229cbfefb27c2dddc1",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -22687,7 +22904,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23075,7 +23293,8 @@
     "base_commit": "022947a2a587483ac897f403f52a1e0a50f53667",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23190,7 +23409,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23257,7 +23477,8 @@
     "base_commit": "2125765025c65fdd2aec89856bdc095dfb0fc826",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23349,7 +23570,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23531,7 +23753,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23554,7 +23777,8 @@
     "base_commit": "af3e6670efd11b3eef6a47aef68eb644213db056",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23670,7 +23894,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23740,7 +23965,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23856,7 +24082,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -23879,7 +24106,8 @@
     "base_commit": "801c9adb94b213fc5e8cacb0d9920a0ff7727c2e",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -24331,7 +24559,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -24558,7 +24787,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -24919,7 +25149,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25032,7 +25263,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25124,7 +25356,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25440,7 +25673,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25621,7 +25855,8 @@
     "base_commit": "39acdeef6424bf7e336ff71cf3a04540b92e2fcd",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25803,7 +26038,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -25873,7 +26109,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -26032,7 +26269,8 @@
     "base_commit": "d8b5ebca42a32be615b938627a0601c2cb59e68f",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -26329,7 +26567,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -26489,7 +26728,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -26987,7 +27227,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -27123,7 +27364,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -27371,7 +27613,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -27508,7 +27751,8 @@
     "base_commit": "419b66158881af9da5b9b4d8f84b77f7a9c46105",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -27643,7 +27887,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -27868,7 +28113,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28186,7 +28432,8 @@
     "base_commit": "000938414f46aeaff20256e63d84c96612ae014d",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28347,7 +28594,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28371,7 +28619,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28416,7 +28665,8 @@
     "base_commit": "6c620e8ef8e2222f2e3c2d9cadb90b1527d4045a",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28462,7 +28712,8 @@
     "base_commit": "9dc5ac4337b09df8c28b6d678485a4894d354970",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28714,7 +28965,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28760,7 +29012,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28829,7 +29082,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28942,7 +29196,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -28966,7 +29221,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29079,7 +29335,8 @@
     "base_commit": "b8220b5b975e3f4e19d078033aa1e68da28e2c9b",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29125,7 +29382,8 @@
     "base_commit": "b56e1ae626617a1e5982126302e0e4c2abd7e649",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29193,7 +29451,8 @@
     "base_commit": "bf3686e59347320c95503573979a4fc3ad6be9ab",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29217,7 +29476,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29513,7 +29773,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29537,7 +29798,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29698,7 +29960,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -29788,7 +30051,8 @@
     "base_commit": "db50579bbfdd89aeaf17b73d0dcd50b5ea93f1dc",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30128,7 +30392,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30220,7 +30485,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30244,7 +30510,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30360,7 +30627,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30565,7 +30833,8 @@
     "base_commit": "c4fafd9b04a6d0988a23ecda626c2473891ef7e5",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30588,7 +30857,8 @@
     "base_commit": "d3e13462d0622d7cc20c383d976bf566b6b8ad76",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30657,7 +30927,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30837,7 +31108,8 @@
     "base_commit": "2fd5adb8fec09c51cbd607e4e852f2c1d4293348",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30927,7 +31199,8 @@
     "base_commit": "46259b9f5b89a226d47e2119afb40ad7b4fa5e63",
     "splits": [
       "full",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -30997,7 +31270,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"
@@ -31158,7 +31432,8 @@
     "splits": [
       "full",
       "test",
-      "lite"
+      "lite",
+      "lite-gold"
     ],
     "log_parser": "pytest",
     "_type": "swebench_live_cube.task.SWEBenchLiveTaskMetadata"

--- a/cubes/swebench-live-cube/tests/test_benchmark.py
+++ b/cubes/swebench-live-cube/tests/test_benchmark.py
@@ -10,6 +10,7 @@ from cube.task import TaskExecutionInfo
 
 from swebench_live_cube.benchmark import SWEBenchLiveBenchmarkConfig
 from swebench_live_cube.debug import _TASK_ACTIONS, get_debug_benchmark
+from swebench_live_cube.gold_subset import lite_gold_ids
 from swebench_live_cube.task import (
     SWEBenchLiveExecutionInfo,
     SWEBenchLiveTaskConfig,
@@ -74,6 +75,17 @@ def test_named_subset_verified():
     # Every retained task lists 'verified' in its splits field
     for tm in cfg.tasks().values():
         assert "verified" in tm.splits
+
+
+def test_named_subset_lite_gold():
+    """``named_subset('lite-gold')`` returns the 275 root-gold-solvable lite tasks, each a lite task."""
+    cfg = SWEBenchLiveBenchmarkConfig().named_subset("lite-gold")
+    assert cfg.num_tasks == 275
+    assert set(cfg.tasks().keys()) == lite_gold_ids()
+    # lite-gold ⊂ lite: every gold task also carries the 'lite' marker.
+    for tm in cfg.tasks().values():
+        assert "lite-gold" in tm.splits
+        assert "lite" in tm.splits
 
 
 def test_debug_benchmark_type():

--- a/openspec/specs/eval_log/spec.md
+++ b/openspec/specs/eval_log/spec.md
@@ -104,23 +104,31 @@ Tracked packages: `cube-harness`, `cube`, `litellm`, `anthropic`, `openai`,
 
 ```python
 class BenchmarkSubset(TypedBaseModel):
-    name: str           # benchmark_metadata.name (includes subset suffix like "[level=l1]")
-    n_tasks: int        # len(benchmark.task_metadata) — denominator for completion rate
-    filter: str | None  # glob expression if subset_from_glob was used
+    name: str                  # benchmark_metadata.name + subset suffix, e.g. "swebench-live-cube[lite-gold]"
+    n_tasks: int               # num_tasks (the SELECTED view) — denominator for completion rate
+    filter: str | None         # registered named_subsets key for an official subset; else None
+    task_ids: list[str] | None # explicit list for an ad-hoc subset; else None
 
     @classmethod
-    def from_benchmark(cls, benchmark: Any) -> "BenchmarkSubset"
+    def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset"
 ```
 
-Automatically derived from the benchmark object. Used by ATLAS for MNAR propensity
-correction: `n_tasks` tells ATLAS what fraction of the benchmark was run without requiring
-submitters to fill in subjective fields.
+Automatically derived from the benchmark config. Used by ATLAS for MNAR propensity
+correction (`n_tasks` is the denominator) and by the journal-eligibility scan to route a
+run to one of three outcomes:
 
-**`name`** captures any subset suffix applied via `subset_from_glob` (e.g.,
-`"WorkArena_[level=l1]"`) or `subset_from_list`. It is `benchmark_metadata.name` verbatim.
+- **Full benchmark** — `task_ids` None, `filter` None → submittable.
+- **Registered named subset** — the config was built via `named_subset(name)`, which records
+  the registered key on `BenchmarkConfig.subset_name` (cube-standard). `from_benchmark_config`
+  reads it (via `getattr`, degrading gracefully on an older cube-standard) and records it in
+  `filter`, leaving `task_ids` None → submittable when complete.
+- **Ad-hoc subset** (`subset_from_list`, or a `subset_from_glob` that isn't a registered named
+  subset) — `subset_name` is None, so the explicit `task_ids` are recorded → the scan flags it
+  `subset_review`.
 
-**`filter`** is `None` unless manually populated — there is currently no standard way to
-extract the glob pattern from a benchmark object automatically.
+**`n_tasks`** is `benchmark_config.num_tasks` (the selected view), not the full class-level
+`task_metadata` — so a subset run records its real denominator and isn't mis-flagged as
+incomplete.
 
 ---
 
@@ -177,6 +185,8 @@ class ExperimentRecord(TypedBaseModel):
     benchmark_name: str             # benchmark_metadata.name
     benchmark_version: str | None
     benchmark_subset: BenchmarkSubset
+    debug_limit: int | None = None  # set if the runner truncated the task list to the first N
+    is_official: bool | None = None # run-intent override for the scan (see below)
     investigator_llm_config: InvestigatorLLMConfig | None = None
 
     @classmethod
@@ -185,10 +195,19 @@ class ExperimentRecord(TypedBaseModel):
         exp_name: str,
         output_dir: Path,
         agent_config: Any,
-        benchmark: Any,
+        benchmark_config: BenchmarkConfig,
         git_cwd: str | None = None,
+        debug_limit: int | None = None,
+        is_official: bool | None = None,
     ) -> "ExperimentRecord"
 ```
+
+**`is_official`** is an explicit run-intent override read only by the journal-eligibility
+scan: `None` (default) infers intent from `debug_limit` + subset shape; `True` asserts an
+official evaluation (bypasses the subset-review gate → submittable when complete and clean);
+`False` marks a debug run (never submittable). It overrides only the `subset_review` /
+`submittable` decision, never the integrity gates, and never affects execution. Sourced from
+`Experiment.is_official`; editable in `experiment_record.json` to reclassify without re-running.
 
 Written once per experiment to `experiment_record.json`. Contains all fields shared
 across every episode: agent description, benchmark metadata, git provenance.
@@ -375,5 +394,6 @@ distinct from the experiment's working files.
 - `git_is_dirty = True` means the eval may not reproduce exactly from `git_commit` alone.
 - `AgentInfo.description` is never auto-populated by `from_agent_config()`. Set it
   manually when preparing ATLAS submissions.
-- `BenchmarkSubset.filter` is `None` unless manually populated after calling
-  `BenchmarkSubset.from_benchmark()`.
+- `BenchmarkSubset.filter` holds the registered `named_subsets` key only when the config was
+  built via `named_subset()` (which records `BenchmarkConfig.subset_name`); it is `None` for an
+  ad-hoc subset or the full benchmark.

--- a/src/cube_harness/auto_cube/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/templates/exp_config.py
@@ -45,6 +45,7 @@ exp = Experiment(
     benchmark_config=benchmark,
     infra=INFRA_CONFIGS["local"],
     max_steps=agent.budget.max_actions or 60,
+    is_official=False,  # Auto-CUBE iteration run — never a submittable evaluation.
 )
 
 if __name__ == "__main__":

--- a/src/cube_harness/auto_cube/use_cases/debug/SKILL.md
+++ b/src/cube_harness/auto_cube/use_cases/debug/SKILL.md
@@ -245,7 +245,7 @@ All in [`src/cube_harness/auto_cube/templates/`](../../templates/):
 
 - [`session.md`](../../templates/session.md) — session scope + live tracker
 - [`notes.md`](../../templates/notes.md) — per-round hypothesis → result
-- [`exp_config.py`](../../templates/exp_config.py) — copy-and-edit experiment recipe
+- [`exp_config.py`](../../templates/exp_config.py) — copy-and-edit experiment recipe. Keep `is_official=False`: Auto-CUBE runs are iteration, never submittable evaluations.
 - [`fix_report.md`](../../templates/fix_report.md) — PR body for fixes
 - [`report.md`](../../templates/report.md) — final REPORT.md rollup
 

--- a/src/cube_harness/auto_cube/use_cases/hinter/SKILL.md
+++ b/src/cube_harness/auto_cube/use_cases/hinter/SKILL.md
@@ -178,4 +178,5 @@ Shared Auto-CUBE templates live in
 `fix_report.md`, `report.md`). This use-case ships its own
 [`templates/exp_config.py`](templates/exp_config.py), pre-wired with
 `with_benchmark_clarifications(...)` and `description_overrides` so a round can
-apply both the curated overlay and an experimental action-wording change.
+apply both the curated overlay and an experimental action-wording change. Keep
+`is_official=False`: hinter rounds are iteration, never submittable evaluations.

--- a/src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/use_cases/hinter/templates/exp_config.py
@@ -53,6 +53,7 @@ exp = Experiment(
     agent_config=agent,
     benchmark_config=benchmark,
     max_steps=10,
+    is_official=False,  # Auto-CUBE iteration run — never a submittable evaluation.
 )
 
 if __name__ == "__main__":

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -634,6 +634,16 @@ class ExperimentRecord(TypedBaseModel):
             "code path that didn't propagate the value into the record)."
         ),
     )
+    is_official: bool | None = Field(
+        default=None,
+        description=(
+            "Explicit run-intent override for the journal-eligibility scan. None: infer from "
+            "debug_limit + subset shape (default). True: official evaluation — bypasses the "
+            "subset-review gate, so a complete, clean run is submittable. False: debug run — "
+            "never submittable. Edit this one field and re-scan to reclassify without re-running; "
+            "it never affects execution."
+        ),
+    )
     investigator_llm_config: InvestigatorLLMConfig | None = Field(
         default=None,
         description="Investigator configuration if a post-hoc LLM investigator was run on these episodes.",
@@ -648,6 +658,7 @@ class ExperimentRecord(TypedBaseModel):
         benchmark_config: BenchmarkConfig,
         git_cwd: str | None = None,
         debug_limit: int | None = None,
+        is_official: bool | None = None,
     ) -> "ExperimentRecord":
         """Build ExperimentRecord from experiment parameters."""
         harness_version = _get_package_version("cube-harness") or "unknown"
@@ -666,6 +677,7 @@ class ExperimentRecord(TypedBaseModel):
             benchmark_version=bm_version,
             benchmark_subset=BenchmarkSubset.from_benchmark_config(benchmark_config),
             debug_limit=debug_limit,
+            is_official=is_official,
         )
 
     def write(self, output_dir: Path) -> None:

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -434,33 +434,51 @@ class AgentInfo(TypedBaseModel):
 class BenchmarkSubset(TypedBaseModel):
     """Benchmark subset descriptor for MNAR propensity correction.
 
-    Automatically derived from the benchmark object. The name field captures any subset
-    suffix applied via subset_from_glob (e.g., "[level=l1]") or subset_from_list.
-    n_tasks is the denominator for computing completion rate without requiring the benchmark.
+    Automatically derived from the benchmark config. ``n_tasks`` is the size of the
+    selected view (the denominator for completion rate). The descriptor routes the
+    journal-eligibility scan to one of three outcomes:
+
+    * Full benchmark — ``task_ids`` None → submittable.
+    * Registered named subset — when the config was built via ``named_subset(name)``
+      (carried on ``BenchmarkConfig.subset_name``), ``filter`` holds the subset key and
+      ``task_ids`` stays None, so a complete run is submittable.
+    * Ad-hoc subset (``subset_from_list`` / unregistered glob) — ``task_ids`` records the
+      explicit list, which the scan flags as subset_review.
     """
 
-    name: str = Field(description="Benchmark name including any subset suffix (benchmark_metadata.name).")
-    n_tasks: int = Field(description="Total tasks in this subset — denominator for completion rate.")
+    name: str = Field(description="Benchmark name including any subset suffix, e.g. 'swebench-live-cube[lite-gold]'.")
+    n_tasks: int = Field(description="Tasks in this subset (the selected view) — denominator for completion rate.")
     filter: str | None = Field(
         default=None,
-        description="Glob expression if the subset was created via subset_from_glob.",
+        description="Registered named_subsets key (BenchmarkConfig.subset_name) for an official subset; None otherwise.",
     )
     task_ids: list[str] | None = Field(
         default=None,
         description=(
-            "Explicit task list when the subset was constructed via subset_from_list. "
-            "Hand-picked subsets without a natural name don't make good reproducibility "
-            "reference points — the journal-eligibility scan flags them as subset_review. "
-            "None when the subset was built from a filter or is the full benchmark."
+            "Explicit task list for an ad-hoc subset (subset_from_list, or a glob that isn't a "
+            "registered named subset). Hand-picked subsets aren't reproducibility reference points, "
+            "so the journal-eligibility scan flags them as subset_review. None for a registered named "
+            "subset or the full benchmark."
         ),
     )
 
     @classmethod
     def from_benchmark_config(cls, benchmark_config: BenchmarkConfig) -> "BenchmarkSubset":
-        """Derive BenchmarkSubset from a cube BenchmarkConfig object."""
-        name = benchmark_config.benchmark_metadata.name
-        n_tasks = len(benchmark_config.task_metadata)
-        return cls(name=name, n_tasks=n_tasks)
+        """Derive BenchmarkSubset from a cube BenchmarkConfig object.
+
+        ``n_tasks`` comes from ``num_tasks`` (the selected view), not the full class-level
+        registry, so a subset run records its real denominator. A config built via
+        ``named_subset(name)`` carries the registered key on ``subset_name``; it is recorded
+        via ``filter`` (→ submittable when complete). Any other subset records its
+        ``task_ids`` (→ subset_review). ``getattr`` guards against a cube-standard predating
+        the ``subset_name`` field (then it degrades to the ad-hoc path).
+        """
+        base_name = benchmark_config.benchmark_metadata.name
+        n_tasks = benchmark_config.num_tasks
+        subset_name = getattr(benchmark_config, "subset_name", None)
+        if subset_name is not None:
+            return cls(name=f"{base_name}[{subset_name}]", n_tasks=n_tasks, filter=subset_name)
+        return cls(name=base_name, n_tasks=n_tasks, task_ids=benchmark_config.task_ids)
 
 
 class InvestigatorLLMConfig(TypedBaseModel):

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -93,6 +93,13 @@ class Experiment(TypedBaseModel):
     ``run_sequentially`` / ``run_with_ray`` need the runner to propagate it
     here before ``save_config()`` if they want the same coverage.
     """
+    is_official: bool | None = None
+    """Run-intent override for the reproducibility-journal scan. ``None`` (default)
+    lets the scan infer intent from ``debug_limit`` and the subset shape. ``True``
+    asserts an official evaluation (bypasses the subset-review gate → submittable when
+    complete and clean); ``False`` marks a debug run (never submittable). Recorded into
+    ``experiment_record.json`` — flip it there and re-scan to reclassify without
+    re-running. Read only by the scan; it never affects execution."""
 
     @model_validator(mode="after")
     def _ensure_unique_output_dir(self) -> "Experiment":
@@ -226,6 +233,7 @@ class Experiment(TypedBaseModel):
             benchmark_config=self.benchmark_config,
             git_cwd=self.git_cwd,
             debug_limit=self.debug_limit,
+            is_official=self.is_official,
         )
         exp_record.write(output_path)
 

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -21,6 +21,13 @@ Categories (more restrictive than the original sketch — the philosophy is
     operator can submit with ``--yes`` after eyeballing the diagnosis.
   • ``submittable``        — clean run of a complete named subset or the full
     benchmark. Hand off to ``submit_to_journal.py``.
+
+The ``is_official`` field on ``ExperimentRecord`` is an explicit operator override
+of the subset_review/submittable inference (it never overrides the integrity
+checks): ``True`` ⇒ submittable when complete and clean, ``False`` ⇒ never
+submittable, ``None`` (default) ⇒ infer from debug_limit + subset shape. Editing
+that one field in ``experiment_record.json`` and re-scanning reclassifies a run
+without re-running it.
 """
 
 from __future__ import annotations
@@ -122,6 +129,7 @@ class ScanResult:
     benchmark_subset_name: str = ""
     benchmark_subset_filter: str | None = None
     has_explicit_task_list: bool = False
+    is_official: bool | None = None
 
 
 def _load_experiment_record(experiment_dir: Path) -> ExperimentRecord | None:
@@ -228,6 +236,7 @@ def classify(
         benchmark_subset_name=bench_subset.name,
         benchmark_subset_filter=bench_subset.filter,
         has_explicit_task_list=has_explicit_task_list,
+        is_official=record.is_official,
     )
 
     # ── In-flight episodes mean the experiment is still running ──────────
@@ -266,7 +275,20 @@ def classify(
             reasons=(f"{n_missing}/{n_tasks} task(s) have no status file — experiment may have stopped early",),
         )
 
-    # ── Subset-shape gate: more restrictive than the original sketch ─────
+    # ── Explicit run-intent override ─────────────────────────────────────
+    # is_official is the operator's stated intent; it overrides the subset-shape
+    # inference below but never the integrity checks above (a run must still be
+    # complete and non-broken). None ⇒ fall through to inference.
+    if record.is_official is False:
+        return ScanResult(
+            **base,
+            category=ScanCategory.subset_review,
+            reasons=("is_official=False — run marked debug, not for submission",),
+        )
+    if record.is_official is True:
+        return ScanResult(**base, category=ScanCategory.submittable)
+
+    # ── Subset-shape gate (is_official is None ⇒ infer) ──────────────────
     review_reasons: list[str] = []
     if debug_limit:
         review_reasons.append(f"debug_limit={debug_limit} was applied — not a full subset")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,34 @@ class MockCubeBenchmarkConfig(CubeBenchmarkConfig):
     benchmark_class = MockCubeBenchmark
 
 
+class MockNamedSubsetBenchmarkConfig(CubeBenchmarkConfig):
+    """Cube BenchmarkConfig with a registered named subset ('gold') globbed over a tag.
+
+    Two of three tasks carry the 'GOLD' marker, so named_subset('gold') selects {g1, g2}.
+    Used to exercise BenchmarkSubset's official-named-subset recognition.
+    """
+
+    benchmark_metadata = BenchmarkMetadata(
+        name="mock-cube",
+        version="0.1.0",
+        description="Mock cube benchmark with a named gold subset",
+        named_subsets={"gold": ("abstract_description", "GOLD")},
+    )
+    task_metadata = {
+        "g1": TaskMetadata(id="g1", abstract_description="GOLD"),
+        "g2": TaskMetadata(id="g2", abstract_description="GOLD"),
+        "t3": TaskMetadata(id="t3", abstract_description="other"),
+    }
+    task_config_class = MockCubeTaskConfig
+    benchmark_class = MockCubeBenchmark
+
+
+@pytest.fixture
+def mock_named_subset_benchmark_config() -> MockNamedSubsetBenchmarkConfig:
+    """Cube benchmark config exposing a registered named subset 'gold' (= {g1, g2})."""
+    return MockNamedSubsetBenchmarkConfig()
+
+
 @pytest.fixture
 def mock_cube_task_config() -> MockCubeTaskConfig:
     """Cube task config for mock_cube_task_1."""

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -375,6 +375,38 @@ def test_benchmark_subset_from_benchmark(mock_cube_benchmark_config) -> None:
     assert subset.name == "mock-cube"
     assert subset.n_tasks == 2
     assert subset.filter is None
+    # Full benchmark: no explicit list and no filter → submittable.
+    assert subset.task_ids is None
+
+
+def test_benchmark_subset_ad_hoc_list_records_task_ids(mock_cube_benchmark_config) -> None:
+    # A hand-picked subset_from_list records its real count (1, not 2) and the
+    # explicit task_ids, so the scan flags it as subset_review.
+    sub_cfg = mock_cube_benchmark_config.subset_from_list(["mock_cube_task_1"])
+    subset = BenchmarkSubset.from_benchmark_config(sub_cfg)
+    assert subset.n_tasks == 1
+    assert subset.task_ids == ["mock_cube_task_1"]
+    assert subset.filter is None
+
+
+def test_benchmark_subset_named_subset_is_recognised(mock_named_subset_benchmark_config) -> None:
+    # named_subset('gold') matches a registered named subset → recorded via filter,
+    # no explicit task_ids, so a complete run is submittable.
+    gold = mock_named_subset_benchmark_config.named_subset("gold")
+    subset = BenchmarkSubset.from_benchmark_config(gold)
+    assert subset.name == "mock-cube[gold]"
+    assert subset.filter == "gold"
+    assert subset.n_tasks == 2
+    assert subset.task_ids is None
+
+
+def test_benchmark_subset_unregistered_glob_is_ad_hoc(mock_named_subset_benchmark_config) -> None:
+    # A glob that doesn't correspond to a registered named subset is not official:
+    # record the explicit task_ids so the scan asks for review.
+    other = mock_named_subset_benchmark_config.subset_from_glob("abstract_description", "other")
+    subset = BenchmarkSubset.from_benchmark_config(other)
+    assert subset.filter is None
+    assert subset.task_ids == ["t3"]
 
 
 def test_benchmark_subset_unknown_benchmark() -> None:

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -52,7 +52,8 @@ def _exp_record(n_tasks: int = 5) -> ExperimentRecord:
         agent=_agent_info(),
         benchmark_name="miniwob",
         benchmark_version="1.0.0",
-        benchmark_subset=BenchmarkSubset(name="miniwob[level=all]", n_tasks=n_tasks, filter="level=all"),
+        # filter is the registered named_subsets key (post named-subset PR), not a glob.
+        benchmark_subset=BenchmarkSubset(name="miniwob[all]", n_tasks=n_tasks, filter="all"),
     )
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -220,6 +220,16 @@ class TestClassifierSubsetReview:
         result = classify(exp_dir)
         assert result.category is ScanCategory.unfinished
 
+    def test_is_official_true_does_not_override_unfinished_with_debug_limit(self, tmp_path: Path) -> None:
+        # The integrity gate fires before the is_official override even when a debug_limit
+        # truncated the run: a partial run stays unfinished, never submittable.
+        exp_dir = tmp_path / "vouched_truncated"
+        _populate_clean_run(exp_dir, n_tasks=1, n_success=1)
+        _set_subset_field(exp_dir, n_tasks=3)  # 2 tasks never ran
+        _set_record_field(exp_dir, debug_limit=1, is_official=True)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.unfinished
+
     def test_is_official_none_falls_back_to_inference(self, tmp_path: Path) -> None:
         # Default None → existing inference: clean full run is submittable.
         exp_dir = tmp_path / "inferred"

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -192,6 +192,42 @@ class TestClassifierSubsetReview:
         assert result.category is ScanCategory.subset_review
         assert any("hand-picked" in r for r in result.reasons)
 
+    def test_is_official_false_blocks_clean_full_run(self, tmp_path: Path) -> None:
+        # A clean full run that would be submittable is held back when marked debug.
+        exp_dir = tmp_path / "marked_debug"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_record_field(exp_dir, is_official=False)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.subset_review
+        assert any("is_official=False" in r for r in result.reasons)
+
+    def test_is_official_true_promotes_hand_picked_subset(self, tmp_path: Path) -> None:
+        # is_official=True overrides the subset-shape gate: a hand-picked list becomes
+        # submittable (the operator vouches it's an official eval).
+        exp_dir = tmp_path / "vouched"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, task_ids=["t0", "t1", "t2"])
+        _set_record_field(exp_dir, is_official=True)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.submittable
+
+    def test_is_official_true_does_not_override_unfinished(self, tmp_path: Path) -> None:
+        # Intent never overrides integrity: a run still missing tasks stays unfinished.
+        exp_dir = tmp_path / "vouched_incomplete"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_subset_field(exp_dir, n_tasks=5)  # 2 tasks have no status file
+        _set_record_field(exp_dir, is_official=True)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.unfinished
+
+    def test_is_official_none_falls_back_to_inference(self, tmp_path: Path) -> None:
+        # Default None → existing inference: clean full run is submittable.
+        exp_dir = tmp_path / "inferred"
+        _populate_clean_run(exp_dir, n_tasks=3, n_success=3)
+        _set_record_field(exp_dir, is_official=None)
+        result = classify(exp_dir)
+        assert result.category is ScanCategory.submittable
+
 
 class TestClassifierIdempotency:
     def test_already_submitted_takes_priority(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Two related additions to the reproducibility-journal eligibility surface.

Depends-on: cube-standard/dev

## 1. Official `lite-gold` named subset (swebench-live)

Registers swebench-live's gold-patch-solvable lite set as an official named subset (`lite-gold`, 275 tasks, root/Daytona oracle), so a complete run is 🟢 **submittable** instead of 🟡 `subset_review` / 🔴 `unfinished`.

- **Cube**: append a `lite-gold` marker to each gold task's `splits`; `named_subsets["lite-gold"] = ("splits", "*'lite-gold'*")`. Sourced from the committed `lite_solvable_daytona_2026-05-25.json` (275) via new `gold_subset.py`, wired into `create_task_metadata.py` so the tag survives regeneration.
- **Harness** (`BenchmarkSubset.from_benchmark_config`): records `n_tasks` from the selected view (`num_tasks`) — fixing subset runs flagged `unfinished` — and reads **`BenchmarkConfig.subset_name`** (set forward by `named_subset()`, cube-standard#213, merged to dev) to record an official subset via `filter` with `task_ids=None` → submittable. Hand-picked lists / unregistered globs → `task_ids` recorded → `subset_review`. Replaces an earlier reverse-inference approach with a direct read of provenance recorded at subset-creation time.

swebench-verified is intentionally **not** here: its only complete gold run on disk is the non-root EAI Toolkit pass (475/500, with 19 non-root-flagged misses likely flaky/eval-brittle), too soft to be canonical. A root/Daytona gold list will define its `gold` subset later; until then the full 500 is the official target (a complete run is already submittable).

## 2. Explicit `is_official` run-intent override

Adds `is_official: bool | None = None` to `Experiment`, recorded onto `ExperimentRecord` (`experiment_record.json`) and read by the scan:

- **None** (default): infer from `debug_limit` + subset shape — unchanged behavior.
- **True**: official eval — bypasses the subset-review gate (a complete, clean run is submittable, even a hand-picked subset the operator vouches for).
- **False**: debug run — never submittable.

The override applies only to the `subset_review`/`submittable` decision; it **never** overrides the integrity gates (`broken`/`unfinished` still win — intent can't make an incomplete run submittable). It lives in the recorded JSON, so flipping the one field and re-scanning reclassifies without re-running, and it never percolates into execution.

- **Auto-CUBE adopts it**: both `exp_config.py` templates (debug + hinter) set `is_official=False`, and the two `SKILL.md` files note to keep it — so iteration runs can never slip into the submittable bucket.

## Tests

- `test_eval_log.py` — full / ad-hoc list / registered named subset / unregistered glob descriptor shapes.
- `test_scan.py` — `is_official` True (promotes hand-picked → submittable), False (blocks clean full run), None (falls back to inference), and True-doesn't-override-unfinished.
- `cubes/swebench-live-cube` — `named_subset("lite-gold")` = 275, each also `lite`.

eval_log / scan / experiment / reproducibility + swebench-live suites green against cube-standard dev (subset_name, #213); lint clean. JSON diff is tag-only (audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)