### PR TITLE
feat(tool): migrate off cube-standard AbstractAsyncTool / AsyncToolbox shims

### DIFF
--- a/src/cube_harness/agent.py
+++ b/src/cube_harness/agent.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from cube.core import ActionSchema, Observation, StepError, ValidatedConfig
-from cube.tool import AbstractAsyncTool
 from pydantic import Field
 
 from cube_harness.core import AgentOutput
@@ -147,7 +146,7 @@ class Agent(ABC):
     def run(
         self,
         initial_obs: Observation,
-        env_tool: "AbstractTool | AbstractAsyncTool",
+        env_tool: "AbstractTool",
     ) -> None:
         """Episode's canonical entry point — dispatches to one of two loop bodies.
 
@@ -155,12 +154,15 @@ class Agent(ABC):
 
           * `False` (default) → `_run` (sync body, called directly). No event loop
             on the calling thread — sync tools (Playwright, shell) work natively and
-            pdb lands in a single stack with no thread hops. env_tool must be a sync
-            container (`Toolbox`, sync `MonitoredTool`, or any `AbstractTool`).
+            pdb lands in a single stack with no thread hops.
 
           * `True` → `_arun` (async body). Spins its own `asyncio.run` scoped to the
-            parallel gather — the event loop lives only here, not in Episode. env_tool
-            is auto-wrapped from sync if needed.
+            parallel gather — the event loop lives only here, not in Episode.
+
+        `env_tool` is any `AbstractTool` — `Tool.execute_action` and
+        `Tool.async_execute_action` both handle sync and async `@tool_action`
+        methods, bridging when caller and method differ. The agent picks the
+        dispatch shape; the tool doesn't need to know.
 
         The recorder is attached out-of-band via `attach_recorder()` before `run` is
         called; LLM/tool events auto-emit. `self._recorder.budget` is available for
@@ -176,20 +178,9 @@ class Agent(ABC):
           * `BudgetExceeded` from a MonitoredTool.
         """
         if self.config.parallel_actions:
-            # _arun needs an async-shaped env_tool. Convert sync → async.
-            from cube_harness.tool import as_async  # local import: avoid cycle
-
-            async_env = env_tool if isinstance(env_tool, AbstractAsyncTool) else as_async(env_tool)
             # Event loop scoped to just the parallel gather — not the whole episode.
-            asyncio.run(self._arun(initial_obs, async_env))
+            asyncio.run(self._arun(initial_obs, env_tool))
         else:
-            if isinstance(env_tool, AbstractAsyncTool):
-                raise TypeError(
-                    f"Agent._run (sync default) requires a sync env_tool; got "
-                    f"{type(env_tool).__name__}. Either set "
-                    f"`AgentConfig.parallel_actions=True` to use the async `_arun` body, "
-                    f"or override `run` to customize dispatch for async-only tools."
-                )
             self._run(initial_obs, env_tool)
 
     def _run(
@@ -232,11 +223,12 @@ class Agent(ABC):
     async def _arun(
         self,
         initial_obs: Observation,
-        env_tool: "AbstractAsyncTool",
+        env_tool: "AbstractTool",
     ) -> None:
         """Async gym-style loop — N actions per step fan out via
-        `asyncio.gather`. Tool calls run in real parallel (sync tools
-        via `asyncio.to_thread` inside `async_execute_action`).
+        `asyncio.gather`. Tool calls run in real parallel (sync
+        `@tool_action` methods hop to `asyncio.to_thread` inside
+        `Tool.async_execute_action`).
 
         The default observation-merge concatenates results in original
         action order (`Observation.__iadd__`). Subclasses with bespoke
@@ -257,10 +249,8 @@ class Agent(ABC):
                 raise RuntimeError(f"Agent step returned error: {agent_output.error.exception_str}")
             if not agent_output.actions:
                 return
-            # Parallel fan-out. AsyncToolbox routes through
-            # MonitoredTool.async_execute_action, which uses to_thread
-            # for sync inners — real OS-thread parallelism.
-            results = await asyncio.gather(*(env_tool.execute_action(a) for a in agent_output.actions))
+            # Parallel fan-out via the unified async call-site.
+            results = await asyncio.gather(*(env_tool.async_execute_action(a) for a in agent_output.actions))
             merged = self._merge_results(results)
             if merged is None:
                 return

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -247,9 +247,11 @@ class Episode:
                 # `find_tool`). The agent's monitored view shares the same
                 # inner tool instance(s), so env state is shared. `Agent.run`
                 # picks `_run` (sync) or `_arun` (async gather) by
-                # `AgentConfig.parallel_actions` and applies `as_async` to the
-                # env_tool when needed. The `task` reference never reaches the
-                # agent. Agent-private tools live on the agent itself.
+                # `AgentConfig.parallel_actions`; the unified `Tool` handles
+                # per-method sync/async routing internally, so the agent
+                # doesn't need to reshape the tool. The `task` reference
+                # never reaches the agent. Agent-private tools live on the
+                # agent itself.
                 env_tool = build_monitored_env_tool(task, streamer)
 
                 # 5. Record the initial obs as a synthetic ToolCallEvent

--- a/src/cube_harness/mcp/server.py
+++ b/src/cube_harness/mcp/server.py
@@ -1,13 +1,11 @@
 """MCP server that exposes cube-harness tools via the Model Context Protocol."""
 
-import asyncio
 import functools
-import inspect
 import logging
 from typing import Any, Literal
 
 from cube.core import Action, Observation, TypedBaseModel
-from cube.tool import AbstractAsyncTool, AbstractTool
+from cube.tool import AbstractTool
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
 
@@ -26,10 +24,10 @@ class McpServerConfig(TypedBaseModel):
 
 
 class McpServer:
-    """Adapts an cube-harness tool to serve its actions as MCP tools.
+    """Adapts a cube-harness tool to serve its actions as MCP tools.
 
-    Wraps any AbstractTool | AbstractAsyncTool (PlaywrightTool, BgymTool, Toolbox, etc.)
-    and exposes its action_set as MCP tools using FastMCP.
+    Wraps any `AbstractTool` (PlaywrightTool, BgymTool, Toolbox, etc.)
+    and exposes its `action_set` as MCP tools using FastMCP.
 
     Usage:
         tool = PlaywrightConfig(headless=True).make()
@@ -37,7 +35,7 @@ class McpServer:
         server.run()  # blocks, serving MCP over stdio
     """
 
-    def __init__(self, tool: AbstractTool | AbstractAsyncTool, config: McpServerConfig | None = None) -> None:
+    def __init__(self, tool: AbstractTool, config: McpServerConfig | None = None) -> None:
         self._tool = tool
         self._config = config or McpServerConfig()
         self._mcp = FastMCP(self._config.server_name)
@@ -60,26 +58,19 @@ class McpServer:
         self._mcp.run(transport=self._config.transport)
 
 
-def _make_async_handler(tool: AbstractTool | AbstractAsyncTool, method: Any, action_name: str) -> Any:
-    """Create an async MCP handler that dispatches to tool.execute_action.
+def _make_async_handler(tool: AbstractTool, method: Any, action_name: str) -> Any:
+    """Create an async MCP handler that dispatches to the tool through
+    `async_execute_action` — works for both sync and async `@tool_action`
+    methods (sync hops through `asyncio.to_thread` internally).
 
     The wrapper preserves the original method's signature via functools.wraps,
     allowing FastMCP to infer the parameter schema from type hints.
-
-    Async tools (e.g. AsyncPlaywrightTool) are awaited directly.
-    Sync tools are dispatched via asyncio.to_thread to avoid blocking the loop.
     """
-    is_async = inspect.iscoroutinefunction(tool.execute_action)
 
     @functools.wraps(method)
     async def handler(*args: Any, **kwargs: Any) -> list[TextContent | ImageContent]:
         action = Action(name=action_name, arguments=kwargs)
-        if is_async:
-            assert isinstance(tool, AbstractAsyncTool), f"Expected async tool, got {type(tool)}"
-            obs: Observation = await tool.execute_action(action)
-        else:
-            assert isinstance(tool, AbstractTool), f"Expected sync tool, got {type(tool)}"
-            obs: Observation = await asyncio.to_thread(tool.execute_action, action)
+        obs: Observation = await tool.async_execute_action(action)
         return observation_to_mcp_content(obs)
 
     # Override the return annotation so FastMCP treats the output as MCP content

--- a/src/cube_harness/tool.py
+++ b/src/cube_harness/tool.py
@@ -1,32 +1,18 @@
-"""MonitoredTool — single wrapper that records `ToolCallEvent`s.
+"""MonitoredTool — wraps any cube-standard `Tool` and records `ToolCallEvent`s.
 
-Part of RFC `agent-owns-loop`. One `MonitoredTool` class wraps ANY
-cube-standard tool (sync `AbstractTool` or async `AbstractAsyncTool`)
-and exposes a dual call surface:
+`MonitoredTool` is a thin pass-through that adds budget enforcement,
+ToolCallEvent emission, and the cube-standard `Task.step` semantics
+(STOP_ACTION, obs_postprocess, validate_per_step, finished). It exposes
+the same dual call surface as its inner `Tool`:
 
-  * `tool.execute_action(action)` — sync. Sync-inner only; raises
-    TypeError for async inner. Runs the inner on the calling thread
-    with NO `to_thread` hop. Pick this in sequential loops where
-    single-stack debuggability matters (default `Agent._run`).
+  * `tool.execute_action(action)` — sync.
+  * `await tool.async_execute_action(action)` — async.
 
-  * `await tool.async_execute_action(action)` — async. Works for BOTH
-    inner kinds. Sync inner is dispatched via `asyncio.to_thread` so
-    `asyncio.gather` over N calls runs them in real parallel. Async
-    inner is awaited directly. Pick this for parallel dispatch
-    (`Agent._arun` / `Genny[parallel_actions=True]`) or when the inner
-    may be async.
-
-The dual API lets agent authors pick the right call shape for their
-loop semantics. cube-harness internals route through the right one
-based on `Agent._run` vs `_arun`.
-
-The collapse to one class was enabled by cube-standard adding
-`async_execute_action` as a default method on `AbstractTool` /
-`AbstractAsyncTool` and relaxing `AsyncToolbox` to accept mixed sync +
-async leaves (see cube-standard PR #152).
+The inner `Tool` handles per-method sync/async routing itself, so
+`MonitoredTool` doesn't need to know whether the `@tool_action` method
+is sync or async — it just delegates and records.
 """
 
-import asyncio
 import copy
 import logging
 import time
@@ -34,13 +20,7 @@ from typing import Any, Callable
 
 from cube.core import Action, Observation, StepError
 from cube.task import STOP_ACTION
-from cube.tool import (
-    AbstractAsyncTool,
-    AbstractTool,
-    ActionSchema,
-    AsyncToolbox,
-    Toolbox,
-)
+from cube.tool import AbstractTool, ActionSchema, Toolbox
 
 from cube_harness.budget import Budget, BudgetExceeded
 from cube_harness.core import EvaluationEvent, ToolCallEvent, TrajectoryEvent
@@ -232,22 +212,16 @@ def _post_execute_wrapping(
 
 
 class MonitoredTool(AbstractTool):
-    """Single wrapper around a `cube.tool.AbstractTool` or `AbstractAsyncTool`.
+    """Wraps a `cube.tool.AbstractTool` to add budget enforcement,
+    `ToolCallEvent` emission, and the cube-standard `Task.step`
+    semantics (STOP_ACTION, obs_postprocess, validate_per_step,
+    finished).
 
-    Subclasses `AbstractTool` so it's structurally compatible with sync
-    `Toolbox` containment, but also exposes `async_execute_action` (the
-    one declared on `AbstractTool` by cube-standard) which works for
-    both inner kinds.
-
-    Dual call surface:
-
-      * `tool.execute_action(action)` — sync. Sync inner only; raises
-        TypeError if the inner is async.
-
-      * `await tool.async_execute_action(action)` — async. Works for
-        BOTH inner kinds. Sync inner is called synchronously on the
-        current task (no `to_thread` hop — debuggable). Async inner
-        is awaited.
+    Both `execute_action` (sync) and `async_execute_action` (async) are
+    available — each delegates to the inner tool's same-named dispatch
+    method. The inner `Tool` handles per-method sync/async routing,
+    bridging to a thread+loop or `asyncio.to_thread` when caller and
+    `@tool_action` method differ.
 
     Construction is per-episode. Re-using across episodes is a bug —
     the budget counter and trajectory are episode-scoped.
@@ -255,18 +229,15 @@ class MonitoredTool(AbstractTool):
 
     def __init__(
         self,
-        inner: AbstractTool | AbstractAsyncTool,
+        inner: AbstractTool,
         emit: "Callable[[TrajectoryEvent], str]",
         budget: Budget,
         parent_event_id_getter: Callable[[], str] | None = None,
         task: Any | None = None,
     ) -> None:
-        if not isinstance(inner, (AbstractTool, AbstractAsyncTool)):
-            raise TypeError(
-                f"MonitoredTool wraps a cube.tool.AbstractTool or AbstractAsyncTool; got {type(inner).__name__}."
-            )
+        if not isinstance(inner, AbstractTool):
+            raise TypeError(f"MonitoredTool wraps a cube.tool.AbstractTool; got {type(inner).__name__}.")
         self.inner = inner
-        self._inner_is_async = isinstance(inner, AbstractAsyncTool)
         self._state = _MonitorState(emit, budget, parent_event_id_getter, task)
         # TEMP (F4 / design-debt): when set, this leaf does NOT surface
         # STOP_ACTION. `_dedup_stop_actions` flips it on every monitored leaf
@@ -283,11 +254,10 @@ class MonitoredTool(AbstractTool):
 
         `STOP_ACTION` is the cube-standard sentinel an agent emits to
         signal graceful end-of-episode. `Task.action_set` includes it
-        (when `task.accept_agent_stop` is True), but `Toolbox` /
-        `AsyncToolbox` only see member-tool action sets. Surfacing it
-        here lets a containing toolbox dispatch `STOP_ACTION` to this
-        wrapper, where `_maybe_stop_action` translates it into
-        `TaskDone`.
+        (when `task.accept_agent_stop` is True), but `Toolbox` only
+        sees member-tool action sets. Surfacing it here lets a
+        containing toolbox dispatch `STOP_ACTION` to this wrapper,
+        where `_maybe_stop_action` translates it into `TaskDone`.
         """
         actions = list(self.inner.action_set)
         task = self._state.task
@@ -297,27 +267,10 @@ class MonitoredTool(AbstractTool):
         return actions
 
     def reset(self) -> None:
-        """Sync reset. Async inner returns a coroutine; we close it and
-        log a debug — callers wanting proper async cleanup should go
-        through `AsyncToolbox.reset` (which awaits) or the live agent
-        loop's shutdown path."""
-        r = self.inner.reset()
-        if asyncio.iscoroutine(r):
-            r.close()
-            logger.debug(
-                "MonitoredTool.reset: async inner returned a coroutine; "
-                "closed without awaiting. Use AsyncToolbox.reset for proper cleanup."
-            )
+        self.inner.reset()
 
     def close(self) -> None:
-        """Sync close. Same async-coroutine handling as `reset`."""
-        c = self.inner.close()
-        if asyncio.iscoroutine(c):
-            c.close()
-            logger.debug(
-                "MonitoredTool.close: async inner returned a coroutine; "
-                "closed without awaiting. Use AsyncToolbox.close for proper cleanup."
-            )
+        self.inner.close()
 
     # --- monitored execution ---
 
@@ -334,14 +287,10 @@ class MonitoredTool(AbstractTool):
              does NOT bleed reward/info back to the agent.
           6. task.finished() check — raises TaskDone on True.
 
-        Sync inner only. For async inner, use `async_execute_action`."""
-        if self._inner_is_async:
-            raise TypeError(
-                "MonitoredTool.execute_action (sync) does not support async inner tools. "
-                "Use `await tool.async_execute_action(action)` for async-shaped dispatch "
-                "(works for both sync and async inners), or wrap with asyncio.to_thread "
-                "inside asyncio.gather for parallel dispatch of sync inners."
-            )
+        Works for any inner `Tool`: a sync `@tool_action` runs directly
+        on the calling thread; an async `@tool_action` is bridged via a
+        one-shot worker thread inside `Tool.execute_action` (~2-5 ms).
+        """
         if _maybe_stop_action(self._state, action):
             raise TaskDone(action=action)
         if self._state.budget.exhausted:
@@ -361,20 +310,13 @@ class MonitoredTool(AbstractTool):
         return _post_execute_wrapping(self._state, action, result, tool_call_event_id)
 
     async def async_execute_action(self, action: Action) -> Observation | StepError:
-        """Async monitored dispatch — the parallel-safe call-site that
-        works for BOTH sync and async inners.
+        """Async monitored dispatch — the parallel-safe call-site.
 
-        Sync inner: dispatched via `asyncio.to_thread`. Lets
-        `asyncio.gather` over N sync-inner calls run them in real
-        parallel (each on its own OS thread). The lock on `Budget` +
-        `EventStreamer._lock` keeps stats coherent under that
-        concurrency.
-
-        Async inner: `await self.inner.execute_action(action)`.
-
-        For agents that want sync-on-main-thread dispatch (default
-        `Agent._run` — single-stack pdb, no thread hop), call the sync
-        `execute_action` directly instead.
+        Delegates to the inner tool's `async_execute_action`, which
+        routes per-method: an async `@tool_action` is awaited directly;
+        a sync `@tool_action` hops through `asyncio.to_thread` so
+        `asyncio.gather` over N calls runs them in real OS-thread
+        parallel.
 
         Same wrapping steps as `execute_action` (STOP, budget, record,
         obs_postprocess, step-eval, finished).
@@ -384,10 +326,7 @@ class MonitoredTool(AbstractTool):
         if self._state.budget.exhausted:
             raise BudgetExceeded(action=action)
         start = time.time()
-        if self._inner_is_async:
-            result = await self.inner.execute_action(action)
-        else:
-            result = await asyncio.to_thread(self.inner.execute_action, action)
+        result = await self.inner.async_execute_action(action)
         end = time.time()
         tool_call_event_id = _record_tool_call(
             self._state.emit,
@@ -423,7 +362,7 @@ class MonitoredTool(AbstractTool):
 
 
 def wrap_tool(
-    inner: AbstractTool | AbstractAsyncTool,
+    inner: AbstractTool,
     emit: "Callable[[TrajectoryEvent], str]",
     budget: Budget,
     parent_event_id_getter: Callable[[], str] | None = None,
@@ -439,7 +378,7 @@ def wrap_tool(
     return MonitoredTool(inner, emit, budget, parent_event_id_getter, task)
 
 
-def build_monitored_env_tool(task: Any, streamer: Any) -> AbstractTool | AbstractAsyncTool | None:
+def build_monitored_env_tool(task: Any, streamer: Any) -> AbstractTool | None:
     """Build the monitored ``env_tool`` the agent drives — WITHOUT mutating
     the task's own tool.
 
@@ -473,12 +412,12 @@ def build_monitored_env_tool(task: Any, streamer: Any) -> AbstractTool | Abstrac
     return env_tool
 
 
-def _dedup_stop_actions(env_tool: AbstractTool | AbstractAsyncTool) -> None:
+def _dedup_stop_actions(env_tool: AbstractTool) -> None:
     """TEMP (F4 / design-debt): surface STOP_ACTION on exactly one monitored leaf.
 
     `MonitoredTool.action_set` appends `STOP_ACTION` per leaf, so a multi-leaf
     monitored toolbox advertises `stop` N times — which both trips
-    `AsyncToolbox.__init__`'s duplicate-name guard (crashing `parallel_actions`
+    `Toolbox.__init__`'s duplicate-name guard (crashing `parallel_actions`
     on multi-tool cubes) and sends duplicate `stop` tool schemas to the LLM.
     Keep STOP on the first monitored leaf and suppress it on the rest.
 
@@ -491,7 +430,7 @@ def _dedup_stop_actions(env_tool: AbstractTool | AbstractAsyncTool) -> None:
     stack: list = [env_tool]
     while stack:
         node = stack.pop()
-        if isinstance(node, (Toolbox, AsyncToolbox)):
+        if isinstance(node, Toolbox):
             stack.extend(node.tools)
         elif isinstance(node, MonitoredTool):
             if seen_stop:
@@ -501,21 +440,21 @@ def _dedup_stop_actions(env_tool: AbstractTool | AbstractAsyncTool) -> None:
 
 
 def _monitored_view(
-    container: AbstractTool | AbstractAsyncTool,
+    container: AbstractTool,
     emit: "Callable[[TrajectoryEvent], str]",
     budget: Budget,
     parent_event_id_getter: Callable[[], str] | None,
     task: Any | None = None,
-) -> AbstractTool | AbstractAsyncTool:
+) -> AbstractTool:
     """Return a monitored view of `container` sharing its inner instances,
-    without mutating it. A `Toolbox` / `AsyncToolbox` is shallow-copied with
-    `MonitoredTool` leaves (nested toolboxes copied recursively); a single
-    tool is wrapped directly. Idempotent via `wrap_tool`."""
-    if isinstance(container, (Toolbox, AsyncToolbox)):
+    without mutating it. A `Toolbox` is shallow-copied with `MonitoredTool`
+    leaves (nested toolboxes copied recursively); a single tool is wrapped
+    directly. Idempotent via `wrap_tool`."""
+    if isinstance(container, Toolbox):
         view = copy.copy(container)  # same type + attrs; we replace tools below
         view.tools = [
             _monitored_view(leaf, emit, budget, parent_event_id_getter, task)
-            if isinstance(leaf, (Toolbox, AsyncToolbox))
+            if isinstance(leaf, Toolbox)
             else wrap_tool(leaf, emit, budget, parent_event_id_getter, task)
             for leaf in container.tools
         ]
@@ -525,29 +464,3 @@ def _monitored_view(
         view._action_name_to_tool = {action.name: tool for tool in view.tools for action in tool.action_set}
         return view
     return wrap_tool(container, emit, budget, parent_event_id_getter, task)
-
-
-# ---------------------------------------------------------------------------
-# as_async — expose any toolbox as `AbstractAsyncTool` for the agent
-# ---------------------------------------------------------------------------
-
-
-def as_async(tool: AbstractTool | AbstractAsyncTool) -> AbstractAsyncTool:
-    """Return `tool` as an `AbstractAsyncTool` for `Agent.run`.
-
-    `AbstractAsyncTool` instance passes through unchanged. A sync
-    `Toolbox` (post-`build_monitored_env_tool`, with `MonitoredTool` leaves)
-    is rebuilt as an `AsyncToolbox` containing the same leaves —
-    `AsyncToolbox` now accepts mixed sync + async leaves (cube-standard
-    PR #152) and dispatches each through `async_execute_action`,
-    running sync leaves synchronously on the current task without a
-    `to_thread` hop. A single sync tool (not wrapped in a Toolbox) is
-    wrapped in a one-element `AsyncToolbox`.
-    """
-    if isinstance(tool, AbstractAsyncTool):
-        return tool
-    if isinstance(tool, Toolbox):
-        return AsyncToolbox(tools=tool.tools)
-    if isinstance(tool, AbstractTool):
-        return AsyncToolbox(tools=[tool])
-    raise TypeError(f"as_async expects AbstractTool / AbstractAsyncTool; got {type(tool).__name__}")

--- a/tests/test_monitored_tool_compat.py
+++ b/tests/test_monitored_tool_compat.py
@@ -1,14 +1,11 @@
 """Tests for MonitoredTool — drop-in compatibility,
 mixed toolbox dispatch, budget enforcement, and build_monitored_env_tool.
 
-Design note: the RFC originally specified a single async wrapper, but in
-practice every in-tree cube uses sync `Tool` subclasses (and
-`Toolbox.execute_action` asserts `isinstance(tool, AbstractTool)`), so
-we ship both sync and async wrappers with shared recording logic. See
-src/cube_harness/tool.py docstring.
-
-Post-Trajectory-removal: events stream to a Storage hook; tests inspect
-what was sent there rather than walking an in-memory list.
+Post-tool-consolidation: one `MonitoredTool` wraps any `cube.tool.Tool`,
+whether its `@tool_action` methods are sync, async, or a mix. The inner
+`Tool` handles per-method dispatch (bridging via thread+loop or
+`asyncio.to_thread` when needed); `MonitoredTool` just adds budget
+enforcement, `ToolCallEvent` emission, and the `Task.step` wrapping.
 """
 
 import asyncio
@@ -17,14 +14,13 @@ from typing import Callable
 import pytest
 from cube.core import Action, ActionSchema, Observation, StepError
 from cube.task import STOP_ACTION
-from cube.tool import AbstractAsyncTool, AbstractTool, AsyncToolbox, Toolbox
+from cube.tool import AbstractTool, Tool, Toolbox, tool_action
 
 from cube_harness.core import ToolCallEvent, TrajectoryEvent
 from cube_harness.tool import (
     Budget,
     BudgetExceeded,
     MonitoredTool,
-    as_async,
     build_monitored_env_tool,
     wrap_tool,
 )
@@ -51,14 +47,17 @@ class _SyncOtherTool(AbstractTool):
         return Observation.from_text("other")
 
 
-class _AsyncEchoTool(AbstractAsyncTool):
-    @property
-    def action_set(self) -> list[ActionSchema]:
-        return [ActionSchema(name="async_echo", description="echo", parameters={"type": "object", "properties": {}})]
+class _AsyncEchoTool(Tool):
+    """A `Tool` with an async `@tool_action` — the post-consolidation way
+    to express what used to be `AbstractAsyncTool`. Dispatch routes per
+    method's kind: `execute_action` bridges via thread+loop,
+    `async_execute_action` awaits directly."""
 
-    async def execute_action(self, action: Action) -> Observation | StepError:
+    @tool_action
+    async def async_echo(self, msg: str = "") -> str:
+        """Echo the given message."""
         await asyncio.sleep(0)
-        return Observation.from_text(f"async:{action.arguments.get('msg', '')}")
+        return f"async:{msg}"
 
 
 def _action(name: str, **args: object) -> Action:
@@ -88,13 +87,13 @@ class _FakeStorage:
 
 
 def _make_monitored(
-    inner: AbstractTool | AbstractAsyncTool,
+    inner: AbstractTool,
     budget: Budget,
     *,
     storage: _FakeStorage | None = None,
     parent_event_id_getter: Callable[[], str] | None = None,
 ) -> MonitoredTool:
-    """Construct a MonitoredTool. One class wraps any inner kind now."""
+    """Construct a MonitoredTool. One class wraps any inner kind."""
     storage = storage if storage is not None else _FakeStorage()
 
     def emit(te: TrajectoryEvent) -> str:
@@ -127,30 +126,30 @@ def test_sync_monitored_tool_returns_observation_unchanged() -> None:
     assert isinstance(result, Observation)
 
 
-def test_async_inner_via_async_execute_action() -> None:
-    """Async inner is supported via the dual `async_execute_action` API.
-    Calling sync `execute_action` on an async-inner MonitoredTool raises
-    a TypeError — the test below verifies the sync path's safety check."""
+def test_async_action_via_async_execute_action() -> None:
+    """A `Tool` with an async `@tool_action` is dispatched directly when
+    the caller goes through `async_execute_action` — no thread hop."""
     budget = Budget(max_agent_steps=5)
     tool = _make_monitored(_AsyncEchoTool(), budget)
     result = asyncio.run(tool.async_execute_action(_action("async_echo", msg="hi")))
     assert isinstance(result, Observation)
 
 
-def test_async_inner_sync_execute_action_raises() -> None:
-    """`MonitoredTool.execute_action` is sync — sync inners only. Calling
-    it with an async inner raises TypeError directing the caller to
-    `async_execute_action`."""
+def test_async_action_via_sync_execute_action_bridges() -> None:
+    """Calling sync `execute_action` on a tool with an async `@tool_action`
+    bridges through a one-shot worker thread + event loop. The caller
+    gets a normal `Observation` synchronously — no TypeError."""
     budget = Budget(max_agent_steps=5)
     tool = _make_monitored(_AsyncEchoTool(), budget)
-    with pytest.raises(TypeError, match="async_execute_action"):
-        tool.execute_action(_action("async_echo", msg="hi"))
+    result = tool.execute_action(_action("async_echo", msg="hi"))
+    assert isinstance(result, Observation)
 
 
-def test_sync_inner_via_async_execute_action() -> None:
-    """Sync inner works through async dispatch too — runs directly on
-    the current task with NO `to_thread` hop. Lets one code path serve
-    both inner kinds."""
+def test_sync_action_via_async_execute_action() -> None:
+    """Sync action through async dispatch hops through `asyncio.to_thread`
+    inside `Tool.async_execute_action`. Lets one code path serve both
+    method kinds; `asyncio.gather` over N sync actions runs them in real
+    OS-thread parallel."""
     budget = Budget(max_agent_steps=5)
     tool = _make_monitored(_SyncEchoTool(), budget)
     result = asyncio.run(tool.async_execute_action(_action("sync_echo", msg="hi")))
@@ -169,7 +168,7 @@ def test_monitored_tool_records_event_per_call() -> None:
 
 
 def test_wrong_inner_type_raises() -> None:
-    """MonitoredTool accepts sync OR async cube tools — but not arbitrary objects."""
+    """MonitoredTool accepts any `AbstractTool` — not arbitrary objects."""
 
     class _NotATool:
         pass
@@ -220,12 +219,12 @@ def test_budget_exceeded_is_base_exception() -> None:
 
 
 def test_sync_toolbox_with_mixed_monitored_and_unmonitored() -> None:
-    """A sync Toolbox can contain MonitoredTool wrappers AND bare tools
+    """A `Toolbox` can contain `MonitoredTool` wrappers AND bare tools
     side-by-side. Dispatch by action name routes each call correctly.
 
-    Validates the RFC design goal: MonitoredTool is API-identical to any
-    AbstractTool from the caller's perspective. The agent doesn't know
-    or care which tools are monitored."""
+    Validates the design goal: `MonitoredTool` is API-identical to any
+    `AbstractTool` from the caller's perspective. The agent doesn't
+    know or care which tools are monitored."""
     budget = Budget(max_agent_steps=10)
     storage = _FakeStorage()
     monitored = _make_monitored(_SyncEchoTool(), budget, storage=storage)
@@ -241,25 +240,25 @@ def test_sync_toolbox_with_mixed_monitored_and_unmonitored() -> None:
     assert events[0].action_id == "id-sync_echo"
 
 
-def test_async_toolbox_with_mixed_monitored_and_unmonitored() -> None:
-    """Symmetric check for AsyncToolbox containing async-inner MonitoredTool."""
+def test_toolbox_async_dispatch_over_mixed_leaves() -> None:
+    """A single `Toolbox` may hold a mix of sync-action and async-action
+    leaves; `async_execute_action` routes per the leaf's action method's
+    kind. Only the monitored leaf records a ToolCallEvent."""
 
-    class _AsyncOther(AbstractAsyncTool):
-        @property
-        def action_set(self) -> list[ActionSchema]:
-            return [ActionSchema(name="async_other", description="x", parameters={"type": "object", "properties": {}})]
-
-        async def execute_action(self, action: Action) -> Observation | StepError:
-            return Observation.from_text("other")
+    class _AsyncOther(Tool):
+        @tool_action
+        async def async_other(self) -> str:
+            """Bare async tool."""
+            return "other"
 
     budget = Budget(max_agent_steps=10)
     storage = _FakeStorage()
     monitored = _make_monitored(_AsyncEchoTool(), budget, storage=storage)
     bare = _AsyncOther()
-    box = AsyncToolbox([monitored, bare])
+    box = Toolbox([monitored, bare])
 
-    asyncio.run(box.execute_action(_action("async_echo", msg="m")))
-    asyncio.run(box.execute_action(_action("async_other")))
+    asyncio.run(box.async_execute_action(_action("async_echo", msg="m")))
+    asyncio.run(box.async_execute_action(_action("async_other")))
     assert len(storage.tool_call_events()) == 1
 
 
@@ -301,8 +300,8 @@ def _noop_emit(te: TrajectoryEvent) -> str:
     return te.output.id
 
 
-def test_wrap_tool_returns_monitored_tool_for_both_inner_kinds() -> None:
-    """One `MonitoredTool` class handles both sync and async inners."""
+def test_wrap_tool_returns_monitored_tool_for_both_action_kinds() -> None:
+    """One `MonitoredTool` class handles both sync-action and async-action inners."""
     budget = Budget(max_agent_steps=5)
     sync_wrapped = wrap_tool(_SyncEchoTool(), emit=_noop_emit, budget=budget)
     async_wrapped = wrap_tool(_AsyncEchoTool(), emit=_noop_emit, budget=budget)
@@ -323,7 +322,7 @@ def test_wrap_tool_is_idempotent() -> None:
 
 
 class _FakeTask:
-    def __init__(self, tools: list[AbstractTool | AbstractAsyncTool], *, attr: str = "toolbox") -> None:
+    def __init__(self, tools: list[AbstractTool], *, attr: str = "toolbox") -> None:
         setattr(self, attr, Toolbox(tools))
 
 
@@ -421,8 +420,8 @@ def test_build_monitored_env_tool_recurses_into_nested_toolboxes() -> None:
 
 def test_build_monitored_env_tool_surfaces_stop_once_for_multi_leaf() -> None:
     """F4: a multi-leaf monitored toolbox must advertise STOP_ACTION exactly
-    once. Otherwise AsyncToolbox (parallel_actions path) raises on the
-    duplicate 'stop', and the LLM gets duplicate stop tool schemas."""
+    once. Otherwise `Toolbox.__init__`'s duplicate-name guard trips, and
+    the LLM gets duplicate stop tool schemas."""
 
     class _StopTask:
         accept_agent_stop = True
@@ -434,9 +433,9 @@ def test_build_monitored_env_tool_surfaces_stop_once_for_multi_leaf() -> None:
     env_tool = build_monitored_env_tool(task, _make_streamer(Budget(max_agent_steps=5)))
     stop_count = sum(a.name == STOP_ACTION.name for a in env_tool.action_set)
     assert stop_count == 1, f"expected exactly one STOP_ACTION, got {stop_count}"
-    # Parallel path: converting to AsyncToolbox must not trip its duplicate
-    # action-name guard.
-    as_async(env_tool)
+    # Rebuilding a fresh Toolbox over the same leaves must not trip
+    # its duplicate action-name guard.
+    Toolbox(tools=env_tool.tools)
 
 
 def test_build_monitored_env_tool_with_parent_event_id_getter() -> None:


### PR DESCRIPTION
## Summary

Paired with [cube-standard #212](https://github.com/The-AI-Alliance/cube-standard/pull/212), which drops the `AsyncTool` / `AsyncToolbox` / `AbstractAsyncTool` deprecation aliases outright (alpha, no external consumers). This PR migrates cube-harness's only internal usage so the cube-standard PR can land without breaking dev.

## What changes

| File | Change |
|---|---|
| `agent.py` | Drop `AbstractAsyncTool` import + 2 isinstance gates. `Agent.run` always passes `env_tool` through. `_arun` uses `async_execute_action` (was `execute_action` on the now-deleted `AbstractAsyncTool`). |
| `tool.py` | `MonitoredTool` becomes a thin pass-through: drops the `_inner_is_async` flag + the dual dispatch bodies + the "raises TypeError on async inner" guard. The inner `Tool` handles per-method routing itself. Deletes `as_async` (any `Tool` already has `async_execute_action`). |
| `mcp/server.py` | Collapse the sync/async dispatch branches into a single `await tool.async_execute_action(...)`. |
| `tests/test_monitored_tool_compat.py` | Migrate async fixtures from `AbstractAsyncTool` subclassing to `Tool` + `@tool_action async def`. |
| `episode.py` | Comment cleanup (no behavior change). |

**Net**: +133 / −239 (≈ −100 LOC).

## Why the deletion is safe here

- Sync vs async is now a per-method property of `Tool`, not a per-class one. `Tool.execute_action` bridges to a worker thread for async methods; `Tool.async_execute_action` hops to `asyncio.to_thread` for sync methods.
- `MonitoredTool` doesn't need to know the inner's shape — it just delegates and records. The `_inner_is_async` flag was conditional dispatch that the inner now does itself.
- `as_async` existed to give a sync toolbox an awaitable interface; now every `Toolbox` has `async_execute_action` natively.

Depends-on: cube-standard/feat/tool-consolidation

## Test plan

- [x] `make lint` clean
- [x] `pytest tests/test_monitored_tool_compat.py` — 20/20 pass
- [x] Full unit suite (`-m "not slow and not live_api and not integration"`) — 962 pass, 1 unrelated pre-existing failure (`test_eval_log.py::test_benchmark_subset_named_subset_is_recognised` from #491, asserts `'mock-cube[gold]' == 'mock-cube'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)