### PR TITLE
feat(analyze): XRay clean + submit (eligibility, archive, registry/EEE submit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ temp/
 # Auto-CUBE experiment outputs (large, not for VCS)
 auto_cube/results/
 
+# Submission staging dirs written by submit_to_journal.py / submit_to_eee.py
+# (relative to cwd when run from the repo root)
+journal-out/
+eee-out/
+
 # Personal experiment recipes (shared recipes are committed without the custom_ prefix)
 recipes/custom_*
 

--- a/openspec/specs/analyze/spec.md
+++ b/openspec/specs/analyze/spec.md
@@ -79,13 +79,46 @@ Legacy V1/V2 trajectories are adapted into this same event stream by the
 storage loader (`TrajectoryView._step_to_event`); the viewer never sees the old
 `EnvironmentOutput | AgentOutput` step shape.
 
+## Experiment eligibility — clean + submit
+
+The Experiments table adds a reproducibility-journal **eligibility** column and
+two auto-select actions, all backed by `reproducibility.scan.classify` — the same
+classifier the `scripts/scan_experiments.py` CLI uses, so XRay and the CLI never
+disagree.
+
+- **Eligibility badge** (`xray_utils.eligibility_badge`) — the cached scan
+  `category` (`submittable` / `subset_review` / `unfinished` / `broken` /
+  `already_submitted`) with a *fresh* `submissions.json` overlay that always wins:
+  ✅ submitted, 🚫 rejected, 📤 submitting, ❌ submit-failed.
+- **Archive 🤖✓** (`xray_utils.is_archivable`) — ticks non-keepers: `broken`, a
+  recorded rejection, or an explicit-debug run (`is_official is False`).
+  `is_official is True` is an **absolute keep** — a pinned reference run is never
+  auto-archived, even if broken/rejected. A bare `subset_review` is kept (it may
+  be a legit subset awaiting `--yes`).
+- **Submit 🤖✓ → Registry / EEE** (`xray_utils.is_submittable_pick`) — ticks
+  `submittable` runs not already submitted or mid-submission; the two buttons shell
+  out to `scripts/submit_to_journal.py` / `submit_to_eee.py`.
+- **Submission lifecycle** (`reproducibility.submissions`): absent → `pending`
+  (stamped on submit) → `submitted` | `failed`; `rejected` is a permanent decision.
+  `pending`/`failed` are transient and retryable — only `submitted`/`rejected`
+  count as a `has_decision`.
+
+Row data is cached per experiment in `.xray_summary.json` (`_v`), invalidated by
+episode-dir mtime **and** the recorded `submissions.json` mtime (so a submit or a
+rollback that clears it forces a reclassify); the eligibility badge is always
+recomputed fresh on top of the cache.
+
 ## Invariants
 
 1. Read-only for *trajectory* data — the viewer never modifies trajectories,
-   logs, or configs. The single exception is `_promote_ghost_episodes` writing
-   `STALE` into `status.json` files for in-flight episodes whose driver is
-   provably dead (see `xray_utils` above). This is gated by
-   `experiment_status.json` so the viewer cannot accidentally kill live work.
+   logs, or configs. Three scoped exceptions, none of which touch trajectory data:
+   (a) `_promote_ghost_episodes` writes `STALE` into `status.json` for in-flight
+   episodes whose driver is provably dead (gated by `experiment_status.json` so it
+   cannot kill live work); (b) the clean+submit actions move whole experiment dirs
+   into `_archive/` and write `submissions.json` (pending / failed / submitted, and
+   a `rejected` stamp when archiving a broken run); (c) the submit buttons invoke
+   the submit scripts. All are explicit, user-triggered actions on whole
+   experiments, never edits to recorded run data.
 2. Consumes events only; V1/V2 legacy layouts are adapted to events in the
    loader (`TrajectoryView`), never in the viewer.
 3. Live polling: a `gr.Timer.tick` handler refreshes in-flight trajectories and

--- a/scripts/scan_experiments.py
+++ b/scripts/scan_experiments.py
@@ -9,6 +9,8 @@ the script classifies it into one of:
   • broken             — cannot produce a meaningful submission (silent
                           rejection persisted into ``submissions.json``)
   • unfinished         — still running; state may change, re-scan later
+  • incomplete         — finished, but ran only a subset of the declared
+                          benchmark (partial / debug slice); not submittable
   • subset_review      — passed integrity but not a "complete named subset";
                           requires ``--yes`` to submit
   • submittable        — clean run of a full benchmark or a complete named
@@ -43,6 +45,7 @@ _CATEGORY_ICON = {
     ScanCategory.submittable: "→",
     ScanCategory.subset_review: "?",
     ScanCategory.unfinished: "…",
+    ScanCategory.incomplete: "◐",
     ScanCategory.broken: "✗",
 }
 

--- a/scripts/scan_experiments.py
+++ b/scripts/scan_experiments.py
@@ -8,9 +8,8 @@ the script classifies it into one of:
   • already_submitted  — ``submissions.json`` already has a 'journal' decision
   • broken             — cannot produce a meaningful submission (silent
                           rejection persisted into ``submissions.json``)
-  • unfinished         — still running; state may change, re-scan later
-  • incomplete         — finished, but ran only a subset of the declared
-                          benchmark (partial / debug slice); not submittable
+  • unfinished         — still running, or tasks missing a status file; state
+                          may change, re-scan later
   • subset_review      — passed integrity but not a "complete named subset";
                           requires ``--yes`` to submit
   • submittable        — clean run of a full benchmark or a complete named
@@ -45,7 +44,6 @@ _CATEGORY_ICON = {
     ScanCategory.submittable: "→",
     ScanCategory.subset_review: "?",
     ScanCategory.unfinished: "…",
-    ScanCategory.incomplete: "◐",
     ScanCategory.broken: "✗",
 }
 

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -125,6 +125,7 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
         # `gh repo fork --clone --remote` forks (if needed) and clones into
         # the cwd's subdirectory. We feed it the parent and let gh pick the
         # directory name. Quiet output keeps the user-visible echo clean.
+        # git clone flags go after a `--` separator (gh dropped `--clone-flags=`).
         subprocess.run(
             [
                 "gh",
@@ -133,7 +134,8 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
                 CUBE_REGISTRY_REPO,
                 "--clone",
                 "--remote",
-                "--clone-flags=--depth=1",
+                "--",
+                "--depth=1",
             ],
             cwd=tmp,
             check=True,
@@ -168,6 +170,13 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
         # Push to the *fork* (origin). The canonical repo is `upstream`.
         subprocess.run(["git", "-C", str(clone_dir), "push", "-u", "origin", branch], check=True)
 
+        # Fork owner, parsed from origin's URL (https or ssh) — needed for the
+        # cross-repo --head below.
+        origin_url = subprocess.check_output(
+            ["git", "-C", str(clone_dir), "remote", "get-url", "origin"], text=True
+        ).strip()
+        fork_owner = origin_url.rstrip("/").removesuffix(".git").split("/")[-2].split(":")[-1]
+
         title = f"results: {record['benchmark_name']} — {record['agent']['llm_model']}"
         body = (
             f"Adds one community evaluation result for `{record['benchmark_name']}`.\n\n"
@@ -179,9 +188,9 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
             f"- outcomes: {record['results']['outcomes']}\n\n"
             f"_Submitted via cube-harness `scripts/submit_to_journal.py`._"
         )
-        # `gh pr create` from inside the fork clone defaults to opening the PR
-        # against the parent (upstream) repo. We pass --repo explicitly to
-        # make the target unambiguous.
+        # Target the canonical repo with --repo, and name the head branch as
+        # `<fork_owner>:<branch>` — with --repo set, gh would otherwise look for
+        # the branch on upstream (where it doesn't exist) and fail.
         pr = subprocess.check_output(
             [
                 "gh",
@@ -189,6 +198,8 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
                 "create",
                 "--repo",
                 CUBE_REGISTRY_REPO,
+                "--head",
+                f"{fork_owner}:{branch}",
                 "--title",
                 title,
                 "--body",

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1545,11 +1545,22 @@ def run_xray(
             tail = next((ln for ln in reversed(stream.strip().splitlines()) if ln.strip()), "")
             return ok, tail
 
-        def on_submit(table: Any, destination: str) -> tuple[list[list[Any]], Any]:
-            """Submit the checked experiments to EEE or the cube-registry journal."""
+        def on_submit(table: Any, destination: str) -> tuple[Any, ...]:
+            """Submit the checked experiments to EEE or the cube-registry journal.
+
+            Outputs: [exp_table, *_hierarchy_outputs, exp_action_status]. After
+            submitting, the just-submitted rows are no longer ticked, so we re-
+            select the first experiment and rebuild the detail panel — otherwise
+            the table would show no selection while the panel still displays the
+            previous experiment."""
             dirs = _selected_exp_dirs(table)
             if not dirs:
-                return _exp_table_value(), gr.update(value="Nothing selected to submit.", visible=True)
+                skip_hierarchy = tuple(gr.skip() for _ in _hierarchy_outputs)
+                return (
+                    _exp_table_value(),
+                    *skip_hierarchy,
+                    gr.update(value="Nothing selected to submit.", visible=True),
+                )
             if destination == "eee":
                 script, extra = "submit_to_eee.py", []
             else:
@@ -1566,7 +1577,30 @@ def run_xray(
                 if not ok:
                     submissions.record_failed(d, dest_key, reason=tail or "submission failed")
                 lines.append(f"- {'✅' if ok else '❌'} `{d.name}` — {tail or ('done' if ok else 'failed')}")
-            return _exp_table_value(), gr.update(value="\n".join(lines), visible=True)
+            status = gr.update(value="\n".join(lines), visible=True)
+            # Re-select the first experiment so the table + detail panel stay in sync.
+            rows = xray_utils.get_experiments_table_rows(state.results_dir)
+            if not rows:
+                state._selected_exp_names = []
+                state.trajectories = []
+                state.selected_agent_key = None
+                empty_hierarchy = (
+                    "",
+                    None,
+                    None,
+                    StepId(),
+                    gr.Tab(label="Agents (0)"),
+                    gr.Tab(label="Trajectories (0)"),
+                    "",
+                    "",
+                    gr.Timer(active=False),
+                )
+                return (_to_exp_table(rows), *empty_hierarchy, status)
+            rows[0]["selected"] = True
+            first = rows[0]["experiment"]
+            state._selected_exp_names = [first]
+            state.load_experiments([state.results_dir / first])
+            return (_to_exp_table(rows), *_load_and_build_hierarchy(), gr.Timer(active=state.should_poll()), status)
 
         def on_browse_dir() -> tuple[list[list[Any]], str]:
             """Open a native folder picker; on choice, switch the results dir and
@@ -1595,10 +1629,14 @@ def run_xray(
         exp_pick_archivable_btn.click(fn=on_pick_archivable, outputs=[exp_table, exp_action_status])
         exp_pick_submittable_btn.click(fn=on_pick_submittable, outputs=[exp_table, exp_action_status])
         exp_submit_registry_btn.click(
-            fn=lambda t: on_submit(t, "journal"), inputs=exp_table, outputs=[exp_table, exp_action_status]
+            fn=lambda t: on_submit(t, "journal"),
+            inputs=exp_table,
+            outputs=[exp_table, *_hierarchy_outputs, exp_action_status],
         )
         exp_submit_eee_btn.click(
-            fn=lambda t: on_submit(t, "eee"), inputs=exp_table, outputs=[exp_table, exp_action_status]
+            fn=lambda t: on_submit(t, "eee"),
+            inputs=exp_table,
+            outputs=[exp_table, *_hierarchy_outputs, exp_action_status],
         )
         exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs, exp_action_status])
 

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1296,7 +1296,6 @@ def run_xray(
 | ⛔ | Failed — episode errored |
 | 👻 | Stale — no activity for too long |
 | 🚫 | Cancelled |
-| ○ | Task in the declared subset that never ran (partial / early-stopped run) |
 | ✕ | System error — crashed before trajectory was written |
 """,
                     elem_classes="help-content",

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -476,23 +476,46 @@ html {
     margin-bottom: 2px !important;
     min-height: 0 !important;
 }
-/* Experiments toolbar: render each (action, auto-select) pair as a single
-   split-button so it's clear the 🤖✓ belongs to its action. gap:0 makes the
-   pair touch; explicit left margins re-introduce spacing BETWEEN groups. */
+/* Experiments toolbar: one row that never wraps. Dir controls on the left; the
+   growing dir label pushes the two action split-buttons (Archive 🤖✓ · Submit 🤖✓)
+   to the right. Each (action, auto-select) pair renders as one split-button. */
 .xray-exp-toolbar {
     gap: 0 !important;
-    align-items: center;
+    align-items: center !important;
+    flex-wrap: nowrap !important;
+    width: 100%;
 }
-#exp_pick_archivable_btn, #exp_pick_submittable_btn, #exp_refresh_btn {
+/* The dir label grows to fill, right-aligning the actions; ellipsis if long. */
+#exp_dir_label {
+    flex: 1 1 auto !important;
+    min-width: 30px;
+    margin: 0 10px !important;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+#exp_refresh_btn {
     min-width: 34px !important;
     max-width: 40px;
     padding: 2px 8px !important;
     flex: 0 0 auto;
+    margin-left: 6px !important;
 }
-/* On row 2 (Archive-pair · Submit-pair), only Submit needs a left margin to
-   separate the two split-buttons; Archive is first. */
+/* auto-select buttons: stretch to the action button's height (so the split-
+   button halves match) and fit "🤖✓" on ONE line (no vertical wrap). */
+#exp_pick_archivable_btn, #exp_pick_submittable_btn {
+    min-width: 0 !important;
+    flex: 0 0 auto;
+    align-self: stretch !important;
+}
+#exp_pick_archivable_btn button, #exp_pick_submittable_btn button {
+    height: 100% !important;
+    padding: 2px 10px !important;
+    white-space: nowrap !important;
+}
+/* gap between the Archive split-button and the Submit split-button */
 #exp_submit_btn {
-    margin-left: 18px !important;
+    margin-left: 16px !important;
 }
 #exp_archive_btn button, #exp_submit_btn button {
     border-top-right-radius: 0 !important;
@@ -1269,17 +1292,17 @@ def run_xray(
                     elem_classes="help-content",
                 )
             with gr.Tab("Experiments", id="experiments_tab"):
-                # Row 1: directory controls. Row 2: the two actions, each with an
-                # attached 🤖✓ auto-select button (split-button) that ticks the rows
-                # it applies to; the user reviews, then clicks the action. Tooltips
-                # are set in _INIT_JS.
-                with gr.Row():
+                # One toolbar row: directory controls on the left, the two action
+                # split-buttons (Archive 🤖✓ · Submit 🤖✓) pushed to the right by the
+                # growing directory label. Each 🤖✓ auto-selects the rows its action
+                # applies to; the user reviews, then clicks the action. Tooltips are
+                # set in _INIT_JS.
+                with gr.Row(elem_classes="xray-exp-toolbar"):
                     exp_browse_btn = gr.Button(
                         "📁 Browse…", scale=0, size="sm", variant="secondary", elem_id="exp_browse_btn"
                     )
-                    results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
                     exp_refresh_btn = gr.Button("↺", scale=0, size="sm", elem_id="exp_refresh_btn", min_width=0)
-                with gr.Row(elem_classes="xray-exp-toolbar"):
+                    results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`", elem_id="exp_dir_label")
                     exp_archive_btn = gr.Button(
                         "🗃 Archive", scale=0, size="sm", variant="secondary", elem_id="exp_archive_btn"
                     )

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1504,7 +1504,7 @@ def run_xray(
             (partial / debug) subsets, and runs already recorded as rejected
             (e.g. all-ghost runs). The user reviews the ticks before archiving
             (e.g. to spare an intentional small subset)."""
-            return _select_rows(xray_utils.is_archivable, "broken / incomplete / rejected")
+            return _select_rows(lambda c, d: xray_utils.is_archivable(d, c), "broken / incomplete / rejected")
 
         def on_pick_submittable() -> tuple[list[list[Any]], Any]:
             """Auto-tick submittable, not-yet-submitted experiments for Submit."""

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1522,11 +1522,17 @@ def run_xray(
             return [state.results_dir / row[1] for row in records if row and bool(row[0])]
 
         def _run_submitter(script: str, exp_dir: Path, extra: list[str]) -> tuple[bool, str]:
-            """Invoke a submit script for one experiment; return (ok, last-output-line)."""
+            """Invoke a submit script for one experiment; return (ok, last-meaningful-line).
+
+            On failure the tail is taken from stderr (where the traceback /
+            CalledProcessError lands) so the recorded failure reason is the actual
+            error, not the last incidental stdout line."""
             cmd = [sys.executable, str(Path(__file__).resolve().parents[3] / "scripts" / script), str(exp_dir), *extra]
             proc = subprocess.run(cmd, capture_output=True, text=True)
-            tail = (proc.stdout.strip().splitlines() or [""])[-1]
-            return proc.returncode == 0, tail
+            ok = proc.returncode == 0
+            stream = proc.stdout if ok else (proc.stderr or proc.stdout)
+            tail = next((ln for ln in reversed(stream.strip().splitlines()) if ln.strip()), "")
+            return ok, tail
 
         def on_submit(table: Any, destination: str) -> tuple[list[list[Any]], Any]:
             """Submit the checked experiments to EEE or the cube-registry journal."""

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -691,7 +691,7 @@ _INIT_JS = """
         '#exp_browse_btn': 'Pick a different results directory',
         '#exp_refresh_btn': 'Re-scan the results directory (cached — fast)',
         '#exp_archive_btn': 'Archive all checked experiments (moves them to _archive/)',
-        '#exp_pick_archivable_btn': 'Auto-select broken / un-scorable experiments to archive',
+        '#exp_pick_archivable_btn': 'Auto-select broken + incomplete (partial/debug) experiments to archive',
         '#exp_submit_btn': 'Submit checked experiments to the cube-registry — opens a PR that auto-validates + merges',
         '#exp_pick_submittable_btn': 'Auto-select submittable, not-yet-submitted experiments',
     };
@@ -1501,8 +1501,10 @@ def run_xray(
             return _to_exp_table(rows), gr.update(value=msg, visible=True)
 
         def on_pick_archivable() -> tuple[list[list[Any]], Any]:
-            """Auto-tick broken / un-scorable experiments for Archive."""
-            return _select_rows(lambda c: c == "broken", "broken / archivable")
+            """Auto-tick non-keepers for Archive: broken runs + incomplete
+            (partial / debug) subsets. The user reviews the ticks before
+            archiving (e.g. to spare an intentional small subset)."""
+            return _select_rows(lambda c: c in ("broken", "incomplete"), "broken / incomplete")
 
         def on_pick_submittable() -> tuple[list[list[Any]], Any]:
             """Auto-tick submittable, not-yet-submitted experiments for Submit."""

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -691,7 +691,7 @@ _INIT_JS = """
         '#exp_browse_btn': 'Pick a different results directory',
         '#exp_refresh_btn': 'Re-scan the results directory (cached — fast)',
         '#exp_archive_btn': 'Archive all checked experiments (moves them to _archive/)',
-        '#exp_pick_archivable_btn': 'Auto-select broken + incomplete (partial/debug) experiments to archive',
+        '#exp_pick_archivable_btn': 'Auto-select broken + incomplete (partial/debug) + rejected experiments to archive',
         '#exp_submit_btn': 'Submit checked experiments to the cube-registry — opens a PR that auto-validates + merges',
         '#exp_pick_submittable_btn': 'Auto-select submittable, not-yet-submitted experiments',
     };
@@ -1486,28 +1486,29 @@ def run_xray(
         def _exp_table_value() -> list[list[Any]]:
             return _exp_table_rows(auto_select_first=False)
 
-        def _select_rows(category_match: Callable[[str], bool], label: str) -> tuple[list[list[Any]], Any]:
-            """Tick rows whose cached scan category matches. Routes through the
-            same cached `get_experiments_table_rows` as Refresh (status + ghost
-            heartbeat + eligibility, all cached), so it is as fast as a refresh."""
+        def _select_rows(predicate: Callable[[str, Path], bool], label: str) -> tuple[list[list[Any]], Any]:
+            """Tick rows for which ``predicate(category, exp_dir)`` is true. Routes
+            through the same cached `get_experiments_table_rows` as Refresh (status +
+            ghost heartbeat + eligibility, all cached), so it is as fast as a refresh."""
             rows = xray_utils.get_experiments_table_rows(state.results_dir)
             n = 0
             for r in rows:
-                hit = category_match(r.get("_category", "broken"))
+                hit = predicate(r.get("_category", "broken"), state.results_dir / r["experiment"])
                 r["selected"] = hit
                 n += int(hit)
             msg = f"🎯 Selected **{n}** {label} experiment(s). Review the ticks, then click the action button."
             return _to_exp_table(rows), gr.update(value=msg, visible=True)
 
         def on_pick_archivable() -> tuple[list[list[Any]], Any]:
-            """Auto-tick non-keepers for Archive: broken runs + incomplete
-            (partial / debug) subsets. The user reviews the ticks before
-            archiving (e.g. to spare an intentional small subset)."""
-            return _select_rows(lambda c: c in ("broken", "incomplete"), "broken / incomplete")
+            """Auto-tick non-keepers for Archive: broken runs, incomplete
+            (partial / debug) subsets, and runs already recorded as rejected
+            (e.g. all-ghost runs). The user reviews the ticks before archiving
+            (e.g. to spare an intentional small subset)."""
+            return _select_rows(xray_utils.is_archivable, "broken / incomplete / rejected")
 
         def on_pick_submittable() -> tuple[list[list[Any]], Any]:
             """Auto-tick submittable, not-yet-submitted experiments for Submit."""
-            return _select_rows(lambda c: c == "submittable", "submittable")
+            return _select_rows(lambda c, _d: c == "submittable", "submittable")
 
         def _selected_exp_dirs(table: Any) -> list[Path]:
             """Experiment dirs whose checkbox is ticked in the current table value."""

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -476,16 +476,33 @@ html {
     margin-bottom: 2px !important;
     min-height: 0 !important;
 }
-/* Experiments toolbar: tight row; the 🎯 auto-select buttons hug their action. */
+/* Experiments toolbar: render each (action, auto-select) pair as a single
+   split-button so it's clear the 🤖✓ belongs to its action. gap:0 makes the
+   pair touch; explicit left margins re-introduce spacing BETWEEN groups. */
 .xray-exp-toolbar {
-    gap: 4px !important;
+    gap: 0 !important;
     align-items: center;
 }
 #exp_pick_archivable_btn, #exp_pick_submittable_btn, #exp_refresh_btn {
-    min-width: 32px !important;
-    max-width: 38px;
-    padding: 2px 6px !important;
+    min-width: 34px !important;
+    max-width: 40px;
+    padding: 2px 8px !important;
     flex: 0 0 auto;
+}
+#exp_refresh_btn {
+    margin-left: 10px !important;
+}
+#exp_archive_btn, #exp_submit_btn {
+    margin-left: 18px !important;
+}
+#exp_archive_btn button, #exp_submit_btn button {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+}
+#exp_pick_archivable_btn button, #exp_pick_submittable_btn button {
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    border-left: 1px solid rgba(0, 0, 0, 0.18) !important;
 }
 .compact-header {
     padding: 8px 16px;
@@ -1202,7 +1219,7 @@ def run_xray(
         active_tab = gr.State(value="Chat")
         step_id = gr.State(value=StepId())
 
-        with gr.Tabs():
+        with gr.Tabs(selected="experiments_tab"):
             with gr.Tab("Help"):
                 gr.Markdown(
                     """\
@@ -1252,9 +1269,9 @@ def run_xray(
 """,
                     elem_classes="help-content",
                 )
-            with gr.Tab("Experiments"):
+            with gr.Tab("Experiments", id="experiments_tab"):
                 # Single toolbar row. Each action (Archive / Submit) has a small
-                # attached 🎯 auto-select button that ticks the rows it applies to;
+                # attached 🤖✓ auto-select button that ticks the rows it applies to;
                 # the user reviews the selection, then clicks the action. Tooltips
                 # (set in _INIT_JS) describe each button.
                 with gr.Row(elem_classes="xray-exp-toolbar"):
@@ -1266,13 +1283,13 @@ def run_xray(
                         "🗃 Archive", scale=0, size="sm", variant="secondary", elem_id="exp_archive_btn"
                     )
                     exp_pick_archivable_btn = gr.Button(
-                        "🎯", scale=0, size="sm", elem_id="exp_pick_archivable_btn", min_width=0
+                        "🤖✓", scale=0, size="sm", elem_id="exp_pick_archivable_btn", min_width=0
                     )
                     exp_submit_btn = gr.Button(
                         "⬆️ Submit", scale=0, size="sm", variant="primary", elem_id="exp_submit_btn"
                     )
                     exp_pick_submittable_btn = gr.Button(
-                        "🎯", scale=0, size="sm", elem_id="exp_pick_submittable_btn", min_width=0
+                        "🤖✓", scale=0, size="sm", elem_id="exp_pick_submittable_btn", min_width=0
                     )
                 results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
                 exp_action_status = gr.Markdown("", visible=False)

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -489,10 +489,9 @@ html {
     padding: 2px 8px !important;
     flex: 0 0 auto;
 }
-#exp_refresh_btn {
-    margin-left: 10px !important;
-}
-#exp_archive_btn, #exp_submit_btn {
+/* On row 2 (Archive-pair · Submit-pair), only Submit needs a left margin to
+   separate the two split-buttons; Archive is first. */
+#exp_submit_btn {
     margin-left: 18px !important;
 }
 #exp_archive_btn button, #exp_submit_btn button {
@@ -1270,15 +1269,17 @@ def run_xray(
                     elem_classes="help-content",
                 )
             with gr.Tab("Experiments", id="experiments_tab"):
-                # Single toolbar row. Each action (Archive / Submit) has a small
-                # attached 🤖✓ auto-select button that ticks the rows it applies to;
-                # the user reviews the selection, then clicks the action. Tooltips
-                # (set in _INIT_JS) describe each button.
-                with gr.Row(elem_classes="xray-exp-toolbar"):
+                # Row 1: directory controls. Row 2: the two actions, each with an
+                # attached 🤖✓ auto-select button (split-button) that ticks the rows
+                # it applies to; the user reviews, then clicks the action. Tooltips
+                # are set in _INIT_JS.
+                with gr.Row():
                     exp_browse_btn = gr.Button(
                         "📁 Browse…", scale=0, size="sm", variant="secondary", elem_id="exp_browse_btn"
                     )
+                    results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
                     exp_refresh_btn = gr.Button("↺", scale=0, size="sm", elem_id="exp_refresh_btn", min_width=0)
+                with gr.Row(elem_classes="xray-exp-toolbar"):
                     exp_archive_btn = gr.Button(
                         "🗃 Archive", scale=0, size="sm", variant="secondary", elem_id="exp_archive_btn"
                     )
@@ -1291,7 +1292,6 @@ def run_xray(
                     exp_pick_submittable_btn = gr.Button(
                         "🤖✓", scale=0, size="sm", elem_id="exp_pick_submittable_btn", min_width=0
                     )
-                results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
                 exp_action_status = gr.Markdown("", visible=False)
                 exp_table = gr.DataFrame(
                     headers=[

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -852,9 +852,12 @@ def run_xray(
         hierarchy = _load_and_build_hierarchy()
         return (*hierarchy, gr.Timer(active=state.should_poll()))
 
-    def on_archive_selected() -> tuple[Any, str, Any, Any, Any, StepId, gr.Tab, gr.Tab, gr.Tab, str, str, gr.Timer]:
+    def on_archive_selected() -> tuple[
+        Any, str, Any, Any, Any, StepId, gr.Tab, gr.Tab, gr.Tab, str, str, gr.Timer, Any
+    ]:
         """Archive all currently selected experiments and reset state."""
-        for name in list(state._selected_exp_names):
+        names = list(state._selected_exp_names)
+        for name in names:
             xray_utils.archive_experiment(state.results_dir, name)
         state._selected_exp_names = []
         state.trajectories = []
@@ -870,7 +873,13 @@ def run_xray(
             "",
             gr.Timer(active=False),
         )
-        return (_exp_table_rows(), *_empty_hierarchy)
+        # Replace the now-stale "Selected N…" line with a result (or clear it).
+        status = (
+            gr.update(value=f"🗃 Archived **{len(names)}** experiment(s) to `_archive/`.", visible=True)
+            if names
+            else gr.update(value="", visible=False)
+        )
+        return (_exp_table_rows(), *_empty_hierarchy, status)
 
     def on_select_agent(evt: gr.SelectData, agent_df: Any) -> tuple[Any, Any, StepId, gr.Tab, gr.Tab, str, str]:
         if evt is None or evt.index is None or agent_df is None or len(agent_df) == 0:
@@ -1287,6 +1296,7 @@ def run_xray(
 | ⛔ | Failed — episode errored |
 | 👻 | Stale — no activity for too long |
 | 🚫 | Cancelled |
+| ○ | Task in the declared subset that never ran (partial / early-stopped run) |
 | ✕ | System error — crashed before trajectory was written |
 """,
                     elem_classes="help-content",
@@ -1554,7 +1564,7 @@ def run_xray(
         exp_submit_btn.click(
             fn=lambda t: on_submit(t, "journal"), inputs=exp_table, outputs=[exp_table, exp_action_status]
         )
-        exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs])
+        exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs, exp_action_status])
 
         bg_timer.tick(
             fn=on_bg_load_tick,

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -476,6 +476,17 @@ html {
     margin-bottom: 2px !important;
     min-height: 0 !important;
 }
+/* Experiments toolbar: tight row; the 🎯 auto-select buttons hug their action. */
+.xray-exp-toolbar {
+    gap: 4px !important;
+    align-items: center;
+}
+#exp_pick_archivable_btn, #exp_pick_submittable_btn, #exp_refresh_btn {
+    min-width: 32px !important;
+    max-width: 38px;
+    padding: 2px 6px !important;
+    flex: 0 0 auto;
+}
 .compact-header {
     padding: 8px 16px;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -635,10 +646,21 @@ _INIT_JS = """
     document.body.classList.remove('dark');
     if (window.__xrayInit) return;
     window.__xrayInit = true;
+    const TIPS = {
+        '#xray_prev_btn': 'Previous event (← or ↑)',
+        '#xray_next_btn': 'Next event (→ or ↓)',
+        '#exp_browse_btn': 'Pick a different results directory',
+        '#exp_refresh_btn': 'Re-scan the results directory (cached — fast)',
+        '#exp_archive_btn': 'Archive all checked experiments (moves them to _archive/)',
+        '#exp_pick_archivable_btn': 'Auto-select broken / un-scorable experiments to archive',
+        '#exp_submit_btn': 'Submit checked experiments to the cube-registry — opens a PR that auto-validates + merges',
+        '#exp_pick_submittable_btn': 'Auto-select submittable, not-yet-submitted experiments',
+    };
     const setTip = () => {
-        const pb = document.querySelector('#xray_prev_btn'), nb = document.querySelector('#xray_next_btn');
-        if (pb) pb.title = 'Previous event (← or ↑)';
-        if (nb) nb.title = 'Next event (→ or ↓)';
+        for (const [sel, tip] of Object.entries(TIPS)) {
+            const el = document.querySelector(sel);
+            if (el) el.title = tip;
+        }
     };
     setTip();
     setTimeout(setTip, 1000);
@@ -1231,21 +1253,26 @@ def run_xray(
                     elem_classes="help-content",
                 )
             with gr.Tab("Experiments"):
-                with gr.Row():
-                    exp_browse_btn = gr.Button("📁 Browse…", scale=0, size="sm", variant="secondary")
-                    exp_refresh_btn = gr.Button("↺ Refresh", scale=0, size="sm")
-                    exp_archive_btn = gr.Button("🗃 Archive selected", scale=0, size="sm", variant="secondary")
-                with gr.Row():
-                    # Clean + submit workflow. The two Submit buttons stay hidden
-                    # until "Check submittable" selects clean runs, to keep the
-                    # default toolbar uncluttered.
-                    exp_gc_btn = gr.Button("🧹 Garbage-collect", scale=0, size="sm", variant="secondary")
-                    exp_checksubmit_btn = gr.Button("📤 Check submittable", scale=0, size="sm", variant="secondary")
-                    exp_submit_eee_btn = gr.Button(
-                        "⬆️ Submit → EEE", scale=0, size="sm", variant="primary", visible=False
+                # Single toolbar row. Each action (Archive / Submit) has a small
+                # attached 🎯 auto-select button that ticks the rows it applies to;
+                # the user reviews the selection, then clicks the action. Tooltips
+                # (set in _INIT_JS) describe each button.
+                with gr.Row(elem_classes="xray-exp-toolbar"):
+                    exp_browse_btn = gr.Button(
+                        "📁 Browse…", scale=0, size="sm", variant="secondary", elem_id="exp_browse_btn"
                     )
-                    exp_submit_registry_btn = gr.Button(
-                        "⬆️ Submit → Registry", scale=0, size="sm", variant="primary", visible=False
+                    exp_refresh_btn = gr.Button("↺", scale=0, size="sm", elem_id="exp_refresh_btn", min_width=0)
+                    exp_archive_btn = gr.Button(
+                        "🗃 Archive", scale=0, size="sm", variant="secondary", elem_id="exp_archive_btn"
+                    )
+                    exp_pick_archivable_btn = gr.Button(
+                        "🎯", scale=0, size="sm", elem_id="exp_pick_archivable_btn", min_width=0
+                    )
+                    exp_submit_btn = gr.Button(
+                        "⬆️ Submit", scale=0, size="sm", variant="primary", elem_id="exp_submit_btn"
+                    )
+                    exp_pick_submittable_btn = gr.Button(
+                        "🎯", scale=0, size="sm", elem_id="exp_pick_submittable_btn", min_width=0
                     )
                 results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
                 exp_action_status = gr.Markdown("", visible=False)
@@ -1410,38 +1437,26 @@ def run_xray(
         def _exp_table_value() -> list[list[Any]]:
             return _exp_table_rows(auto_select_first=False)
 
-        def on_garbage_collect() -> list[list[Any]]:
-            """Reclassify every experiment (sweeping dead RUNNING/QUEUED → stale)
-            and auto-check the broken ones for the user to review and Archive."""
-            rows = xray_utils.get_experiments_table_rows(state.results_dir)
-            for r in rows:
-                exp_dir = state.results_dir / r["experiment"]
-                category = xray_utils.scan_category(exp_dir, sweep_stale=True)
-                r["_category"] = category
-                r["eligibility"] = xray_utils.eligibility_badge(exp_dir, category)
-                r["selected"] = category == "broken"
-            return _to_exp_table(rows)
-
-        def on_check_submit() -> tuple[list[list[Any]], Any, Any, Any]:
-            """Auto-check the submittable experiments and reveal the Submit buttons."""
+        def _select_rows(category_match: Callable[[str], bool], label: str) -> tuple[list[list[Any]], Any]:
+            """Tick rows whose cached scan category matches. Routes through the
+            same cached `get_experiments_table_rows` as Refresh (status + ghost
+            heartbeat + eligibility, all cached), so it is as fast as a refresh."""
             rows = xray_utils.get_experiments_table_rows(state.results_dir)
             n = 0
             for r in rows:
-                is_submittable = r.get("_category") == "submittable"
-                r["selected"] = is_submittable
-                n += int(is_submittable)
-            msg = (
-                f"📤 Selected **{n}** submittable experiment(s). Review the selection, then "
-                "**Submit → EEE** or **Submit → Registry**."
-                if n
-                else "No submittable experiments found (need a clean, complete run with an experiment record)."
-            )
-            return (
-                _to_exp_table(rows),
-                gr.update(visible=n > 0),
-                gr.update(visible=n > 0),
-                gr.update(value=msg, visible=True),
-            )
+                hit = category_match(r.get("_category", "broken"))
+                r["selected"] = hit
+                n += int(hit)
+            msg = f"🎯 Selected **{n}** {label} experiment(s). Review the ticks, then click the action button."
+            return _to_exp_table(rows), gr.update(value=msg, visible=True)
+
+        def on_pick_archivable() -> tuple[list[list[Any]], Any]:
+            """Auto-tick broken / un-scorable experiments for Archive."""
+            return _select_rows(lambda c: c == "broken", "broken / archivable")
+
+        def on_pick_submittable() -> tuple[list[list[Any]], Any]:
+            """Auto-tick submittable, not-yet-submitted experiments for Submit."""
+            return _select_rows(lambda c: c == "submittable", "submittable")
 
         def _selected_exp_dirs(table: Any) -> list[Path]:
             """Experiment dirs whose checkbox is ticked in the current table value."""
@@ -1494,15 +1509,9 @@ def run_xray(
         exp_table.change(fn=on_experiments_change, inputs=exp_table, outputs=_hierarchy_outputs)
         exp_browse_btn.click(fn=on_browse_dir, outputs=[exp_table, results_dir_md])
         exp_refresh_btn.click(fn=_exp_table_value, outputs=exp_table)
-        exp_gc_btn.click(fn=on_garbage_collect, outputs=exp_table)
-        exp_checksubmit_btn.click(
-            fn=on_check_submit,
-            outputs=[exp_table, exp_submit_eee_btn, exp_submit_registry_btn, exp_action_status],
-        )
-        exp_submit_eee_btn.click(
-            fn=lambda t: on_submit(t, "eee"), inputs=exp_table, outputs=[exp_table, exp_action_status]
-        )
-        exp_submit_registry_btn.click(
+        exp_pick_archivable_btn.click(fn=on_pick_archivable, outputs=[exp_table, exp_action_status])
+        exp_pick_submittable_btn.click(fn=on_pick_submittable, outputs=[exp_table, exp_action_status])
+        exp_submit_btn.click(
             fn=lambda t: on_submit(t, "journal"), inputs=exp_table, outputs=[exp_table, exp_action_status]
         )
         exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs])

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -29,6 +29,7 @@ from cube_harness.analyze import inspect_results, xray_utils
 from cube_harness.analyze.xray_events import EpisodeEvents
 from cube_harness.core import Trajectory
 from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus
+from cube_harness.reproducibility import submissions
 from cube_harness.storage import FileStorage
 
 # ---------------------------------------------------------------------------
@@ -858,6 +859,9 @@ def run_xray(
         """Archive all currently selected experiments and reset state."""
         names = list(state._selected_exp_names)
         for name in names:
+            # Stamp a durable rejection for broken runs before moving them, so the
+            # verdict travels into _archive/ (mirrors scan_experiments --persist-broken).
+            xray_utils.persist_broken_rejection(state.results_dir / name)
             xray_utils.archive_experiment(state.results_dir, name)
         state._selected_exp_names = []
         state.trajectories = []
@@ -1507,8 +1511,10 @@ def run_xray(
             return _select_rows(lambda c, d: xray_utils.is_archivable(d, c), "broken / incomplete / rejected")
 
         def on_pick_submittable() -> tuple[list[list[Any]], Any]:
-            """Auto-tick submittable, not-yet-submitted experiments for Submit."""
-            return _select_rows(lambda c, _d: c == "submittable", "submittable")
+            """Auto-tick submittable experiments that aren't already submitted or
+            mid-submission (reads submissions.json fresh, so a just-submitted run
+            is not re-ticked even if its cached category lags)."""
+            return _select_rows(lambda c, d: xray_utils.is_submittable_pick(d, c), "submittable")
 
         def _selected_exp_dirs(table: Any) -> list[Path]:
             """Experiment dirs whose checkbox is ticked in the current table value."""
@@ -1531,9 +1537,17 @@ def run_xray(
                 script, extra = "submit_to_eee.py", []
             else:
                 script, extra = "submit_to_journal.py", ["--auto-pr", "--i-understand-this-is-not-a-leaderboard"]
+            dest_key = "eee" if destination == "eee" else "journal"
             lines = [f"### Submit → {destination.upper()} ({len(dirs)} experiment(s))"]
             for d in dirs:
+                # Mark in-progress so the row reads "submitting…" and the auto-
+                # selector won't re-tick it. The submitter writes `submitted` on
+                # success (overwriting pending); we record `failed` otherwise so
+                # the failure persists in submissions.json instead of vanishing.
+                submissions.record_pending(d, dest_key)
                 ok, tail = _run_submitter(script, d, extra)
+                if not ok:
+                    submissions.record_failed(d, dest_key, reason=tail or "submission failed")
                 lines.append(f"- {'✅' if ok else '❌'} `{d.name}` — {tail or ('done' if ok else 'failed')}")
             return _exp_table_value(), gr.update(value="\n".join(lines), visible=True)
 

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -514,13 +514,20 @@ html {
     padding: 2px 10px !important;
     white-space: nowrap !important;
 }
-/* gap between the Archive split-button and the Submit split-button */
-#exp_submit_btn {
+/* gap between the Archive split-button and the Submit cluster */
+#exp_submit_registry_btn {
     margin-left: 16px !important;
 }
-#exp_archive_btn button, #exp_submit_btn button {
+/* Submit cluster = [Registry | EEE | 🤖✓] joined into one unit. Left segment
+   (Registry) keeps its left radius; the middle (EEE) is square; the 🤖✓ keeps
+   the right radius (handled by the shared pick-button rule below). */
+#exp_archive_btn button, #exp_submit_registry_btn button {
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
+}
+#exp_submit_eee_btn button {
+    border-radius: 0 !important;
+    border-left: 1px solid rgba(0, 0, 0, 0.18) !important;
 }
 #exp_pick_archivable_btn button, #exp_pick_submittable_btn button {
     border-top-left-radius: 0 !important;
@@ -693,8 +700,9 @@ _INIT_JS = """
         '#exp_refresh_btn': 'Re-scan the results directory (cached — fast)',
         '#exp_archive_btn': 'Archive all checked experiments (moves them to _archive/)',
         '#exp_pick_archivable_btn': 'Auto-select broken + incomplete (partial/debug) + rejected experiments to archive',
-        '#exp_submit_btn': 'Submit checked experiments to the cube-registry — opens a PR that auto-validates + merges',
-        '#exp_pick_submittable_btn': 'Auto-select submittable, not-yet-submitted experiments',
+        '#exp_submit_registry_btn': 'Submit checked experiments to the cube-registry reproducibility journal — opens an auto-validating, auto-merging PR. For publishing REFERENCE values (cross-infra drift detection), NOT a leaderboard.',
+        '#exp_submit_eee_btn': 'Submit checked experiments to EEE (the eval results store) — for showcasing agent/model performance. Runs scripts/submit_to_eee.py.',
+        '#exp_pick_submittable_btn': 'Auto-select submittable, not-yet-submitted experiments (applies to whichever submit button you click next)',
     };
     const setTip = () => {
         for (const [sel, tip] of Object.entries(TIPS)) {
@@ -1305,11 +1313,11 @@ def run_xray(
                     elem_classes="help-content",
                 )
             with gr.Tab("Experiments", id="experiments_tab"):
-                # One toolbar row: directory controls on the left, the two action
-                # split-buttons (Archive 🤖✓ · Submit 🤖✓) pushed to the right by the
-                # growing directory label. Each 🤖✓ auto-selects the rows its action
-                # applies to; the user reviews, then clicks the action. Tooltips are
-                # set in _INIT_JS.
+                # One toolbar row: directory controls on the left, the action
+                # clusters (Archive 🤖✓ · Registry EEE 🤖✓) pushed to the right by
+                # the growing directory label. Each 🤖✓ auto-selects the rows its
+                # action applies to; the user reviews, then clicks Registry or EEE.
+                # Tooltips are set in _INIT_JS.
                 with gr.Row(elem_classes="xray-exp-toolbar"):
                     exp_browse_btn = gr.Button(
                         "📁 Browse…", scale=0, size="sm", variant="secondary", elem_id="exp_browse_btn"
@@ -1322,8 +1330,11 @@ def run_xray(
                     exp_pick_archivable_btn = gr.Button(
                         "🤖✓", scale=0, size="sm", elem_id="exp_pick_archivable_btn", min_width=0
                     )
-                    exp_submit_btn = gr.Button(
-                        "⬆️ Submit", scale=0, size="sm", variant="primary", elem_id="exp_submit_btn"
+                    exp_submit_registry_btn = gr.Button(
+                        "⬆️ Registry", scale=0, size="sm", variant="primary", elem_id="exp_submit_registry_btn"
+                    )
+                    exp_submit_eee_btn = gr.Button(
+                        "⬆️ EEE", scale=0, size="sm", variant="primary", elem_id="exp_submit_eee_btn"
                     )
                     exp_pick_submittable_btn = gr.Button(
                         "🤖✓", scale=0, size="sm", elem_id="exp_pick_submittable_btn", min_width=0
@@ -1583,8 +1594,11 @@ def run_xray(
         exp_refresh_btn.click(fn=_exp_table_value, outputs=exp_table)
         exp_pick_archivable_btn.click(fn=on_pick_archivable, outputs=[exp_table, exp_action_status])
         exp_pick_submittable_btn.click(fn=on_pick_submittable, outputs=[exp_table, exp_action_status])
-        exp_submit_btn.click(
+        exp_submit_registry_btn.click(
             fn=lambda t: on_submit(t, "journal"), inputs=exp_table, outputs=[exp_table, exp_action_status]
+        )
+        exp_submit_eee_btn.click(
+            fn=lambda t: on_submit(t, "eee"), inputs=exp_table, outputs=[exp_table, exp_action_status]
         )
         exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs, exp_action_status])
 

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -464,8 +464,9 @@ html {
     border-radius: 8px;
     border: 1px solid #e2e8f0;
 }
-/* Tiny, tight prev/next nav buttons, centred and hugging the rail. */
-#xray_prev_btn, #xray_next_btn {
+/* Tiny, tight nav buttons (jump-to-first ⤒ · prev ◀ · next ▶ · jump-to-last ⤓),
+   centred and hugging the rail. */
+#xray_first_btn, #xray_prev_btn, #xray_next_btn, #xray_last_btn {
     min-width: 28px !important;
     max-width: 34px;
     padding: 2px 6px !important;
@@ -682,8 +683,9 @@ th {
 """
 
 # Runs once on app load (Blocks js=): force light theme + bind keyboard event
-# navigation. Arrow keys (←/→ or ↑/↓) move to the previous/next event — plain
-# arrows, not Shift+arrow (which the browser steals for text selection). Gradio
+# navigation. Plain arrows (←/→ or ↑/↓) step to the previous/next event; Shift+↑/↓
+# (or Home/End) jump to the first/last step. preventDefault + the input/textarea
+# guard keep Shift+arrow from extending a browser text selection. Gradio
 # puts `elem_id` on the <button> itself, so the selectors are `#xray_prev_btn`,
 # NOT `#xray_prev_btn button`. Tooltips advertise the shortcut. (Rail scroll is
 # preserved by the CSS overflow living on the stable `#xray_rail` container, so
@@ -694,8 +696,10 @@ _INIT_JS = """
     if (window.__xrayInit) return;
     window.__xrayInit = true;
     const TIPS = {
+        '#xray_first_btn': 'Jump to first step (Shift+↑ or Home)',
         '#xray_prev_btn': 'Previous event (← or ↑)',
         '#xray_next_btn': 'Next event (→ or ↓)',
+        '#xray_last_btn': 'Jump to last step / end (Shift+↓ or End)',
         '#exp_browse_btn': 'Pick a different results directory',
         '#exp_refresh_btn': 'Re-scan the results directory (cached — fast)',
         '#exp_archive_btn': 'Archive all checked experiments (moves them to _archive/)',
@@ -717,7 +721,13 @@ _INIT_JS = """
         if (tag === 'input' || tag === 'textarea' || tag === 'select' || t.isContentEditable) return;
         if (e.metaKey || e.ctrlKey || e.altKey) return;
         let sel = null;
-        if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') sel = '#xray_prev_btn';
+        // Shift+↑/↓ and Home/End jump to the first/last step; plain arrows step.
+        if (e.shiftKey) {
+            if (e.key === 'ArrowUp') sel = '#xray_first_btn';
+            else if (e.key === 'ArrowDown') sel = '#xray_last_btn';
+        } else if (e.key === 'Home') sel = '#xray_first_btn';
+        else if (e.key === 'End') sel = '#xray_last_btn';
+        else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') sel = '#xray_prev_btn';
         else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') sel = '#xray_next_btn';
         if (!sel) return;
         const b = document.querySelector(sel);
@@ -1015,6 +1025,20 @@ def run_xray(
         if state.current_events is None:
             return StepId(step=state.selected)
         state.selected = state.current_events.next_group_root(state.selected)
+        return StepId(step=state.selected)
+
+    def navigate_first() -> StepId:
+        """Jump to the first step (group after the initial observation)."""
+        if state.current_events is None or len(state.current_events) == 0:
+            return StepId(step=state.selected)
+        state.selected = state.current_events.first_group_root()
+        return StepId(step=state.selected)
+
+    def navigate_last() -> StepId:
+        """Jump to the last group (end of the episode)."""
+        if state.current_events is None or len(state.current_events) == 0:
+            return StepId(step=state.selected)
+        state.selected = state.current_events.last_group_root()
         return StepId(step=state.selected)
 
     def handle_timeline_click(clicked_index: int | None) -> StepId:
@@ -1432,8 +1456,10 @@ def run_xray(
         with gr.Row(equal_height=False):
             with gr.Column(scale=1, min_width=240):
                 with gr.Row(elem_classes="xray-nav-row"):
+                    first_btn = gr.Button("⤒", size="sm", elem_id="xray_first_btn", min_width=0, scale=0)
                     prev_btn = gr.Button("◀", size="sm", elem_id="xray_prev_btn", min_width=0, scale=0)
                     next_btn = gr.Button("▶", size="sm", elem_id="xray_next_btn", min_width=0, scale=0)
+                    last_btn = gr.Button("⤓", size="sm", elem_id="xray_last_btn", min_width=0, scale=0)
                 timeline_html = gr.HTML(elem_id="xray_rail")
             with gr.Column(scale=3):
                 # Reasoning (the LLM's thinking) beside the dispatched action.
@@ -1673,8 +1699,10 @@ def run_xray(
 
         # Navigation buttons — handlers read state.step from closure (inputs=[]) so that
         # JS button.click() also works without Gradio losing the gr.State value.
+        first_btn.click(fn=navigate_first, inputs=[], outputs=step_id)
         prev_btn.click(fn=navigate_prev, inputs=[], outputs=step_id)
         next_btn.click(fn=navigate_next, inputs=[], outputs=step_id)
+        last_btn.click(fn=navigate_last, inputs=[], outputs=step_id)
 
         # Always-rendered on step change
         step_id.change(fn=get_compact_header_info, outputs=header_info)

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -14,6 +14,8 @@ import argparse
 import html as html_lib
 import json
 import re
+import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1233,13 +1235,36 @@ def run_xray(
                     exp_browse_btn = gr.Button("📁 Browse…", scale=0, size="sm", variant="secondary")
                     exp_refresh_btn = gr.Button("↺ Refresh", scale=0, size="sm")
                     exp_archive_btn = gr.Button("🗃 Archive selected", scale=0, size="sm", variant="secondary")
+                with gr.Row():
+                    # Clean + submit workflow. The two Submit buttons stay hidden
+                    # until "Check submittable" selects clean runs, to keep the
+                    # default toolbar uncluttered.
+                    exp_gc_btn = gr.Button("🧹 Garbage-collect", scale=0, size="sm", variant="secondary")
+                    exp_checksubmit_btn = gr.Button("📤 Check submittable", scale=0, size="sm", variant="secondary")
+                    exp_submit_eee_btn = gr.Button(
+                        "⬆️ Submit → EEE", scale=0, size="sm", variant="primary", visible=False
+                    )
+                    exp_submit_registry_btn = gr.Button(
+                        "⬆️ Submit → Registry", scale=0, size="sm", variant="primary", visible=False
+                    )
                 results_dir_md = gr.Markdown(f"📂 `{state.results_dir}`")
+                exp_action_status = gr.Markdown("", visible=False)
                 exp_table = gr.DataFrame(
-                    headers=["", "experiment", "date", "agent", "model", "benchmark", "status", "avg_reward"],
-                    datatype=["bool", "str", "str", "str", "str", "str", "html", "str"],
-                    col_count=(8, "fixed"),
+                    headers=[
+                        "",
+                        "experiment",
+                        "date",
+                        "agent",
+                        "model",
+                        "benchmark",
+                        "status",
+                        "avg_reward",
+                        "eligibility",
+                    ],
+                    datatype=["bool", "str", "str", "str", "str", "str", "html", "str", "html"],
+                    col_count=(9, "fixed"),
                     interactive=True,
-                    static_columns=[1, 2, 3, 4, 5, 6, 7],
+                    static_columns=[1, 2, 3, 4, 5, 6, 7, 8],
                     max_height=260,
                     show_label=False,
                     elem_id="exp_table",
@@ -1360,10 +1385,7 @@ def run_xray(
         # Event wiring
         # ------------------------------------------------------------------
 
-        def _exp_table_rows(auto_select_first: bool = False) -> list[list[Any]]:
-            rows = xray_utils.get_experiments_table_rows(state.results_dir)
-            if auto_select_first and rows:
-                rows[0]["selected"] = True
+        def _to_exp_table(rows: list[dict[str, Any]]) -> list[list[Any]]:
             return [
                 [
                     r["selected"],
@@ -1374,12 +1396,79 @@ def run_xray(
                     r["benchmark"],
                     r["status"],
                     r.get("avg_reward", "—"),
+                    r.get("eligibility", "—"),
                 ]
                 for r in rows
             ]
 
+        def _exp_table_rows(auto_select_first: bool = False) -> list[list[Any]]:
+            rows = xray_utils.get_experiments_table_rows(state.results_dir)
+            if auto_select_first and rows:
+                rows[0]["selected"] = True
+            return _to_exp_table(rows)
+
         def _exp_table_value() -> list[list[Any]]:
             return _exp_table_rows(auto_select_first=False)
+
+        def on_garbage_collect() -> list[list[Any]]:
+            """Reclassify every experiment (sweeping dead RUNNING/QUEUED → stale)
+            and auto-check the broken ones for the user to review and Archive."""
+            rows = xray_utils.get_experiments_table_rows(state.results_dir)
+            for r in rows:
+                exp_dir = state.results_dir / r["experiment"]
+                category = xray_utils.scan_category(exp_dir, sweep_stale=True)
+                r["_category"] = category
+                r["eligibility"] = xray_utils.eligibility_badge(exp_dir, category)
+                r["selected"] = category == "broken"
+            return _to_exp_table(rows)
+
+        def on_check_submit() -> tuple[list[list[Any]], Any, Any, Any]:
+            """Auto-check the submittable experiments and reveal the Submit buttons."""
+            rows = xray_utils.get_experiments_table_rows(state.results_dir)
+            n = 0
+            for r in rows:
+                is_submittable = r.get("_category") == "submittable"
+                r["selected"] = is_submittable
+                n += int(is_submittable)
+            msg = (
+                f"📤 Selected **{n}** submittable experiment(s). Review the selection, then "
+                "**Submit → EEE** or **Submit → Registry**."
+                if n
+                else "No submittable experiments found (need a clean, complete run with an experiment record)."
+            )
+            return (
+                _to_exp_table(rows),
+                gr.update(visible=n > 0),
+                gr.update(visible=n > 0),
+                gr.update(value=msg, visible=True),
+            )
+
+        def _selected_exp_dirs(table: Any) -> list[Path]:
+            """Experiment dirs whose checkbox is ticked in the current table value."""
+            records = table.values.tolist() if hasattr(table, "values") else (table or [])
+            return [state.results_dir / row[1] for row in records if row and bool(row[0])]
+
+        def _run_submitter(script: str, exp_dir: Path, extra: list[str]) -> tuple[bool, str]:
+            """Invoke a submit script for one experiment; return (ok, last-output-line)."""
+            cmd = [sys.executable, str(Path(__file__).resolve().parents[3] / "scripts" / script), str(exp_dir), *extra]
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            tail = (proc.stdout.strip().splitlines() or [""])[-1]
+            return proc.returncode == 0, tail
+
+        def on_submit(table: Any, destination: str) -> tuple[list[list[Any]], Any]:
+            """Submit the checked experiments to EEE or the cube-registry journal."""
+            dirs = _selected_exp_dirs(table)
+            if not dirs:
+                return _exp_table_value(), gr.update(value="Nothing selected to submit.", visible=True)
+            if destination == "eee":
+                script, extra = "submit_to_eee.py", []
+            else:
+                script, extra = "submit_to_journal.py", ["--auto-pr", "--i-understand-this-is-not-a-leaderboard"]
+            lines = [f"### Submit → {destination.upper()} ({len(dirs)} experiment(s))"]
+            for d in dirs:
+                ok, tail = _run_submitter(script, d, extra)
+                lines.append(f"- {'✅' if ok else '❌'} `{d.name}` — {tail or ('done' if ok else 'failed')}")
+            return _exp_table_value(), gr.update(value="\n".join(lines), visible=True)
 
         def on_browse_dir() -> tuple[list[list[Any]], str]:
             """Open a native folder picker; on choice, switch the results dir and
@@ -1405,6 +1494,17 @@ def run_xray(
         exp_table.change(fn=on_experiments_change, inputs=exp_table, outputs=_hierarchy_outputs)
         exp_browse_btn.click(fn=on_browse_dir, outputs=[exp_table, results_dir_md])
         exp_refresh_btn.click(fn=_exp_table_value, outputs=exp_table)
+        exp_gc_btn.click(fn=on_garbage_collect, outputs=exp_table)
+        exp_checksubmit_btn.click(
+            fn=on_check_submit,
+            outputs=[exp_table, exp_submit_eee_btn, exp_submit_registry_btn, exp_action_status],
+        )
+        exp_submit_eee_btn.click(
+            fn=lambda t: on_submit(t, "eee"), inputs=exp_table, outputs=[exp_table, exp_action_status]
+        )
+        exp_submit_registry_btn.click(
+            fn=lambda t: on_submit(t, "journal"), inputs=exp_table, outputs=[exp_table, exp_action_status]
+        )
         exp_archive_btn.click(fn=on_archive_selected, outputs=[exp_table, *_hierarchy_outputs])
 
         bg_timer.tick(

--- a/src/cube_harness/analyze/xray_events.py
+++ b/src/cube_harness/analyze/xray_events.py
@@ -249,6 +249,17 @@ class EpisodeEvents:
         pos = roots.index(self._root_of[i])
         return roots[max(pos - 1, 0)]
 
+    def first_group_root(self) -> int:
+        """Root of the first *step* — the group right after the initial-observation
+        group (group_roots()[0] is the task-reset observation). Falls back to the
+        very first group when the reset is the only group."""
+        roots = self.group_roots()
+        return roots[1] if len(roots) > 1 else roots[0]
+
+    def last_group_root(self) -> int:
+        """Root of the last group (the end of the episode)."""
+        return self.group_roots()[-1]
+
     # --- parent-link pairing ----------------------------------------------
 
     def parent_index(self, i: int) -> int | None:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -625,6 +625,16 @@ def eligibility_badge(exp_dir: Path, category: str, ran: int | None = None, tota
     return _ELIGIBILITY_BADGES.get(category, f"<span>{html_lib.escape(category)}</span>")
 
 
+def is_archivable(exp_dir: Path, category: str) -> bool:
+    """True for runs not worth keeping / not submittable, so the Archive
+    auto-select ticks them: a broken or incomplete (partial/debug) scan, or a run
+    already recorded as rejected (e.g. an all-ghost run decided broken earlier)."""
+    if category in ("broken", "incomplete"):
+        return True
+    subs = submissions.read(exp_dir)
+    return any(subs.get(d, {}).get("status") == "rejected" for d in ("journal", "eee"))
+
+
 def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
     """Compute display fields for one experiment by reading per-episode status.json files.
 

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -147,9 +147,6 @@ _STATUS_HTML: dict[str, str] = {
     "failed": "<span title='Failed — worker crashed'>⛔</span>",
     "stale": "<span title='Stale — heartbeat lost, dead worker'>👻</span>",
     "cancelled": "<span title='Cancelled'>🚫</span>",
-    # Declared-but-never-run tasks (experiment ran a subset of its declared
-    # benchmark — a partial / early-stopped run; this is why it reads unfinished).
-    "missing": "<span title='No status file — task in the declared subset never ran'>○</span>",
     # Legacy heuristic (no status.json — pre-PR#315 experiments)
     "system_error": "<span title='System error — crashed (legacy inferred status)' style='color:#dc3545;font-weight:bold;font-size:14px'>✕</span>",
 }
@@ -186,7 +183,7 @@ def _build_status_cell(statuses: list[str]) -> str:
         if s not in TERMINAL_OUTCOME_STATUSES:
             counts[s] = counts.get(s, 0) + 1
 
-    order = ["running", "queued", "stale", "cancelled", "failed", "system_error", "missing"]
+    order = ["running", "queued", "stale", "cancelled", "failed", "system_error"]
     parts = []
     if n_terminal:
         parts.append(f"{n_terminal}{_COMPLETED_AGGREGATE_HTML}")
@@ -485,8 +482,8 @@ def _parse_experiment_config(exp_dir: Path) -> dict[str, str]:
 GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runner's kill threshold
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
 # Bump when the cached row schema/semantics change so stale caches recompute.
-# v2: added `_category` (eligibility) + count declared-but-unrun tasks in `status`.
-_EXP_ROW_VERSION = 2
+# v3: added _category (eligibility) + _ran/_total for the incomplete badge.
+_EXP_ROW_VERSION = 3
 
 
 def _promote_ghost_episodes(exp_dir: Path) -> None:
@@ -605,11 +602,12 @@ def scan_category(exp_dir: Path, *, sweep_stale: bool = False) -> str:
         return "broken"
 
 
-def eligibility_badge(exp_dir: Path, category: str) -> str:
+def eligibility_badge(exp_dir: Path, category: str, ran: int | None = None, total: int | None = None) -> str:
     """Badge for the eligibility column. The persisted submission state (read
     fresh, cheap) takes precedence over the cached scan `category`: a successful
     submission shows ✅; a recorded rejection shows 🚫 rejected (with its reason),
-    so a previously-rejected/broken run is never mistaken for a success."""
+    so a previously-rejected/broken run is never mistaken for a success.
+    `incomplete` is annotated with ran/declared task counts (e.g. 🧪 3/500 incomplete)."""
     subs = submissions.read(exp_dir)
     submitted = [d for d in ("journal", "eee") if subs.get(d, {}).get("status") == "submitted"]
     if submitted:
@@ -619,6 +617,11 @@ def eligibility_badge(exp_dir: Path, category: str) -> str:
     if rejected is not None:
         reason = html_lib.escape(rejected.get("reason", "previously rejected"))
         return f"<span title='{reason}'>🚫 rejected</span>"
+    if category == "incomplete" and ran is not None and total:
+        return (
+            f"<span title='Ran only {ran} of {total} declared tasks — partial / debug subset, not submittable'>"
+            f"🧪 {ran}/{total} incomplete</span>"
+        )
     return _ELIGIBILITY_BADGES.get(category, f"<span>{html_lib.escape(category)}</span>")
 
 
@@ -643,9 +646,6 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
             for raw, n in result.status_counts.items()
             for display in [_RAW_STATUS_MAP.get(raw, "system_error")] * n
         ]
-        # Surface declared-but-never-run tasks so a partial run reads as e.g.
-        # "3✅ + 497○ / 500" instead of a finished-looking "3✅ / 3".
-        statuses.extend(["missing"] * max(0, result.n_missing))
         rewards = list(result.rewards)
     else:
         statuses, rewards = _read_display_statuses(exp_dir)
@@ -664,6 +664,9 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
         # Cached scan category (stable for terminal runs); the displayed badge is
         # derived fresh in get_experiments_table_rows so submissions stay current.
         "_category": result.category.value,
+        # Ran/declared task counts — used to annotate the incomplete badge (3/500).
+        "_ran": result.n_terminal,
+        "_total": result.n_tasks,
         "_v": _EXP_ROW_VERSION,
     }
 
@@ -753,7 +756,9 @@ def get_experiments_table_rows(results_dir: Path) -> list[dict[str, Any]]:
             row = {"selected": False, "experiment": dir_path.name, **summary}
         # Derive the eligibility badge fresh (submissions.json is cheap and can
         # change after a submit without invalidating the mtime-based cache).
-        row["eligibility"] = eligibility_badge(dir_path, row.get("_category", "broken"))
+        row["eligibility"] = eligibility_badge(
+            dir_path, row.get("_category", "broken"), row.get("_ran"), row.get("_total")
+        )
         rows.append(row)
     rows.sort(key=lambda r: r["date"], reverse=True)
     return rows

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -146,7 +146,7 @@ _STATUS_HTML: dict[str, str] = {
     "max_steps": "<span title='Max steps reached — step budget exhausted'>🎬</span>",
     "failed": "<span title='Failed — worker crashed'>⛔</span>",
     "stale": "<span title='Stale — heartbeat lost, dead worker'>👻</span>",
-    "cancelled": "<span title='Cancelled'>🚫</span>",
+    "cancelled": "<span title='Cancelled — deliberately stopped'>⏹️</span>",
     # Legacy heuristic (no status.json — pre-PR#315 experiments)
     "system_error": "<span title='System error — crashed (legacy inferred status)' style='color:#dc3545;font-weight:bold;font-size:14px'>✕</span>",
 }
@@ -160,7 +160,7 @@ _STATUS_LABEL: dict[str, str] = {
     "max_steps": "🎬 Max steps reached",
     "failed": "⛔ Failed",
     "stale": "👻 Stale",
-    "cancelled": "🚫 Cancelled",
+    "cancelled": "⏹️ Cancelled",
     "system_error": "✕ System error (legacy)",
 }
 
@@ -562,7 +562,13 @@ def _is_cache_valid(exp_dir: Path, cache_mtime: float) -> bool:
     - Episode relaunched: runner archives old dir and creates new one → episodes/ mtime.
     - Status.json written: EpisodeStatus.write() creates a .tmp sibling first, which
       updates the episode dir mtime via the tmp-file creation step.
+    - A submission/rejection recorded: submissions.json lives at the experiment
+      root (outside episodes/), so stat it too — otherwise the cached scan
+      `_category` would keep saying "submittable" after a successful submit.
     """
+    subs_path = exp_dir / submissions.SUBMISSIONS_FILENAME
+    if subs_path.exists() and subs_path.stat().st_mtime > cache_mtime:
+        return False
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
         return True
@@ -585,8 +591,12 @@ _ELIGIBILITY_BADGES: dict[str, str] = {
     "subset_review": "<span title='Passed integrity checks but the subset shape needs a human look'>🔍 review</span>",
     "unfinished": "<span title='Episodes still queued/running — state may change'>⏳ unfinished</span>",
     "incomplete": "<span title='Finished, but ran only a subset of the declared benchmark (partial / debug slice) — not submittable'>🧪 incomplete</span>",
-    "broken": "<span title='Cannot produce a meaningful score'>🚫 broken</span>",
-    "already_submitted": "<span title='Has a prior submission/rejection decision'>✅ decided</span>",
+    "broken": "<span title='Cannot produce a meaningful score'>💥 broken</span>",
+    # Neutral fallback only: a real journal decision is always resolved to ✅
+    # submitted or 🚫 rejected by eligibility_badge's fresh submissions read, so
+    # this never renders in practice — keep it neutral (not a green ✅) so a
+    # stray decided-but-unresolved state can't be mistaken for a success.
+    "already_submitted": "<span title='Has a prior submission decision' style='color:#888'>• decided</span>",
 }
 
 
@@ -617,6 +627,12 @@ def eligibility_badge(exp_dir: Path, category: str, ran: int | None = None, tota
     if rejected is not None:
         reason = html_lib.escape(rejected.get("reason", "previously rejected"))
         return f"<span title='{reason}'>🚫 rejected</span>"
+    if any(subs.get(d, {}).get("status") == "pending" for d in ("journal", "eee")):
+        return "<span title='Submission in progress'>📤 submitting…</span>"
+    failed = next((subs[d] for d in ("journal", "eee") if subs.get(d, {}).get("status") == "failed"), None)
+    if failed is not None:
+        reason = html_lib.escape(failed.get("reason", "submission failed"))
+        return f"<span title='Last submit attempt failed (retryable): {reason}'>❌ submit failed</span>"
     if category == "incomplete" and ran is not None and total:
         return (
             f"<span title='Ran only {ran} of {total} declared tasks — partial / debug subset, not submittable'>"
@@ -633,6 +649,33 @@ def is_archivable(exp_dir: Path, category: str) -> bool:
         return True
     subs = submissions.read(exp_dir)
     return any(subs.get(d, {}).get("status") == "rejected" for d in ("journal", "eee"))
+
+
+def is_submittable_pick(exp_dir: Path, category: str) -> bool:
+    """True for the Submit auto-select: a submittable run that has NOT already
+    been submitted and is NOT mid-submission. Reads submissions.json *fresh* so a
+    run submitted earlier in this session is never re-ticked — the cached scan
+    `category` can lag a submit (submissions.json lives outside episodes/)."""
+    if category != "submittable":
+        return False
+    subs = submissions.read(exp_dir)
+    return not any(subs.get(d, {}).get("status") in ("submitted", "pending") for d in ("journal", "eee"))
+
+
+def persist_broken_rejection(exp_dir: Path) -> bool:
+    """If *exp_dir* classifies as broken and has no prior journal decision, stamp
+    a rejection into submissions.json (mirrors ``scan_experiments.py
+    --persist-broken``). Called on archive so a broken run's verdict is durable
+    and travels with the dir into ``_archive/``. Returns True when newly written."""
+    try:
+        result = scan.classify(exp_dir, sweep_stale=False)
+    except Exception:  # pragma: no cover - defensive
+        return False
+    if result.category is not scan.ScanCategory.broken or submissions.has_decision(exp_dir, "journal"):
+        return False
+    reason = result.reasons[0] if result.reasons else "broken (archived from XRay)"
+    submissions.record_rejected(exp_dir, "journal", reason=f"broken: {reason}")
+    return True
 
 
 def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -483,7 +483,19 @@ GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runne
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
 # Bump when the cached row schema/semantics change so stale caches recompute.
 # v3: added _category (eligibility) + _ran/_total for the incomplete badge.
-_EXP_ROW_VERSION = 3
+# v4: added _subs_mtime so the cache invalidates when submissions.json is
+#     written, updated, OR deleted (a submit, or a rollback that clears it).
+_EXP_ROW_VERSION = 4
+
+
+def _subs_mtime(exp_dir: Path) -> float:
+    """mtime of submissions.json, or 0.0 when absent. Stored on the cached row so
+    it invalidates whenever the submission state changes — including deletion
+    (absent → 0.0 ≠ the stored mtime), which an mtime-vs-cache check would miss."""
+    try:
+        return (exp_dir / submissions.SUBMISSIONS_FILENAME).stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def _promote_ghost_episodes(exp_dir: Path) -> None:
@@ -562,13 +574,11 @@ def _is_cache_valid(exp_dir: Path, cache_mtime: float) -> bool:
     - Episode relaunched: runner archives old dir and creates new one → episodes/ mtime.
     - Status.json written: EpisodeStatus.write() creates a .tmp sibling first, which
       updates the episode dir mtime via the tmp-file creation step.
-    - A submission/rejection recorded: submissions.json lives at the experiment
-      root (outside episodes/), so stat it too — otherwise the cached scan
-      `_category` would keep saying "submittable" after a successful submit.
+
+    Does NOT cover submissions.json (it lives outside episodes/ and can be
+    *deleted*, which an mtime-vs-cache comparison misses) — that's handled
+    separately in get_experiments_table_rows via the cached `_subs_mtime`.
     """
-    subs_path = exp_dir / submissions.SUBMISSIONS_FILENAME
-    if subs_path.exists() and subs_path.stat().st_mtime > cache_mtime:
-        return False
     episodes_dir = exp_dir / "episodes"
     if not episodes_dir.exists():
         return True
@@ -720,6 +730,9 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
         # Ran/declared task counts — used to annotate the incomplete badge (3/500).
         "_ran": result.n_terminal,
         "_total": result.n_tasks,
+        # Submission state at compute time, so the cache invalidates on a later
+        # submit / rollback (see _subs_mtime).
+        "_subs_mtime": _subs_mtime(exp_dir),
         "_v": _EXP_ROW_VERSION,
     }
 
@@ -792,7 +805,10 @@ def get_experiments_table_rows(results_dir: Path) -> list[dict[str, Any]]:
                 if _is_cache_valid(dir_path, cache_mtime):
                     with open(cache_path) as f:
                         cached = json.load(f)
-                    if cached.get("_v") == _EXP_ROW_VERSION:
+                    # Valid only if the schema matches AND the submission state is
+                    # unchanged since the cache was written (a submit or a rollback
+                    # that deletes submissions.json must force a reclassify).
+                    if cached.get("_v") == _EXP_ROW_VERSION and cached.get("_subs_mtime") == _subs_mtime(dir_path):
                         row = {"selected": False, "experiment": dir_path.name, **cached}
             except Exception as exc:
                 logger.debug("Cache read failed for %s: %s", cache_path, exc)

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -599,13 +599,19 @@ def scan_category(exp_dir: Path, *, sweep_stale: bool = False) -> str:
 
 
 def eligibility_badge(exp_dir: Path, category: str) -> str:
-    """Badge for the eligibility column: a ✅ submission state (read fresh, cheap)
-    takes precedence over the cached scan `category`."""
+    """Badge for the eligibility column. The persisted submission state (read
+    fresh, cheap) takes precedence over the cached scan `category`: a successful
+    submission shows ✅; a recorded rejection shows 🚫 rejected (with its reason),
+    so a previously-rejected/broken run is never mistaken for a success."""
     subs = submissions.read(exp_dir)
     submitted = [d for d in ("journal", "eee") if subs.get(d, {}).get("status") == "submitted"]
     if submitted:
         names = " + ".join({"journal": "registry", "eee": "eee"}[d] for d in submitted)
         return f"<span title='Submitted to {names}'>✅ {names}</span>"
+    rejected = next((subs[d] for d in ("journal", "eee") if subs.get(d, {}).get("status") == "rejected"), None)
+    if rejected is not None:
+        reason = html_lib.escape(rejected.get("reason", "previously rejected"))
+        return f"<span title='{reason}'>🚫 rejected</span>"
     return _ELIGIBILITY_BADGES.get(category, f"<span>{html_lib.escape(category)}</span>")
 
 

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -586,7 +586,8 @@ def _is_cache_valid(exp_dir: Path, cache_mtime: float) -> bool:
 _ELIGIBILITY_BADGES: dict[str, str] = {
     "submittable": "<span title='Clean run — ready to submit'>🟢 submittable</span>",
     "subset_review": "<span title='Passed integrity checks but the subset shape needs a human look'>🔍 review</span>",
-    "unfinished": "<span title='Some episodes are still queued/running (or stale)'>⏳ unfinished</span>",
+    "unfinished": "<span title='Episodes still queued/running — state may change'>⏳ unfinished</span>",
+    "incomplete": "<span title='Finished, but ran only a subset of the declared benchmark (partial / debug slice) — not submittable'>🧪 incomplete</span>",
     "broken": "<span title='Cannot produce a meaningful score'>🚫 broken</span>",
     "already_submitted": "<span title='Has a prior submission/rejection decision'>✅ decided</span>",
 }

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -647,12 +647,16 @@ def eligibility_badge(exp_dir: Path, category: str) -> str:
 
 
 def is_archivable(exp_dir: Path, category: str, is_official: bool | None = None) -> bool:
-    """True for runs not worth keeping, so the Archive auto-select ticks them:
-    a broken scan, a run already recorded as rejected (e.g. an all-ghost run),
-    or one the operator explicitly marked debug (``is_official is False``).
+    """True for runs the Archive auto-select should tick: a broken scan, a run
+    recorded as rejected (e.g. an all-ghost run), or one explicitly marked debug
+    (``is_official is False``).
 
-    A bare ``subset_review`` is *not* archived — it may be a legit subset awaiting
-    a `--yes` submission; only an explicit ``is_official=False`` flags it as junk."""
+    ``is_official is True`` is an absolute keep — the operator vouched for / pinned
+    the run (e.g. a reference submission), so it is *never* auto-archived, even if
+    broken or rejected. A bare ``subset_review`` is also kept (it may be a legit
+    subset awaiting a `--yes` submission)."""
+    if is_official is True:
+        return False
     if category == "broken" or is_official is False:
         return True
     subs = submissions.read(exp_dir)

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -147,6 +147,9 @@ _STATUS_HTML: dict[str, str] = {
     "failed": "<span title='Failed — worker crashed'>⛔</span>",
     "stale": "<span title='Stale — heartbeat lost, dead worker'>👻</span>",
     "cancelled": "<span title='Cancelled'>🚫</span>",
+    # Declared-but-never-run tasks (experiment ran a subset of its declared
+    # benchmark — a partial / early-stopped run; this is why it reads unfinished).
+    "missing": "<span title='No status file — task in the declared subset never ran'>○</span>",
     # Legacy heuristic (no status.json — pre-PR#315 experiments)
     "system_error": "<span title='System error — crashed (legacy inferred status)' style='color:#dc3545;font-weight:bold;font-size:14px'>✕</span>",
 }
@@ -183,7 +186,7 @@ def _build_status_cell(statuses: list[str]) -> str:
         if s not in TERMINAL_OUTCOME_STATUSES:
             counts[s] = counts.get(s, 0) + 1
 
-    order = ["running", "queued", "stale", "cancelled", "failed", "system_error"]
+    order = ["running", "queued", "stale", "cancelled", "failed", "system_error", "missing"]
     parts = []
     if n_terminal:
         parts.append(f"{n_terminal}{_COMPLETED_AGGREGATE_HTML}")
@@ -481,6 +484,9 @@ def _parse_experiment_config(exp_dir: Path) -> dict[str, str]:
 
 GHOST_TIMEOUT = DEFAULT_STEP_TIMEOUT_S + DEFAULT_CANCEL_GRACE_S  # mirrors runner's kill threshold
 _XRAY_CACHE_FILENAME = ".xray_summary.json"
+# Bump when the cached row schema/semantics change so stale caches recompute.
+# v2: added `_category` (eligibility) + count declared-but-unrun tasks in `status`.
+_EXP_ROW_VERSION = 2
 
 
 def _promote_ghost_episodes(exp_dir: Path) -> None:
@@ -636,6 +642,9 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
             for raw, n in result.status_counts.items()
             for display in [_RAW_STATUS_MAP.get(raw, "system_error")] * n
         ]
+        # Surface declared-but-never-run tasks so a partial run reads as e.g.
+        # "3✅ + 497○ / 500" instead of a finished-looking "3✅ / 3".
+        statuses.extend(["missing"] * max(0, result.n_missing))
         rewards = list(result.rewards)
     else:
         statuses, rewards = _read_display_statuses(exp_dir)
@@ -654,6 +663,7 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
         # Cached scan category (stable for terminal runs); the displayed badge is
         # derived fresh in get_experiments_table_rows so submissions stay current.
         "_category": result.category.value,
+        "_v": _EXP_ROW_VERSION,
     }
 
 
@@ -721,12 +731,11 @@ def get_experiments_table_rows(results_dir: Path) -> list[dict[str, Any]]:
         if cache_path.exists():
             try:
                 cache_mtime = cache_path.stat().st_mtime
-                # Old caches predate `_category`; treat them as stale so the
-                # eligibility column backfills (and the cache is rewritten).
+                # Older-schema caches are treated as stale (recompute + rewrite).
                 if _is_cache_valid(dir_path, cache_mtime):
                     with open(cache_path) as f:
                         cached = json.load(f)
-                    if "_category" in cached:
+                    if cached.get("_v") == _EXP_ROW_VERSION:
                         row = {"selected": False, "experiment": dir_path.name, **cached}
             except Exception as exc:
                 logger.debug("Cache read failed for %s: %s", cache_path, exc)

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -617,9 +617,46 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
     Returns: {date, agent, model, benchmark, status, avg_reward}.
     """
     cfg_info = _parse_experiment_config(exp_dir)
+
+    # Single source of truth: one classification pass reads the per-episode
+    # statuses AND yields the eligibility category. For record-bearing runs it
+    # also returns the status breakdown + rewards, so we don't re-read the status
+    # files here. Record-less / V1 layouts (which the scanner can't classify) fall
+    # back to a direct read.
+    result = scan.classify(exp_dir, sweep_stale=False)
+    if result.status_counts:
+        statuses = [
+            display
+            for raw, n in result.status_counts.items()
+            for display in [_RAW_STATUS_MAP.get(raw, "system_error")] * n
+        ]
+        rewards = list(result.rewards)
+    else:
+        statuses, rewards = _read_display_statuses(exp_dir)
+
+    status_html = _build_status_cell(statuses) if statuses else "—"
+    mean, stderr = _reward_mean_stderr(rewards)
+    avg_reward_str = f"{mean:.3f} ± {stderr:.3f}" if rewards else "—"
+
+    return {
+        "date": _parse_exp_date(exp_dir),
+        "agent": cfg_info["agent"],
+        "model": cfg_info["model"],
+        "benchmark": cfg_info["benchmark"],
+        "status": status_html,
+        "avg_reward": avg_reward_str,
+        # Cached scan category (stable for terminal runs); the displayed badge is
+        # derived fresh in get_experiments_table_rows so submissions stay current.
+        "_category": result.category.value,
+    }
+
+
+def _read_display_statuses(exp_dir: Path) -> tuple[list[str], list[float]]:
+    """Fallback per-episode read for layouts the scanner can't classify
+    (record-less V2, or V1 flat ``*.metadata.json``). Returns
+    ``(display_statuses, rewards)``."""
     statuses: list[str] = []
     rewards: list[float] = []
-
     episodes_dir = exp_dir / "episodes"
     if episodes_dir.exists():
         for ep_dir in episodes_dir.iterdir():
@@ -635,7 +672,6 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
             else:
                 statuses.append("queued")
     else:
-        # V1: read flat *.metadata.json for status and reward
         for search_dir in (exp_dir, exp_dir / "trajectories"):
             if not search_dir.exists():
                 continue
@@ -656,22 +692,7 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
                 except Exception as exc:
                     logger.debug("Failed to parse %s: %s", meta_file, exc)
                     statuses.append("system_error")
-
-    status_html = _build_status_cell(statuses) if statuses else "—"
-    mean, stderr = _reward_mean_stderr(rewards)
-    avg_reward_str = f"{mean:.3f} ± {stderr:.3f}" if rewards else "—"
-
-    return {
-        "date": _parse_exp_date(exp_dir),
-        "agent": cfg_info["agent"],
-        "model": cfg_info["model"],
-        "benchmark": cfg_info["benchmark"],
-        "status": status_html,
-        "avg_reward": avg_reward_str,
-        # Cached scan category (stable for terminal runs); the displayed badge is
-        # derived fresh in get_experiments_table_rows so submissions stay current.
-        "_category": scan_category(exp_dir),
-    }
+    return statuses, rewards
 
 
 def get_experiments_table_rows(results_dir: Path) -> list[dict[str, Any]]:

--- a/src/cube_harness/analyze/xray_utils.py
+++ b/src/cube_harness/analyze/xray_utils.py
@@ -39,6 +39,7 @@ from cube_harness.episode_status import TERMINAL_STATUSES as _EPISODE_TERMINAL_S
 from cube_harness.exp_runner import DEFAULT_CANCEL_GRACE_S, DEFAULT_STEP_TIMEOUT_S
 from cube_harness.experiment_status import EXPERIMENT_STATUS_FILENAME, ExperimentStatus, is_driver_alive
 from cube_harness.llm import LLMCall
+from cube_harness.reproducibility import scan, submissions
 
 logger = logging.getLogger(__name__)
 
@@ -571,6 +572,43 @@ def _is_cache_valid(exp_dir: Path, cache_mtime: float) -> bool:
     return True
 
 
+# --- Submission eligibility (clean + submit) -------------------------------
+# Compact badges for the Experiments-table "eligibility" column. The raw
+# category (stored on the hidden `_category` key) drives the Garbage-collect /
+# Check-submit auto-selection.
+
+_ELIGIBILITY_BADGES: dict[str, str] = {
+    "submittable": "<span title='Clean run — ready to submit'>🟢 submittable</span>",
+    "subset_review": "<span title='Passed integrity checks but the subset shape needs a human look'>🔍 review</span>",
+    "unfinished": "<span title='Some episodes are still queued/running (or stale)'>⏳ unfinished</span>",
+    "broken": "<span title='Cannot produce a meaningful score'>🚫 broken</span>",
+    "already_submitted": "<span title='Has a prior submission/rejection decision'>✅ decided</span>",
+}
+
+
+def scan_category(exp_dir: Path, *, sweep_stale: bool = False) -> str:
+    """The `ScanCategory` value for one experiment (``"broken"`` on any error).
+
+    The expensive part (reads `experiment_record.json` + per-episode statuses),
+    so it's cached on the row's hidden `_category` key. `sweep_stale=True` lets a
+    cleanup pass reclassify dead RUNNING/QUEUED episodes as broken first."""
+    try:
+        return scan.classify(exp_dir, sweep_stale=sweep_stale).category.value
+    except Exception:  # pragma: no cover - defensive
+        return "broken"
+
+
+def eligibility_badge(exp_dir: Path, category: str) -> str:
+    """Badge for the eligibility column: a ✅ submission state (read fresh, cheap)
+    takes precedence over the cached scan `category`."""
+    subs = submissions.read(exp_dir)
+    submitted = [d for d in ("journal", "eee") if subs.get(d, {}).get("status") == "submitted"]
+    if submitted:
+        names = " + ".join({"journal": "registry", "eee": "eee"}[d] for d in submitted)
+        return f"<span title='Submitted to {names}'>✅ {names}</span>"
+    return _ELIGIBILITY_BADGES.get(category, f"<span>{html_lib.escape(category)}</span>")
+
+
 def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
     """Compute display fields for one experiment by reading per-episode status.json files.
 
@@ -630,6 +668,9 @@ def _compute_exp_row(exp_dir: Path) -> dict[str, Any]:
         "benchmark": cfg_info["benchmark"],
         "status": status_html,
         "avg_reward": avg_reward_str,
+        # Cached scan category (stable for terminal runs); the displayed badge is
+        # derived fresh in get_experiments_table_rows so submissions stay current.
+        "_category": scan_category(exp_dir),
     }
 
 
@@ -649,26 +690,34 @@ def get_experiments_table_rows(results_dir: Path) -> list[dict[str, Any]]:
         if not _is_experiment_dir(dir_path):
             continue
         cache_path = dir_path / _XRAY_CACHE_FILENAME
+        row: dict[str, Any] | None = None
         if cache_path.exists():
             try:
                 cache_mtime = cache_path.stat().st_mtime
+                # Old caches predate `_category`; treat them as stale so the
+                # eligibility column backfills (and the cache is rewritten).
                 if _is_cache_valid(dir_path, cache_mtime):
                     with open(cache_path) as f:
                         cached = json.load(f)
-                    rows.append({"selected": False, "experiment": dir_path.name, **cached})
-                    continue
+                    if "_category" in cached:
+                        row = {"selected": False, "experiment": dir_path.name, **cached}
             except Exception as exc:
                 logger.debug("Cache read failed for %s: %s", cache_path, exc)
-        _promote_ghost_episodes(dir_path)
-        summary = _compute_exp_row(dir_path)
-        if _all_episodes_terminal(dir_path):
-            try:
-                tmp = cache_path.parent / (cache_path.name + ".tmp")
-                tmp.write_text(json.dumps(summary, indent=2))
-                os.replace(tmp, cache_path)
-            except Exception as exc:
-                logger.debug("Cache write failed for %s: %s", cache_path, exc)
-        rows.append({"selected": False, "experiment": dir_path.name, **summary})
+        if row is None:
+            _promote_ghost_episodes(dir_path)
+            summary = _compute_exp_row(dir_path)
+            if _all_episodes_terminal(dir_path):
+                try:
+                    tmp = cache_path.parent / (cache_path.name + ".tmp")
+                    tmp.write_text(json.dumps(summary, indent=2))
+                    os.replace(tmp, cache_path)
+                except Exception as exc:
+                    logger.debug("Cache write failed for %s: %s", cache_path, exc)
+            row = {"selected": False, "experiment": dir_path.name, **summary}
+        # Derive the eligibility badge fresh (submissions.json is cheap and can
+        # change after a submit without invalidating the mtime-based cache).
+        row["eligibility"] = eligibility_badge(dir_path, row.get("_category", "broken"))
+        rows.append(row)
     rows.sort(key=lambda r: r["date"], reverse=True)
     return rows
 

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -94,7 +94,8 @@ def archive_experiment_dir(experiment_dir: Path) -> Path:
 class ScanCategory(str, Enum):
     already_submitted = "already_submitted"
     broken = "broken"
-    unfinished = "unfinished"
+    unfinished = "unfinished"  # episodes still QUEUED/RUNNING — state may change
+    incomplete = "incomplete"  # finished, but ran only a subset of the declared benchmark
     subset_review = "subset_review"
     submittable = "submittable"
 
@@ -271,12 +272,16 @@ def classify(
             ),
         )
 
-    # ── Missing tasks ⇒ unfinished (could resume) ───────────────────────
+    # ── Missing tasks, nothing in flight ⇒ incomplete ───────────────────
+    # A finished run that covered only a subset of the declared benchmark
+    # (selected via glob / task-list / early stop). Distinct from `unfinished`
+    # (still running): this won't progress on its own, and it isn't submittable
+    # as the full benchmark — it's typically a debug / partial slice.
     if n_missing > 0:
         return ScanResult(
             **base,
-            category=ScanCategory.unfinished,
-            reasons=(f"{n_missing}/{n_tasks} task(s) have no status file — experiment may have stopped early",),
+            category=ScanCategory.incomplete,
+            reasons=(f"{n_terminal}/{n_tasks} declared task(s) ran — partial subset, not the full benchmark",),
         )
 
     # ── Subset-shape gate: more restrictive than the original sketch ─────

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
@@ -122,6 +122,12 @@ class ScanResult:
     benchmark_subset_name: str = ""
     benchmark_subset_filter: str | None = None
     has_explicit_task_list: bool = False
+    # Raw per-episode signal collected during the single status pass, so display
+    # consumers (XRay's experiment table) don't have to re-read the status files.
+    # `status_counts` maps raw EpisodeStatus.status → count; `rewards` are the
+    # scored episode rewards (COMPLETED / MAX_STEPS_REACHED).
+    status_counts: dict[str, int] = field(default_factory=dict)
+    rewards: tuple[float, ...] = ()
 
 
 def _load_experiment_record(experiment_dir: Path) -> ExperimentRecord | None:
@@ -197,15 +203,20 @@ def classify(
     n_in_flight = 0
     n_system_error = 0
     seen_task_ids: set[str] = set()
+    status_counts: dict[str, int] = {}
+    rewards: list[float] = []
     try:
         for status in ExperimentResult(experiment_dir).iter_episode_statuses():
             seen_task_ids.add(status.task_id)
+            status_counts[status.status] = status_counts.get(status.status, 0) + 1
             if status.status in IN_FLIGHT_STATUSES:
                 n_in_flight += 1
                 continue
             n_terminal += 1
             if status.status in {"FAILED", "STALE", "INVALID_CONFIG"}:
                 n_system_error += 1
+            elif status.status in {"COMPLETED", "MAX_STEPS_REACHED"} and status.reward is not None:
+                rewards.append(float(status.reward))
     except Exception as e:
         return ScanResult(
             experiment_dir,
@@ -225,6 +236,8 @@ def classify(
         n_system_error=n_system_error,
         n_missing=n_missing,
         debug_limit=debug_limit,
+        status_counts=status_counts,
+        rewards=tuple(rewards),
         benchmark_subset_name=bench_subset.name,
         benchmark_subset_filter=bench_subset.filter,
         has_explicit_task_list=has_explicit_task_list,

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -50,15 +50,6 @@ than about the model — the run is marked BROKEN. 10% is intentionally tight
 ("be restrictive about what gets pushed"). Tunable per scan invocation.
 """
 
-STALE_ABANDONED_FRACTION = 0.5
-"""Fraction of STALE (dead-worker) episodes above which a run is abandoned.
-
-A run this full of stale episodes won't recover — the driver/workers died.
-We mark it BROKEN even when a few episodes still read as in-flight (so it is
-archivable instead of stuck forever in ``unfinished``); the live stragglers
-can't revive a half-dead run.
-"""
-
 
 def sweep_stale_in_dir(experiment_dir: Path) -> list[str]:
     """Mark dead RUNNING/QUEUED episodes as STALE in *experiment_dir*.
@@ -253,23 +244,12 @@ def classify(
         has_explicit_task_list=has_explicit_task_list,
     )
 
-    # ── A stale-dominated run is abandoned, not running ─────────────────
-    # Checked before the in-flight gate: a high stale fraction means the
-    # driver/workers died, so the run is broken (archivable) even if a few
-    # episodes still read as in-flight — those stragglers won't revive it.
-    n_episodes = n_terminal + n_in_flight
-    n_stale = status_counts.get("STALE", 0)
-    if n_in_flight > 0 and n_episodes and n_stale / n_episodes >= STALE_ABANDONED_FRACTION:
-        return ScanResult(
-            **base,
-            category=ScanCategory.broken,
-            reasons=(
-                f"{n_stale}/{n_episodes} episodes stale "
-                f"({n_stale / n_episodes * 100:.0f}%) — run abandoned (dead workers)",
-            ),
-        )
-
     # ── In-flight episodes mean the experiment is still running ──────────
+    # "In-flight" is determined per-episode after the heartbeat sweep: a dead
+    # worker/driver leaves STALE (terminal) episodes, so a truly abandoned run
+    # reaches zero in-flight and falls through to the broken/err-rate rules
+    # below. A run that still has a *live* episode heartbeat stays unfinished —
+    # even in ray mode where workers can outlive a crashed driver.
     if n_in_flight > 0:
         return ScanResult(
             **base,

--- a/src/cube_harness/reproducibility/scan.py
+++ b/src/cube_harness/reproducibility/scan.py
@@ -50,6 +50,15 @@ than about the model — the run is marked BROKEN. 10% is intentionally tight
 ("be restrictive about what gets pushed"). Tunable per scan invocation.
 """
 
+STALE_ABANDONED_FRACTION = 0.5
+"""Fraction of STALE (dead-worker) episodes above which a run is abandoned.
+
+A run this full of stale episodes won't recover — the driver/workers died.
+We mark it BROKEN even when a few episodes still read as in-flight (so it is
+archivable instead of stuck forever in ``unfinished``); the live stragglers
+can't revive a half-dead run.
+"""
+
 
 def sweep_stale_in_dir(experiment_dir: Path) -> list[str]:
     """Mark dead RUNNING/QUEUED episodes as STALE in *experiment_dir*.
@@ -243,6 +252,22 @@ def classify(
         benchmark_subset_filter=bench_subset.filter,
         has_explicit_task_list=has_explicit_task_list,
     )
+
+    # ── A stale-dominated run is abandoned, not running ─────────────────
+    # Checked before the in-flight gate: a high stale fraction means the
+    # driver/workers died, so the run is broken (archivable) even if a few
+    # episodes still read as in-flight — those stragglers won't revive it.
+    n_episodes = n_terminal + n_in_flight
+    n_stale = status_counts.get("STALE", 0)
+    if n_in_flight > 0 and n_episodes and n_stale / n_episodes >= STALE_ABANDONED_FRACTION:
+        return ScanResult(
+            **base,
+            category=ScanCategory.broken,
+            reasons=(
+                f"{n_stale}/{n_episodes} episodes stale "
+                f"({n_stale / n_episodes * 100:.0f}%) — run abandoned (dead workers)",
+            ),
+        )
 
     # ── In-flight episodes mean the experiment is still running ──────────
     if n_in_flight > 0:

--- a/src/cube_harness/reproducibility/submissions.py
+++ b/src/cube_harness/reproducibility/submissions.py
@@ -39,9 +39,16 @@ Or for a broken experiment:
       }
     }
 
-The scan script treats both ``"status": "submitted"`` and
-``"status": "rejected"`` as "do not consider for re-submission." Only the
-absence of a destination key triggers a fresh eligibility check.
+Status values:
+  • ``submitted`` / ``rejected`` — permanent *decisions*. ``has_decision`` is
+    True; the scan script treats both as "do not consider for re-submission."
+  • ``pending`` — a submit attempt is in progress (transient). Not a decision;
+    the auto-selector skips it but a retry is still allowed.
+  • ``failed`` — the last submit attempt failed (transient, *retryable*, unlike
+    ``rejected``). The run stays submittable; the note is preserved for the UI.
+
+Only the absence of a destination key — or a ``pending`` / ``failed`` entry —
+triggers a fresh eligibility check / allows a (re)submission.
 """
 
 from __future__ import annotations
@@ -122,6 +129,34 @@ def record_submitted(
     if local_path:
         entry["local_path"] = local_path
     payload[destination] = entry
+    _write_atomic(_path(experiment_dir), payload)
+
+
+def record_pending(experiment_dir: Path, destination: SubmissionDestination) -> None:
+    """Mark a submission to *destination* as in-progress.
+
+    Written at the start of a submit attempt and overwritten by
+    :func:`record_submitted` (success) or :func:`record_failed` (failure) once it
+    resolves. Lets the UI show "submitting…" and keeps the auto-selector from
+    re-picking a run whose submission is already underway. Not a permanent
+    decision — :func:`has_decision` ignores it, so a crashed/abandoned pending
+    entry never blocks a later retry.
+    """
+    payload = read(experiment_dir)
+    payload[destination] = {"status": "pending", "started_at": _now_iso()}
+    _write_atomic(_path(experiment_dir), payload)
+
+
+def record_failed(experiment_dir: Path, destination: SubmissionDestination, *, reason: str) -> None:
+    """Record a FAILED submission attempt for *destination* with its *reason*.
+
+    Distinct from :func:`record_rejected`: a failure is *retryable* (a flaky PR
+    push, a transient network error), so :func:`has_decision` ignores it and the
+    run stays submittable. The note persists so the row shows "submit failed"
+    instead of silently reverting to a plain submittable badge.
+    """
+    payload = read(experiment_dir)
+    payload[destination] = {"status": "failed", "reason": reason, "failed_at": _now_iso()}
     _write_atomic(_path(experiment_dir), payload)
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -165,14 +165,17 @@ class TestClassifierUnfinished:
         assert result.category is ScanCategory.unfinished
         assert "QUEUED/RUNNING" in result.reasons[0]
 
-    def test_missing_status_files_is_unfinished(self, tmp_path: Path) -> None:
+    def test_missing_status_files_is_incomplete(self, tmp_path: Path) -> None:
+        # A finished run covering only a subset of the declared benchmark is
+        # `incomplete` (a partial/debug slice), distinct from `unfinished`
+        # (still running).
         exp_dir = tmp_path / "partial"
         _populate_clean_run(exp_dir, n_tasks=5, n_success=3)
         # Bump n_tasks to 10 — 5 tasks have no status file at all.
         _set_subset_field(exp_dir, n_tasks=10)
         result = classify(exp_dir)
-        assert result.category is ScanCategory.unfinished
-        assert "have no status file" in result.reasons[0]
+        assert result.category is ScanCategory.incomplete
+        assert "partial subset" in result.reasons[0]
 
 
 class TestClassifierSubsetReview:

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -53,6 +53,25 @@ class TestSubmissions:
         second = submissions.read(tmp_path)["journal"]["decided_at"]
         assert first == second
 
+    def test_pending_is_not_a_decision(self, tmp_path: Path) -> None:
+        submissions.record_pending(tmp_path, "journal")
+        assert submissions.read(tmp_path)["journal"]["status"] == "pending"
+        # Transient — must not block a later (re)submission.
+        assert not submissions.has_decision(tmp_path, "journal")
+
+    def test_failed_is_not_a_decision(self, tmp_path: Path) -> None:
+        submissions.record_failed(tmp_path, "journal", reason="push timed out")
+        entry = submissions.read(tmp_path)["journal"]
+        assert entry["status"] == "failed" and entry["reason"] == "push timed out"
+        # Retryable, unlike rejected — stays eligible.
+        assert not submissions.has_decision(tmp_path, "journal")
+
+    def test_submitted_overwrites_pending(self, tmp_path: Path) -> None:
+        submissions.record_pending(tmp_path, "journal")
+        submissions.record_submitted(tmp_path, "journal", evaluation_id="j/1", schema_version="1.0")
+        assert submissions.has_decision(tmp_path, "journal")
+        assert submissions.read(tmp_path)["journal"]["status"] == "submitted"
+
     def test_journal_and_eee_coexist(self, tmp_path: Path) -> None:
         submissions.record_submitted(
             tmp_path,
@@ -178,33 +197,36 @@ class TestClassifierUnfinished:
         assert "partial subset" in result.reasons[0]
 
 
-class TestClassifierAbandoned:
-    """A stale-dominated run is broken (archivable) even with a live straggler.
+class TestClassifierLiveStragglerStaysUnfinished:
+    """A run with a *live* in-flight episode stays unfinished even if heavily
+    stale — the per-episode heartbeat is the liveness signal, and in ray mode a
+    worker can outlive a crashed driver. (We deliberately do NOT auto-archive on
+    stale fraction.) Once the sweep promotes the straggler, err-rate marks it
+    broken; see test_high_system_error_rate_is_broken."""
 
-    Mirrors the XRay path: ghost promotion has already written STALE into the
-    dead episodes, and classify runs read-only (sweep_stale=False)."""
+    def test_stale_heavy_run_with_in_flight_is_unfinished(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "running_straggler"
+        _populate_clean_run(exp_dir, n_tasks=4, n_success=4)
+        _set_subset_field(exp_dir, n_tasks=4)
+        # 3 STALE + 1 RUNNING → 75% stale, but the RUNNING episode is still live.
+        _add_status(exp_dir, "t0", "STALE")
+        _add_status(exp_dir, "t1", "STALE")
+        _add_status(exp_dir, "t2", "STALE")
+        _add_status(exp_dir, "t3", "RUNNING")
+        result = classify(exp_dir, sweep_stale=False)
+        assert result.category is ScanCategory.unfinished
 
-    def test_stale_dominated_run_is_broken_despite_in_flight(self, tmp_path: Path) -> None:
+    def test_stale_heavy_run_no_in_flight_is_broken(self, tmp_path: Path) -> None:
+        # Same run once the straggler is swept/finished: no in-flight, stale
+        # dominates → broken (archivable) via the system-error rate.
         exp_dir = tmp_path / "abandoned"
         _populate_clean_run(exp_dir, n_tasks=4, n_success=4)
         _set_subset_field(exp_dir, n_tasks=4)
-        # 2 STALE (dead workers) + 1 RUNNING + 1 COMPLETED → 2/4 = 50% stale.
         _add_status(exp_dir, "t0", "STALE")
         _add_status(exp_dir, "t1", "STALE")
-        _add_status(exp_dir, "t2", "RUNNING")
+        _add_status(exp_dir, "t2", "STALE")  # 3/4 = 75% stale, nothing in-flight
         result = classify(exp_dir, sweep_stale=False)
         assert result.category is ScanCategory.broken
-        assert "abandoned" in result.reasons[0]
-
-    def test_few_stale_with_in_flight_stays_unfinished(self, tmp_path: Path) -> None:
-        exp_dir = tmp_path / "mostly_running"
-        _populate_clean_run(exp_dir, n_tasks=4, n_success=4)
-        _set_subset_field(exp_dir, n_tasks=4)
-        # 1 STALE + 1 RUNNING + 2 COMPLETED → 1/4 = 25% stale (< 50%).
-        _add_status(exp_dir, "t0", "STALE")
-        _add_status(exp_dir, "t1", "RUNNING")
-        result = classify(exp_dir, sweep_stale=False)
-        assert result.category is ScanCategory.unfinished
 
 
 class TestClassifierSubsetReview:

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -178,6 +178,35 @@ class TestClassifierUnfinished:
         assert "partial subset" in result.reasons[0]
 
 
+class TestClassifierAbandoned:
+    """A stale-dominated run is broken (archivable) even with a live straggler.
+
+    Mirrors the XRay path: ghost promotion has already written STALE into the
+    dead episodes, and classify runs read-only (sweep_stale=False)."""
+
+    def test_stale_dominated_run_is_broken_despite_in_flight(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "abandoned"
+        _populate_clean_run(exp_dir, n_tasks=4, n_success=4)
+        _set_subset_field(exp_dir, n_tasks=4)
+        # 2 STALE (dead workers) + 1 RUNNING + 1 COMPLETED → 2/4 = 50% stale.
+        _add_status(exp_dir, "t0", "STALE")
+        _add_status(exp_dir, "t1", "STALE")
+        _add_status(exp_dir, "t2", "RUNNING")
+        result = classify(exp_dir, sweep_stale=False)
+        assert result.category is ScanCategory.broken
+        assert "abandoned" in result.reasons[0]
+
+    def test_few_stale_with_in_flight_stays_unfinished(self, tmp_path: Path) -> None:
+        exp_dir = tmp_path / "mostly_running"
+        _populate_clean_run(exp_dir, n_tasks=4, n_success=4)
+        _set_subset_field(exp_dir, n_tasks=4)
+        # 1 STALE + 1 RUNNING + 2 COMPLETED → 1/4 = 25% stale (< 50%).
+        _add_status(exp_dir, "t0", "STALE")
+        _add_status(exp_dir, "t1", "RUNNING")
+        result = classify(exp_dir, sweep_stale=False)
+        assert result.category is ScanCategory.unfinished
+
+
 class TestClassifierSubsetReview:
     def test_debug_limit_flagged(self, tmp_path: Path) -> None:
         exp_dir = tmp_path / "debug"

--- a/tests/test_xray_events.py
+++ b/tests/test_xray_events.py
@@ -146,6 +146,23 @@ def test_group_navigation_moves_one_step_per_press() -> None:
     assert ep.prev_group_root(0) == 0  # first group, clamped
 
 
+def test_first_and_last_group_root() -> None:
+    # groups: {0:reset}, {1:llm,2:obs}, {3:llm,4:obs,5:terminal-eval}.
+    ep = _gym_stream()
+    assert ep.group_roots() == [0, 1, 3]
+    # "First step" skips the initial-observation group (root 0) → first real step.
+    assert ep.first_group_root() == 1
+    # "End" → the last group's root.
+    assert ep.last_group_root() == 3
+
+
+def test_first_group_root_falls_back_when_only_reset() -> None:
+    ep = xe.EpisodeEvents([_tool("obs0", xe.RESET_PARENT)])
+    assert ep.group_roots() == [0]
+    assert ep.first_group_root() == 0  # nothing after the reset → clamp to it
+    assert ep.last_group_root() == 0
+
+
 def test_terminal_eval_attaches_to_last_group() -> None:
     # No parent link on the terminal eval -> it joins the most recent group.
     ep = xe.EpisodeEvents([_llm("llm1"), _tool("obs1", "llm1"), _eval(1.0, terminal=True)])

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -814,3 +814,28 @@ def test_rejected_state_shows_rejected_badge(tmp_path: Path) -> None:
     submissions.record_rejected(tmp_path, "journal", reason="broken: 58/279 episodes errored")
     badge = xray_utils.eligibility_badge(tmp_path, "already_submitted")
     assert "🚫 rejected" in badge and "58/279" in badge
+
+
+class TestIsArchivable:
+    """Archive auto-select: broken + incomplete + rejected, but not submittable/submitted."""
+
+    def test_broken_and_incomplete_are_archivable(self, tmp_path: Path) -> None:
+        assert xray_utils.is_archivable(tmp_path, "broken")
+        assert xray_utils.is_archivable(tmp_path, "incomplete")
+
+    def test_submittable_and_subset_review_are_not(self, tmp_path: Path) -> None:
+        assert not xray_utils.is_archivable(tmp_path, "submittable")
+        assert not xray_utils.is_archivable(tmp_path, "subset_review")
+
+    def test_rejected_run_is_archivable(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_rejected(tmp_path, "journal", reason="broken: all episodes ghost")
+        # category is already_submitted (a journal decision exists) — but it's a rejection.
+        assert xray_utils.is_archivable(tmp_path, "already_submitted")
+
+    def test_successfully_submitted_run_is_not_archivable(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_submitted(tmp_path, "journal", evaluation_id="a", schema_version="1.0")
+        assert not xray_utils.is_archivable(tmp_path, "already_submitted")

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -639,7 +639,7 @@ class TestBuildStatusCell:
 
     def test_cancelled_symbol(self) -> None:
         cell = xray_utils._build_status_cell(["cancelled"])
-        assert "🚫" in cell
+        assert "⏹️" in cell
 
 
 # ---------------------------------------------------------------------------
@@ -839,3 +839,69 @@ class TestIsArchivable:
 
         submissions.record_submitted(tmp_path, "journal", evaluation_id="a", schema_version="1.0")
         assert not xray_utils.is_archivable(tmp_path, "already_submitted")
+
+
+class TestIsSubmittablePick:
+    """Submit auto-select: submittable AND not already submitted / mid-submission."""
+
+    def test_clean_submittable_is_picked(self, tmp_path: Path) -> None:
+        assert xray_utils.is_submittable_pick(tmp_path, "submittable")
+
+    def test_non_submittable_category_is_not(self, tmp_path: Path) -> None:
+        assert not xray_utils.is_submittable_pick(tmp_path, "broken")
+        assert not xray_utils.is_submittable_pick(tmp_path, "subset_review")
+
+    def test_already_submitted_is_not_re_picked(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_submitted(tmp_path, "journal", evaluation_id="a", schema_version="1.0")
+        # Even if the cached category still says submittable, a submitted run is skipped.
+        assert not xray_utils.is_submittable_pick(tmp_path, "submittable")
+
+    def test_pending_is_not_re_picked(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_pending(tmp_path, "journal")
+        assert not xray_utils.is_submittable_pick(tmp_path, "submittable")
+
+    def test_failed_is_still_picked_for_retry(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_failed(tmp_path, "journal", reason="transient")
+        assert xray_utils.is_submittable_pick(tmp_path, "submittable")
+
+
+class TestSubmissionBadges:
+    def test_pending_badge(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_pending(tmp_path, "journal")
+        assert "submitting" in xray_utils.eligibility_badge(tmp_path, "submittable")
+
+    def test_failed_badge_shows_reason(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_failed(tmp_path, "journal", reason="push timed out")
+        badge = xray_utils.eligibility_badge(tmp_path, "submittable")
+        assert "submit failed" in badge and "push timed out" in badge
+
+
+class TestPersistBrokenRejection:
+    def test_broken_dir_gets_durable_rejection(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        exp = tmp_path / "broken_run"
+        exp.mkdir()  # no experiment_record.json → classifies broken
+        assert xray_utils.persist_broken_rejection(exp) is True
+        assert submissions.read(exp)["journal"]["status"] == "rejected"
+        # Idempotent: a second call sees the prior decision and does nothing new.
+        assert xray_utils.persist_broken_rejection(exp) is False
+
+    def test_decided_dir_is_left_alone(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        exp = tmp_path / "submitted_run"
+        exp.mkdir()
+        submissions.record_submitted(exp, "journal", evaluation_id="a", schema_version="1.0")
+        assert xray_utils.persist_broken_rejection(exp) is False
+        assert submissions.read(exp)["journal"]["status"] == "submitted"

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -175,6 +175,28 @@ class TestGetExperimentsTableRows:
         os.utime(ep_dir, (future, future))
         assert not xray_utils._is_cache_valid(tmp_path / "exp_e", cache.stat().st_mtime)
 
+    def test_cache_invalidated_when_submission_recorded_then_cleared(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        now = time.time()
+        exp = tmp_path / "exp_subs"
+        ep_dir = exp / "episodes" / "ep0"
+        ep_dir.mkdir(parents=True)
+        (ep_dir / "status.json").write_text(
+            json.dumps({"status": "COMPLETED", "task_id": "t0", "episode_id": 0, "started_at": now, "ended_at": now})
+        )
+        # No experiment_record.json → classifies broken; that's fine, we only care
+        # that _category tracks the submission state across cache reads.
+        cat = lambda: xray_utils.get_experiments_table_rows(tmp_path)[0]["_category"]  # noqa: E731
+        assert cat() == "broken"
+        # Record a submission: a journal decision short-circuits classify.
+        submissions.record_submitted(exp, "journal", evaluation_id="a", schema_version="1.0")
+        assert cat() == "already_submitted"  # cache must NOT serve the stale 'broken'
+        # Roll back: deleting submissions.json must invalidate the cache too
+        # (the bug — an mtime-vs-cache check misses deletion).
+        (exp / submissions.SUBMISSIONS_FILENAME).unlink()
+        assert cat() == "broken"
+
     def test_ghost_episode_promoted_to_stale(self, tmp_path: Path) -> None:
         old_ts = time.time() - xray_utils.GHOST_TIMEOUT - 100
         ep_dir = tmp_path / "exp_f" / "episodes" / "ep0"

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -776,3 +776,33 @@ class TestPickDirectory:
 
         monkeypatch.setattr(xray_utils.subprocess, "run", lambda *a, **k: _R())
         assert xray_utils.pick_directory(tmp_path) is None
+
+
+class TestEligibility:
+    """Submission-eligibility badge logic (clean + submit)."""
+
+    def test_scan_category_missing_dir_is_broken(self, tmp_path: Path) -> None:
+        # No experiment_record.json → classify returns broken; helper never raises.
+        assert xray_utils.scan_category(tmp_path / "nope") == "broken"
+
+    def test_badge_uses_category_when_no_submission(self, tmp_path: Path) -> None:
+        badge = xray_utils.eligibility_badge(tmp_path, "submittable")
+        assert "submittable" in badge
+        assert xray_utils.eligibility_badge(tmp_path, "broken").count("broken")
+
+    def test_submitted_state_overrides_category(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_submitted(
+            tmp_path, "journal", evaluation_id="me/exp", schema_version="1.0", pr_url="http://x"
+        )
+        badge = xray_utils.eligibility_badge(tmp_path, "broken")  # category ignored once submitted
+        assert "✅" in badge and "registry" in badge
+
+    def test_eee_and_registry_both_submitted(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        submissions.record_submitted(tmp_path, "journal", evaluation_id="a", schema_version="1.0")
+        submissions.record_submitted(tmp_path, "eee", evaluation_id="b", schema_version="0.2")
+        badge = xray_utils.eligibility_badge(tmp_path, "submittable")
+        assert "registry" in badge and "eee" in badge

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -806,3 +806,11 @@ class TestEligibility:
         submissions.record_submitted(tmp_path, "eee", evaluation_id="b", schema_version="0.2")
         badge = xray_utils.eligibility_badge(tmp_path, "submittable")
         assert "registry" in badge and "eee" in badge
+
+
+def test_rejected_state_shows_rejected_badge(tmp_path: Path) -> None:
+    from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+    submissions.record_rejected(tmp_path, "journal", reason="broken: 58/279 episodes errored")
+    badge = xray_utils.eligibility_badge(tmp_path, "already_submitted")
+    assert "🚫 rejected" in badge and "58/279" in badge

--- a/tests/test_xray_utils.py
+++ b/tests/test_xray_utils.py
@@ -862,6 +862,14 @@ class TestIsArchivable:
         # category is already_submitted (a journal decision exists) — but it's a rejection.
         assert xray_utils.is_archivable(tmp_path, "already_submitted")
 
+    def test_official_is_an_absolute_keep(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility import submissions  # noqa: PLC0415
+
+        # is_official=True pins the run — never archived, even broken or rejected.
+        assert not xray_utils.is_archivable(tmp_path, "broken", is_official=True)
+        submissions.record_rejected(tmp_path, "journal", reason="broken: errors")
+        assert not xray_utils.is_archivable(tmp_path, "already_submitted", is_official=True)
+
     def test_successfully_submitted_run_is_not_archivable(self, tmp_path: Path) -> None:
         from cube_harness.reproducibility import submissions  # noqa: PLC0415
 


### PR DESCRIPTION
## XRay clean + submit

Adds experiment **cleanup + reproducibility-journal submission** to the XRay
Experiments table, all backed by the consolidated `reproducibility.scan.classify`
— the same classifier `scripts/scan_experiments.py` uses, so the UI and CLI never
disagree.

Depends-on: cube-standard/dev

### Eligibility + badges
- New **eligibility** column (`xray_utils.eligibility_badge`): the scan category
  (`submittable` / `subset_review` / `unfinished` / `broken` / `already_submitted`)
  with a *fresh* `submissions.json` overlay that always wins — ✅ submitted, 🚫
  rejected, 📤 submitting, ❌ submit-failed.
- Glyphs disambiguated (broken 💥, cancelled-episode ⏹️, rejected 🚫) and the
  unreachable green "decided" neutralised.

### Archive 🤖✓
- `is_archivable` ticks non-keepers: `broken`, a recorded rejection, or an explicit
  debug run (`is_official is False`).
- **`is_official is True` is an absolute keep** — a pinned reference run is never
  auto-archived, even if broken/rejected. A bare `subset_review` is kept too.

### Submit 🤖✓ → Registry / EEE
- Two destination buttons (cube-registry journal vs EEE), sharing one
  `is_submittable_pick` auto-select (submittable, not already submitted/in-flight).
- **Submission lifecycle** (`reproducibility.submissions`): absent → `pending`
  (on submit) → `submitted` | `failed`; `rejected` is permanent. `pending`/`failed`
  are transient/retryable. Failures persist with their reason instead of vanishing.
- Fixed `submit_to_journal.py`'s `--auto-pr` for the current `gh` CLI (dropped
  `--clone-flags=`; `gh pr create` needs an explicit `--head <fork>:<branch>` when
  `--repo` is set). Verified end-to-end against the live registry, then rolled back.

### Step navigation
- Jump-to-first / jump-to-last buttons (⤒ ⤓) flanking prev/next, with
  Shift+↑/↓ and Home/End shortcuts; first = the group after the initial observation.

### Reconciliation with #491 (named subsets + `is_official`)
- #491 fixed the root cause our interim `incomplete` category worked around
  (subset runs now record `n_tasks` from the selected view). **Dropped `incomplete`**
  end-to-end; adopted dev's `n_missing>0 ⇒ unfinished` + `is_official` model.

### Caching / correctness
- Per-experiment `.xray_summary.json` cache invalidated by episode-dir mtime **and**
  `submissions.json` mtime (so a submit or a rollback that clears it reclassifies);
  the badge is always recomputed fresh.
- After a submit, the table re-selects the first experiment so it stays in sync.

### Spec + tests
- `openspec/specs/analyze/spec.md`: new clean+submit section; invariant #1 widened
  to acknowledge the viewer's scoped writes (archive moves + `submissions.json`),
  none of which touch trajectory data.
- Full `tests/` suite green (977 passed) against cube-standard `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
