### PR TITLE
fix(episode): sync episode body; scope asyncio.run to parallel loop only (F1)

### DIFF
--- a/src/cube_harness/agent.py
+++ b/src/cube_harness/agent.py
@@ -144,7 +144,7 @@ class Agent(ABC):
         bundle LLM calls into its return value.
         """
 
-    async def run(
+    def run(
         self,
         initial_obs: Observation,
         env_tool: "AbstractTool | AbstractAsyncTool",
@@ -153,36 +153,35 @@ class Agent(ABC):
 
         Selection is by `self.config.parallel_actions`:
 
-          * `False` (default) → `_run` (sync body). Fully synchronous
-            action dispatch with NO `await` on tool calls. Single-stack
-            pdb; what you `step` is what you debug. env_tool must be a
-            sync container (a `Toolbox`, a sync `MonitoredTool`, or any
-            `AbstractTool` subclass).
+          * `False` (default) → `_run` (sync body, called directly). No event loop
+            on the calling thread — sync tools (Playwright, shell) work natively and
+            pdb lands in a single stack with no thread hops. env_tool must be a sync
+            container (`Toolbox`, sync `MonitoredTool`, or any `AbstractTool`).
 
-          * `True` → `_arun` (async body). N actions per step fan out
-            via `asyncio.gather` for real parallelism. env_tool must
-            be an async container (auto-wrapped from sync if needed).
+          * `True` → `_arun` (async body). Spins its own `asyncio.run` scoped to the
+            parallel gather — the event loop lives only here, not in Episode. env_tool
+            is auto-wrapped from sync if needed.
 
-        The recorder is attached out-of-band via `attach_recorder()`
-        before `run` is called; LLM/tool events auto-emit.
-        `self._recorder.budget` is available for self-stop.
+        The recorder is attached out-of-band via `attach_recorder()` before `run` is
+        called; LLM/tool events auto-emit. `self._recorder.budget` is available for
+        self-stop.
 
-        Override `_run` / `_arun` to customize loop behavior; override
-        `run` only when you need a fundamentally different dispatch
-        (streaming LLM, custom backoff, …).
+        Override `_run` / `_arun` to customize loop behavior; override `run` only
+        when you need a fundamentally different dispatch (streaming LLM, custom
+        backoff, …).
 
         Termination (shared by both bodies):
           * Graceful: `step` returns empty actions with no error.
-          * `TaskDone` from a MonitoredTool (task `finished()` or
-            STOP_ACTION) — propagates; do NOT catch BaseException.
-          * `BudgetExceeded` from a MonitoredTool — propagates.
+          * `TaskDone` from a MonitoredTool (task `finished()` or STOP_ACTION).
+          * `BudgetExceeded` from a MonitoredTool.
         """
         if self.config.parallel_actions:
             # _arun needs an async-shaped env_tool. Convert sync → async.
             from cube_harness.tool import as_async  # local import: avoid cycle
 
             async_env = env_tool if isinstance(env_tool, AbstractAsyncTool) else as_async(env_tool)
-            await self._arun(initial_obs, async_env)
+            # Event loop scoped to just the parallel gather — not the whole episode.
+            asyncio.run(self._arun(initial_obs, async_env))
         else:
             if isinstance(env_tool, AbstractAsyncTool):
                 raise TypeError(

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import time
 from pathlib import Path
@@ -109,14 +108,16 @@ class Episode:
         )
 
     def run(self) -> TrajectoryView:
-        """Sync entry point: drives the async loop via asyncio.run.
+        """Sync entry point — runs the episode body directly on the calling thread.
+
+        No event loop on the calling thread for sequential agents: sync tools
+        (Playwright browser sessions, shell containers) work natively, and pdb
+        lands in a single stack. The parallel agent path (`parallel_actions=True`)
+        opens its own `asyncio.run` scoped only to the gather inside `Agent.run`.
 
         Returns a lazy `TrajectoryView` onto the just-finalized episode dir.
-        The view's metadata is loaded eagerly; events decode from disk
-        on demand. Per the RFC `agent-owns-loop` scope expansion no
-        full trajectory is held in memory at any point.
         """
-        return asyncio.run(self._arun())
+        return self._run_episode()
 
     def _open_status(self, trajectory_id: str) -> EpisodeStatus:
         """Initialise `status.json` for this attempt.
@@ -145,16 +146,17 @@ class Episode:
         self.storage.write_episode_status(trajectory_id, ep_status)
         return ep_status
 
-    async def _arun(self) -> TrajectoryView:
-        """Agent-owns-loop body. Sync `run()` wraps this with asyncio.run.
+    def _run_episode(self) -> TrajectoryView:
+        """Sync episode body — runs directly on the calling thread.
 
         Flow:
             1. setup (status, task, action_set, agent, trajectory, dirs).
             2. wrap task.toolbox with MonitoredTool (install_monitoring).
             3. build EventStreamer bound to trajectory + storage + summary.
             4. record initial obs (streamer.record_reset).
-            5. `await agent.run(initial.obs, task, streamer)` — the agent
-               drives its own loop now.
+            5. agent.run(initial.obs, env_tool) — sync dispatch. For
+               parallel_actions=True the agent opens its own asyncio.run
+               scoped to the gather; for sequential it runs inline.
             6. finalize:
                - terminal task.evaluate() → streamer.record_evaluation.
                - summary_stats + save_trajectory.
@@ -265,7 +267,7 @@ class Episode:
 
                 # 7. Drive the agent. agent.run is the canonical entry.
                 try:
-                    await agent.run(initial.obs, env_tool)
+                    agent.run(initial.obs, env_tool)
                 except BudgetExceeded as e:
                     logger.info(colored(f"Budget exceeded: {e}", "yellow"))
                     streamer.record_failure(e)

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -51,14 +51,17 @@ class Episode:
     It builds the monitored env_tool + EventStreamer, attaches the
     streamer to the agent's event producers (LLM, sub-agents) via
     `agent.attach_recorder(streamer)`, then calls
-    `await agent.run(initial.obs, env_tool)` and finalizes regardless
-    of how the agent returns or raises. The previous `_run_loop` is
-    gone; every agent (legacy `step()` and new overridden `run()`)
-    flows through the same Episode body.
+    `agent.run(initial.obs, env_tool)` and finalizes regardless of how
+    the agent returns or raises. The previous `_run_loop` is gone; every
+    agent (legacy `step()` and new overridden `run()`) flows through the
+    same Episode body.
 
-    Public `run()` stays sync — callers (`exp_runner`, recipes, Ray
-    workers) keep their existing signature. Internally `run()` wraps an
-    `async _arun()` with `asyncio.run`.
+    The episode body (`_run_episode`) is fully synchronous and runs on
+    the calling thread — no event loop. Sequential agents dispatch tools
+    inline (sync Playwright / shell work natively; pdb is single-stack).
+    A parallel agent (`parallel_actions=True`) opens its own
+    `asyncio.run` scoped to the gather inside `Agent.run` — the only
+    place an event loop exists.
     """
 
     def __init__(

--- a/tests/test_default_agent_run.py
+++ b/tests/test_default_agent_run.py
@@ -10,8 +10,6 @@ Post-Trajectory-removal: events stream to a Storage hook; tests inspect
 the captured event stream rather than walking an in-memory list.
 """
 
-import asyncio
-
 from cube.core import Action, ActionSchema, Observation
 from cube.tool import AbstractTool
 
@@ -135,7 +133,7 @@ def test_default_run_completes_when_task_signals_done() -> None:
     agent = _CounterAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
     try:
-        asyncio.run(agent.run(initial_obs=Observation(), env_tool=task.toolbox))
+        agent.run(initial_obs=Observation(), env_tool=task.toolbox)
     except TaskDone:
         pass  # expected: task.finished() returned True after 3 counter increments
 
@@ -166,7 +164,7 @@ def test_default_run_terminates_on_empty_actions() -> None:
     recorder, storage = _setup(task, budget)
     agent = _NoopAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
-    asyncio.run(agent.run(initial_obs=Observation(), env_tool=task.toolbox))
+    agent.run(initial_obs=Observation(), env_tool=task.toolbox)
     outputs = storage.outputs()
     # No LLM call + empty actions => nothing was emitted by the agent
     # loop (LLM auto-emit doesn't fire; ToolCallEvent dispatch doesn't fire).
@@ -185,7 +183,7 @@ def test_default_run_records_parent_event_id_on_tool_calls() -> None:
     agent = _CounterAgent(_CounterAgentConfig())
     agent.attach_recorder(recorder)
     try:
-        asyncio.run(agent.run(Observation(), task.toolbox))
+        agent.run(Observation(), task.toolbox)
     except TaskDone:
         pass
 
@@ -212,7 +210,7 @@ def test_default_run_propagates_budget_exceeded() -> None:
     # The second tool call (turn 2) raises.
     raised: list[BaseException] = []
     try:
-        asyncio.run(agent.run(initial_obs=Observation(), env_tool=task.toolbox))
+        agent.run(initial_obs=Observation(), env_tool=task.toolbox)
     except BaseException as e:  # noqa: BLE001
         raised.append(e)
     assert any(isinstance(e, BudgetExceeded) for e in raised)


### PR DESCRIPTION
## Problem

`#386` made `Episode.run` async (`asyncio.run(_arun())`), putting a running event loop on the calling thread for **all** episodes. Sync-Playwright browser cubes (**miniwob / workarena / browsercomp**) drive their tool from `task.reset()`, inside the sequential agent loop, and in `task.evaluate()`/`close()` — sync Playwright refuses to start when there's a running asyncio loop on the thread:

> `playwright._impl._errors.Error: It looks like you are using Playwright Sync API inside the asyncio loop.`

Every browser cube crashed at `task.reset()` on the new loop. A prior temp fix (`asyncio.to_thread`) would have routed the sync loop onto a worker thread, defeating `_run`'s single-stack pdb guarantees for **all** sequential episodes — so that was closed in favour of this.

## Fix

The event loop is scoped to exactly where it's needed — the parallel agent gather — not wrapped around the whole episode:

| | Before | After |
|---|---|---|
| `Episode.run()` | `asyncio.run(self._arun())` | `self._run_episode()` (sync, direct) |
| `Episode._arun()` | `async def`, one `await agent.run()` | renamed `_run_episode()`, plain `def` |
| `Agent.run()` | `async def`, `await self._arun()` for parallel | plain `def`; `asyncio.run(self._arun())` for parallel only |

**Sequential agents** (default, incl. all browser cubes): no event loop on the calling thread, ever. Sync Playwright works natively; pdb lands in a single stack with no thread hops — actually cleaner than before `#386`.

**Parallel agents** (`parallel_actions=True`): event loop opened and closed inside `Agent.run`, scoped only to the `asyncio.gather`. Clean and local.

## Verification

- **miniwob 3/3 completed**, 1 solved, 0 Playwright crashes, 0 failed — previously crashed instantly at `reset`.
- arithmetic 2/2 reward 1.0 — non-browser path unaffected.
- `genny_parallel_recorder` smoke: **SMOKE OK** — parallel path still works.
- Unit suite: **956 passed, 0 failed**. Lint clean.

## Relationship to #487

For full browser-cube support, **also needs #487** (the task-tool fix). workarena and browsercomp call `find_tool`/`isinstance` in their `evaluate()` — which #487 fixes by not clobbering the task's concrete tool. miniwob needs only this PR (public tool methods). The two PRs are independent off `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)