### PR TITLE
chore(analyze): remove the unused Global Report tab + dead aggregation code

### DIFF
--- a/src/cube_harness/analyze/inspect_results.py
+++ b/src/cube_harness/analyze/inspect_results.py
@@ -1,4 +1,3 @@
-import fnmatch
 import re
 from typing import Any
 
@@ -6,7 +5,6 @@ import numpy as np
 import pandas as pd
 from cube.core import EnvironmentOutput
 
-from cube_harness.analyze.stats import binomial_std_err
 from cube_harness.core import Trajectory
 
 TASK_KEY = "task_name"
@@ -84,127 +82,6 @@ def get_constants_and_variables(df: pd.DataFrame, drop_constants: bool = False) 
         else:
             variable_keys.append(col)
     return constants, variable_keys, df
-
-
-def _benchmark_from_task_name(task_name: str) -> str:
-    return task_name.split(".")[0]
-
-
-def set_index_from_variables(
-    df: pd.DataFrame,
-    index_white_list: tuple[str, ...] = ("agent*",),
-    index_black_list: tuple[str, ...] = ("*model_url*", "*extra*", "*._*", "trajectory_id", "err_msg", "stack_trace"),
-    task_key: str = TASK_KEY,
-) -> None:
-    df.reset_index(inplace=True)
-    _, variables, _ = get_constants_and_variables(df)
-
-    index_variables: list[str] = []
-
-    if "benchmark" not in df.columns and task_key in df.columns:
-        df["benchmark"] = df[task_key].map(_benchmark_from_task_name)
-
-    for var in variables:
-        white = any(fnmatch.fnmatch(var, pattern) for pattern in index_white_list)
-        black = any(fnmatch.fnmatch(var, pattern) for pattern in index_black_list)
-        if white and not black and var not in index_variables:
-            index_variables.append(var)
-
-    for var in index_variables:
-        if df[var].isnull().any():
-            df[var] = df[var].fillna("None")
-
-    if task_key in df.columns:
-        df.set_index([task_key] + index_variables, inplace=True)
-    elif index_variables:
-        df.set_index(index_variables, inplace=True)
-    df.sort_index(inplace=True)
-
-
-def get_std_err(df: pd.DataFrame, metric: str) -> tuple[float, float]:
-    data = df[metric].dropna().values
-    if np.all(np.isin(data, [0, 1])):
-        mean = float(np.mean(data))
-        return mean, binomial_std_err(mean, len(data))
-    return get_sample_std_err(df, metric)
-
-
-def get_sample_std_err(df: pd.DataFrame, metric: str) -> tuple[float, float]:
-    data = df[metric].dropna().values
-    mean = np.mean(data)
-    std_err = np.std(data, ddof=1) / np.sqrt(len(data))
-    if np.isnan(std_err):
-        std_err = np.float64(0)
-    return float(mean), float(std_err)
-
-
-def summarize(sub_df: pd.DataFrame) -> pd.Series | None:
-    if "cum_reward" not in sub_df:
-        return pd.Series(
-            {
-                "avg_reward": np.nan,
-                "std_err": np.nan,
-                "avg_steps": np.nan,
-                "n_completed": f"0/{len(sub_df)}",
-                "n_err": 0,
-            }
-        )
-
-    err = sub_df["err_msg"].notnull()
-    n_completed = err.copy()
-    if "done" in sub_df:
-        n_completed = n_completed | sub_df["done"]
-    n_completed_count = n_completed.sum()
-
-    if n_completed_count == 0:
-        return None
-
-    _mean_reward, std_reward = get_std_err(sub_df, "cum_reward")
-
-    record: dict[str, Any] = {
-        "avg_reward": sub_df["cum_reward"].mean(skipna=True).round(3),
-        "std_err": round(std_reward, 3),
-        "avg_steps": sub_df["n_steps"].mean(skipna=True).round(3),
-        "n_completed": f"{n_completed_count}/{len(sub_df)}",
-        "n_err": err.sum(skipna=True),
-    }
-    if "cost" in sub_df:
-        record["cum_cost"] = sub_df["cost"].sum(skipna=True).round(4)
-    return pd.Series(record)
-
-
-def reduce_episodes(result_df: pd.DataFrame) -> pd.DataFrame:
-    levels = list(range(result_df.index.nlevels))
-    return result_df.groupby(level=levels).apply(summarize)
-
-
-def report_2d(df: pd.DataFrame, reduce_fn=summarize, n_row_keys: int = 1) -> pd.DataFrame:
-    levels = list(range(df.index.nlevels))
-    reduced_df = df.groupby(level=levels).apply(reduce_fn)
-    return reduced_df.unstack(level=levels[n_row_keys:])
-
-
-def global_report(
-    result_df: pd.DataFrame,
-    reduce_fn=summarize,
-    rename_index=None,
-) -> pd.DataFrame:
-    levels = list(range(result_df.index.nlevels))
-
-    if len(levels) == 1:
-        report = report_2d(result_df, reduce_fn=reduce_fn)
-        row = reduce_fn(result_df)
-        if row is not None:
-            report.loc["[ALL TASKS]"] = row
-    else:
-        report = result_df.groupby(level=levels[1:]).apply(reduce_fn)
-        if rename_index is not None:
-            index_names = [rename_index(name) for name in report.index.names]
-            report = report.rename_axis(index=index_names)
-        if "avg_reward" in report.columns:
-            report = report.sort_values("avg_reward", ascending=False)
-
-    return report
 
 
 def map_err_key(err_msg: str | None) -> str | None:
@@ -312,15 +189,3 @@ def format_agent_comparison(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFram
     ]
     var_df = pd.DataFrame(var_records) if var_records else pd.DataFrame(columns=["parameter"])
     return const_df, var_df
-
-
-def load_and_analyze(
-    trajectories: list[Trajectory],
-    index_white_list: tuple[str, ...] = ("agent*",),
-    index_black_list: tuple[str, ...] = ("*model_url*", "*extra*", "*._*", "trajectory_id", "err_msg", "stack_trace"),
-) -> pd.DataFrame | None:
-    df = trajectories_to_df(trajectories)
-    if df is None:
-        return None
-    set_index_from_variables(df, index_white_list=index_white_list, index_black_list=index_black_list)
-    return df

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1231,19 +1231,6 @@ def run_xray(
             return pd.DataFrame(columns=["parameter", "value"]), pd.DataFrame(columns=["parameter"])
         return inspect_results.format_agent_comparison(df)
 
-    def _render_global_report() -> list[list]:
-        if not state.trajectories:
-            return []
-        df = inspect_results.trajectories_to_df(state.trajectories)
-        if df is None:
-            return []
-        inspect_results.set_index_from_variables(df)
-        report = inspect_results.global_report(df)
-        report = report.reset_index()
-        for col in report.columns:
-            report[col] = report[col].astype(str)
-        return report.values.tolist()
-
     def _render_error_report() -> str:
         if not state.trajectories:
             return "No trajectories loaded."
@@ -1425,12 +1412,6 @@ def run_xray(
                             show_label=False,
                             interactive=False,
                         )
-            with gr.Tab("Global Report") as report_tab:
-                report_table = gr.DataFrame(
-                    max_height=400,
-                    show_label=False,
-                    interactive=False,
-                )
             with gr.Tab("Error Report") as err_report_tab:
                 err_report_md = gr.Markdown()
 
@@ -1778,7 +1759,6 @@ def run_xray(
         debug_tab.select(fn=_render_debug, outputs=debug_code)
 
         cv_tab.select(fn=_render_constants_variables, outputs=[cv_const_table, cv_var_table])
-        report_tab.select(fn=_render_global_report, outputs=report_table)
         err_report_tab.select(fn=_render_error_report, outputs=err_report_md)
 
         def _auto_load_first_experiment() -> tuple:

--- a/tests/test_inspect_results.py
+++ b/tests/test_inspect_results.py
@@ -10,10 +10,6 @@ from cube_harness.analyze.inspect_results import (
     error_report,
     format_agent_comparison,
     get_constants_and_variables,
-    global_report,
-    load_and_analyze,
-    set_index_from_variables,
-    summarize,
     trajectories_to_df,
 )
 from cube_harness.core import (
@@ -142,48 +138,6 @@ class TestGetConstantsAndVariables:
         assert "agent_name" not in filtered.columns
 
 
-class TestSetIndexFromVariables:
-    def test_task_name_in_index(self, single_agent_trajectories):
-        df = trajectories_to_df(single_agent_trajectories)
-        set_index_from_variables(df)
-        assert "task_name" in df.index.names
-
-    def test_sorted(self, single_agent_trajectories):
-        df = trajectories_to_df(single_agent_trajectories)
-        set_index_from_variables(df)
-        assert df.index.is_monotonic_increasing
-
-
-class TestSummarize:
-    def test_basic_summary(self, single_agent_trajectories):
-        df = trajectories_to_df(single_agent_trajectories)
-        result = summarize(df)
-        assert result is not None
-        assert result["avg_reward"] == 0.75
-        assert "4/4" in result["n_completed"]
-
-    def test_returns_none_when_no_completions(self):
-        steps = [TrajectoryStep(output=EnvironmentOutput(obs=Observation.from_text("x"), reward=0.0, done=False))]
-        traj = Trajectory(id="t", steps=steps, metadata={"agent_name": "a", "task_name": "t"})
-        df = trajectories_to_df([traj])
-        result = summarize(df)
-        assert result is None
-
-
-class TestGlobalReport:
-    def test_single_agent_per_task_report(self, single_agent_trajectories):
-        df = load_and_analyze(single_agent_trajectories)
-        report = global_report(df)
-        assert "miniwob.click-test" in report.index
-        assert "miniwob.login" in report.index
-        assert "[ALL TASKS]" in report.index
-
-    def test_multi_agent_has_multiple_rows(self, multi_agent_trajectories):
-        df = load_and_analyze(multi_agent_trajectories, index_white_list=("*",))
-        report = global_report(df)
-        assert len(report) >= 2
-
-
 class TestErrorReport:
     def test_no_errors(self, single_agent_trajectories):
         df = trajectories_to_df(single_agent_trajectories)
@@ -262,13 +216,3 @@ class TestFormatAgentComparison:
         row = var_df[var_df["parameter"] == "llm_config.model_name"].iloc[0]
         assert row["Agent-gpt-4o"] == "gpt-4o"
         assert row["Agent-gpt-4o-mini"] == "gpt-4o-mini"
-
-
-class TestLoadAndAnalyze:
-    def test_returns_indexed_df(self, single_agent_trajectories):
-        df = load_and_analyze(single_agent_trajectories)
-        assert df is not None
-        assert "task_name" in df.index.names
-
-    def test_returns_none_for_empty(self):
-        assert load_and_analyze([]) is None


### PR DESCRIPTION
Depends-on: cube-standard/dev

## Remove the Global Report tab

The XRay **Global Report** tab is AgentLab-era cruft that was never refined for
CUBE. It pivots all loaded trajectories by auto-detected "variable" config
dimensions and reduces each cell to mean reward ± stderr — but it only reads
meaningfully when several structurally-similar experiments are loaded together,
and otherwise renders a degenerate, unlabeled table (`1 2 3 4 5 6 7` headers).
In practice nobody uses it, so this removes it rather than refine it.

### Removed
- **xray.py**: the `Global Report` tab, its `report_table`, the `_render_global_report`
  handler, and the `report_tab.select` wiring.
- **inspect_results.py** (now-dead aggregation chain, no remaining callers):
  `global_report`, `report_2d`, `reduce_episodes`, `summarize`, `get_std_err`,
  `get_sample_std_err`, `set_index_from_variables`, `_benchmark_from_task_name`,
  `load_and_analyze`, plus the orphaned `binomial_std_err` / `fnmatch` imports.
- Their unit tests.

### Kept (verified still used)
- **Constants & Variables** and **Error Report** tabs.
- Shared helpers `trajectories_to_df`, `get_constants_and_variables`, `error_report`,
  `map_err_key`, `agent_configs_to_df`, `format_agent_comparison`.

### Verification
211-line net deletion (no additions). `tests/` green (971 passed), ruff clean,
XRay UI builds and serves with the tab gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
