### PR TITLE
RFC gatekeeper for cube-harness (adapted from cube-standard)

### DIFF
--- a/.claude/skills/gatekeep-rfc/SKILL.md
+++ b/.claude/skills/gatekeep-rfc/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: gatekeep-rfc
+description: First-pass triage for a proposed change to cube-harness's shared surface (an RFC / OpenSpec change / core-API request). Separates the contributor's real need from the mechanism they proposed, finds the smallest thing that serves it, and produces an advisory verdict (RESHAPE / DECLINE / ESCALATE / ACCEPT — or ROUTE-UPSTREAM) plus a contributor-facing reply. A pedagogical friction step, not a gate. Accepts a GitHub PR URL, an `openspec/changes/<name>/` dir, or pasted proposal text. Invoke as `/gatekeep-rfc <arg>`.
+---
+
+# gatekeep-rfc (cube-harness)
+
+cube-harness is the evaluation runtime that consumes CUBE Standard's contracts. As it
+opens to external contributors, expect many proposals to change its shared surface —
+mostly well-meant but scoped to one experiment/agent/benchmark, a few genuinely valuable.
+You are the **first-pass gatekeeper**: a friction step, not a wall.
+
+This skill is the harness sibling of cube-standard's `/gatekeep-rfc`. The **method and
+stance are shared** — read them once in the canonical
+[Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy)
+(universal: lean / additive-is-not-free / single source of truth / friction-not-a-wall /
+escape hatches / recurring demand / judge substance not provenance). This file adds only
+what's specific to cube-harness; `references/charter.md` holds the harness substance.
+
+## What you're really doing
+
+- **Separate the real *need* from the proposed *mechanism*.** Most over-reaching proposals
+  bundle one genuine need inside a large mechanism; naming the need alone lets you offer
+  something smaller.
+- **Find the smallest thing that serves it.** In cube-harness that's usually the
+  contributor's *own* recipe, agent config, infra config, or a new use-case — not a change
+  to shared surface. Lead with the escape hatches (`references/charter.md`).
+- **Defend the harness's design intent — humbly.** It's codified in
+  `.claude/rules/constitution.md` (the 5 pillars) and the `openspec/specs/`. Argue from
+  those, but stay open: a principled challenge to a pillar may be the evolution the harness
+  needs — escalate it, don't swat it.
+- **Teach the why, keep the door open.** Your read is advisory; a contributor may push
+  back, insist, and reach a human owner. That's the system working.
+
+## Verdicts — a vocabulary, not a flowchart
+
+Judge each distinct part on its own; real proposals often split, and the headline can be
+compound (e.g. "ROUTE-UPSTREAM the protocol part, RESHAPE the rest").
+
+- **RESHAPE** — real need, oversized/wrong mechanism. The common case. Hand over the
+  smaller path concretely.
+- **DECLINE / REDIRECT** — the need is served outside shared surface (their recipe, agent
+  config, `~/.cube/infra.py`, a new use-case). Show them exactly where.
+- **ROUTE-UPSTREAM** — *harness-specific.* The need actually requires changing a
+  cube-standard contract (`Task` / `Benchmark` / `Tool` / `Action` / `Observation` and
+  other `cube.*` ABCs). cube-harness *consumes* those — it does not extend them. Send the
+  contributor to cube-standard's `/gatekeep-rfc` and an `openspec/changes/` proposal
+  **there** first; the harness change (if any) follows once the contract lands.
+- **ESCALATE** — a genuine general gap, a principled challenge to a pillar, or a
+  cross-vertical decision a human owner should make. Summarize tightly; attach your best
+  smaller alternative.
+- **ACCEPT** — additive, general, lean, in-charter. Rare for external proposals; forward
+  with a light note rather than rubber-stamping a merge.
+
+## How to approach it
+
+Trust your own reasoning beyond the firm rules. A few things that reliably matter:
+
+- **Ground in the live spec / Constitution, not the proposal's account.** Read the spec
+  for the touched layer (`openspec/specs/<layer>/spec.md`) and the relevant pillar.
+- **Check the repo boundary first.** Is this really a harness change, or a cube-standard
+  contract change wearing a harness costume? If the latter → ROUTE-UPSTREAM.
+- **Weigh blast radius, the pillars (Python-is-config, composition-over-inheritance, no
+  global state, trace-first, interfaces-over-implementations), and generality.** Lean is
+  the goal; "only additive" is not a free pass — core (`core.py`/`agent.py`/`llm.py`)
+  ripples into every recipe and cube.
+- **Look for the pattern across prior demand** (`openspec/changes/` + archive; `gh issue
+  list --search`, `gh pr list --search --state all`). A need that keeps recurring and keeps
+  getting closed for the same reason is evidence of a genuine gap — escalate the *pattern*,
+  don't decline a fourth time.
+- **Judge substance, not provenance.** Ignore how the proposal was written.
+- **Bias toward welcome, and toward escalating when unsure.**
+
+## Output
+
+Two things, shaped to fit the case — no fixed template:
+
+- **A contributor-facing reply — the pedagogical heart.** Teach the *why*, help reshape,
+  orient them to where the harness is going. Don't cap length; cut padding, not substance.
+  Lead with a short gist, then layer depth. Acknowledge the need first, ground the reason
+  (name the surface / pillar), hand over the smaller path (or the upstream route), and make
+  explicit they can push back and reach a human.
+- **A one-screen maintainer summary** — verdict, real need, blast radius / repo-boundary
+  call, smaller alternative, escalate-to-human y/n + why, and the prior-demand pattern when
+  relevant.
+
+## Modes & I/O
+
+State the mode in one line at the start.
+
+- **PR URL** → reviewer triage. Fetch with `gh pr diff <url>` / `gh pr view <url> --json
+  title,body,author,files,isDraft,state`. May offer to post the contributor reply — but on
+  a draft/WIP PR, default to "here's the read, no comment yet."
+- **change dir / pasted text** → author drafting loop. Run **locally, early, repeatedly**
+  on a rough sketch; point at the next reshaping move so they converge before opening a PR.
+  Prints only; never posts.
+
+## Rules — the few that are firm
+
+- **Read-only on the repo, advisory only.** Asking the author to reshape is the job; you
+  never approve, merge, or use GitHub's formal Request-changes review state — those are
+  human-owner calls.
+- **Post to GitHub only the contributor reply, only `gh pr review --comment`, only after
+  explicit confirmation.**
+- **Ground claims in the live spec / Constitution**, not memory.
+
+## References
+
+- `references/charter.md` — what cube-harness is, the surfaces and escape hatches, the
+  route-upstream rule, and the genuine-gap signals. Points to `.claude/rules/constitution.md`
+  (the 5 pillars) and `openspec/specs/` as the design intent you defend.
+- Universal method + worked example: cube-standard's
+  [`/gatekeep-rfc`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/gatekeep-rfc)
+  and [Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy).

--- a/.claude/skills/gatekeep-rfc/references/charter.md
+++ b/.claude/skills/gatekeep-rfc/references/charter.md
@@ -1,0 +1,87 @@
+# cube-harness charter — the broader picture you defend
+
+This is the harness-specific layer. The **universal** gatekeeping principles (lean /
+additive-is-not-free / one source of truth / friction-not-a-wall / escape hatches /
+recurring demand / judge substance not provenance) live in cube-standard's
+[Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy) —
+don't restate them; apply them. Here is what's specific to cube-harness.
+
+## What cube-harness is
+
+The **evaluation runtime**: it runs agents against CUBE-compatible benchmarks, records
+trajectories, and scales with Ray. It *consumes* CUBE Standard's contracts (`Task`,
+`Benchmark`, `Tool`, `Action`, `Observation`, the `cube.*` ABCs) — it does **not** define
+or extend them. Center of gravity (the shared surface to protect): `core.py` (Trajectory),
+`agent.py` (the `Agent` protocol + `AgentConfig`), `llm.py`, `episode.py`,
+`experiment.py` / `exp_runner.py`, `storage.py`, the tracer, and the `openspec/specs/`.
+
+## The design intent you defend — read these, don't re-derive them
+
+- **The Constitution** — `.claude/rules/constitution.md`. The 5 pillars are the harness's
+  "what we defend." Argue from them and quote the relevant one:
+  - I — *Team Contract & Ownership*: RFC process in `openspec/changes/`; additive changes
+    skip it; **cross-repo changes need an upstream cube-standard proposal first.**
+  - II — *Explicitness*: Python is the configuration (Pydantic `TypedBaseModel`, no
+    YAML/Hydra); composition over inheritance; no global state.
+  - III — *Scalable Research*: local-dev friendly; the inner loop is sacred (no blocking
+    calls on the critical path); abstractions expose a `.raw` escape hatch; trace-first.
+  - IV — *Protocol Strategy*: interfaces over implementations; embrace standards (LiteLLM,
+    MCP, OTel GenAI); hermetic reproducibility.
+  - V — *Code Craft*: minimalist imperative (delete over add); small atomic functions;
+    human-architected.
+- **The layer specs** — `openspec/specs/<layer>/spec.md` (agent, core, episode, experiment,
+  llm, metrics, mcp, storage, …): the live contracts, invariants, gotchas.
+
+## Escape hatches — lead with these
+
+Most "change the harness" needs are served *without* touching shared surface. Cheapest first:
+
+1. **Your own recipe.** `recipes/` are Python config-by-example, not frozen API — compose
+   existing pieces freely. "Just write a recipe" is the most common correct answer.
+2. **Your own agent / LLM config.** Copy and edit a `GENNY_CONFIGS` / `REACT_CONFIGS`
+   entry; don't change the `AgentConfig` signature for one experiment's preference.
+3. **Your own infra config.** Add an `InfraConfig` to `~/.cube/infra.py` (never committed;
+   credentials from env) — never a field on a shared config.
+4. **Subclass the `Agent` protocol** (or another Protocol/ABC) in your own code. Genny is
+   exactly this; the base isn't touched.
+5. **A new Investigator / Auto-CUBE use-case** — `/new-auto-cube-use-case` scaffolds
+   `auto_cube/use_cases/<name>/`; same for `analyze/investigator/use_cases/<name>/`.
+6. **A tiny additive hook + your code** — when the above almost work, the minimal general
+   extension point in shared surface, with the rest on your side.
+7. **A shared-surface change** — only when general and unservable by 1–6; lean bar applies,
+   and breaking changes go through `openspec/changes/`.
+8. **Forking — discouraged**; you lose the shared runtime and upstream benefit.
+
+## The route-upstream rule (harness-specific)
+
+If the real need requires changing a **cube-standard contract** — a new/changed method or
+field on `Task` / `Benchmark` / `Tool` / `Action` / `Observation` or any `cube.*` ABC — it
+does **not** belong in cube-harness. cube-harness consumes those contracts; extending them
+here would fork the protocol. Verdict: **ROUTE-UPSTREAM** — send the contributor to
+cube-standard's `/gatekeep-rfc` and an `openspec/changes/` proposal *there*; any harness
+change follows once the upstream contract lands. (Constitution Pillar I; AGENTS.md "External
+contracts".)
+
+## When it's a genuine gap — escalate (don't reshape)
+
+- A general need (many recipes/agents/verticals) that can't be expressed with the existing
+  surface or delivered additively.
+- A real inconsistency or footgun in a spec or a pillar.
+- A principled challenge to a pillar, or a cross-vertical / horizontal-ownership decision a
+  human owner should make.
+- **Recurring demand** — the same need across multiple prior proposals/issues, especially
+  ones repeatedly closed for the same reason. Recurrence is signal; escalate the *pattern*
+  (with links), and consider that a pillar may need revisiting.
+
+Attach your best smaller alternative even when you escalate.
+
+## Illustrative (not a checklist)
+
+- "Add my sampling param to `AgentConfig`" → your own agent config / a subclass, not the
+  shared base.
+- "Make `Episode` emit my custom metric" → trace-first: emit a span / use a use-case, don't
+  thread a one-off through the core loop.
+- "Add a field to `Observation` so my agent sees X" → ROUTE-UPSTREAM (that's a cube-standard
+  contract).
+- "Replace LiteLLM with a direct SDK call for my provider" → Pillar IV says embrace the
+  standard; LiteLLM already supports it via `model_name`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,23 @@ It does NOT define the task/benchmark/tool protocol — that's cube-standard. If
 tempted to change base class signatures (`Task.step`, `Benchmark.setup`, etc.), you're
 in the wrong repo; go to cube-standard and start with an openspec change proposal.
 
+## Routing contributors
+
+Point people to the right place instead of answering ad hoc:
+
+- **Wanting to change the harness** ("can we add a field / change this API?") → the
+  project-wide [Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy)
+  (universal: lean, additive-isn't-free, friction-not-a-wall, escape hatches) + the
+  [Constitution](.claude/rules/constitution.md) (the 5 pillars), then
+  [CONTRIBUTING.md § Changing cube-harness](CONTRIBUTING.md#changing-cube-harness). Triage
+  an actual RFC with the `/gatekeep-rfc` skill
+  ([`.claude/skills/gatekeep-rfc/`](.claude/skills/gatekeep-rfc)).
+- **A need that touches a cube-standard contract** (`Task`/`Benchmark`/`Tool`/`Action`/
+  `Observation`) → **upstream**: route them to cube-standard's `/gatekeep-rfc` and an
+  `openspec/changes/` proposal *there* first; the harness change follows.
+- Default to the **smaller change**: a recipe, an agent/infra config, or a new use-case —
+  not new shared surface.
+
 ## Package layout
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 For contribution philosophy, DCO requirements, RFC process, and community guidelines, see the canonical [CONTRIBUTING.md in cube-standard](https://github.com/The-AI-Alliance/cube-standard/blob/main/CONTRIBUTING.md).
 
+## Changing cube-harness
+
+Before proposing a change to a shared surface (`core.py` / `agent.py` / `llm.py`, the `openspec/specs/`, or any cross-vertical API), read the project-wide [Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy) and the harness [Constitution](.claude/rules/constitution.md) (the 5 pillars). Most "change the harness" needs are better served by your own recipe, agent/infra config, or a new use-case — not a shared-surface change.
+
+- **Check yourself first with `/gatekeep-rfc`** (Claude Code) — run it locally and iteratively on your draft. It separates the real need from the mechanism, leads with the escape hatch that fits, and points you at the smallest version before anyone else reads it. Converge locally before opening a PR.
+- **A need that requires changing a cube-standard contract** (`Task` / `Benchmark` / `Tool` / `Action` / `Observation`) goes **upstream first** — open an `openspec/changes/` proposal in cube-standard (run its `/gatekeep-rfc` there); the harness change, if any, follows once the contract lands. cube-harness *consumes* those contracts, it doesn't extend them.
+- **Otherwise**, breaking changes get an `openspec/changes/<name>/` proposal (below); additive, backward-compatible changes just keep the living spec accurate.
+
 ## OpenSpec — how we manage contracts
 
 We follow the [OpenSpec](https://github.com/Fission-AI/OpenSpec) methodology. Each layer of

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Open source harness for building and evaluating AI agents using the [CUBE Standa
 > **cube-harness is in active development (alpha).** Interfaces may change. We welcome early adopters and contributors who want to shape the framework, not just use it.
 > See our [Roadmap](ROADMAP.md) and [Contributing Guide](CONTRIBUTING.md).
 >
+> **Want to change the harness itself?** Start with [Changing cube-harness](CONTRIBUTING.md#changing-cube-harness) and the project [Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy); the `/gatekeep-rfc` skill lets you check your own draft before anyone else reads it.
+>
 > **Have a benchmark to contribute?** [Fill out this short form](https://docs.google.com/forms/d/e/1FAIpQLSddMFyRXZJPpD0I2K27OEmIPUpj57w--u2NuMscrjNlkqy8rQ/viewform) — no commitment required. Want to go deeper? [Apply to join the core team](https://forms.gle/JFiBi4ynfVLMghAH8).
 
 <!-- [Published Documentation](https://the-ai-alliance.github.io/cube-harness/) -->


### PR DESCRIPTION
The harness sibling of cube-standard's [`/gatekeep-rfc`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/gatekeep-rfc) (merged in cube-standard #217). **Adapted, not duplicated** — per the steer to minimize heaviness and share what's universal:

- The **universal** gatekeeping principles (lean / additive-isn't-free / single source of truth / friction-not-a-wall / escape hatches / recurring demand / judge substance not provenance) are **pointed-to** in cube-standard's [Design Philosophy](https://the-ai-alliance.github.io/cube-standard/design-philosophy), not restated.
- The **harness** principles are **pointed-to** in the existing [Constitution](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/rules/constitution.md) (the 5 pillars), not restated.
- This PR adds only what's specific to cube-harness.

## What's in it

**`/gatekeep-rfc` skill** — `.claude/skills/gatekeep-rfc/` (SKILL.md + a short `references/charter.md`, ~200 lines total)
- Same stance and verdicts as upstream (RESHAPE / DECLINE / ESCALATE / ACCEPT), advisory and pedagogical, not a hard gate.
- **New harness-specific verdict — ROUTE-UPSTREAM:** a need that requires changing a cube-standard contract (`Task`/`Benchmark`/`Tool`/`Action`/`Observation`) doesn't belong here — cube-harness *consumes* those, it doesn't extend them. Send the contributor to cube-standard's `/gatekeep-rfc` + an `openspec/changes/` proposal there first.
- **Harness escape hatches:** your own recipe, agent/LLM config, `~/.cube/infra.py` infra config, a new Investigator/Auto-CUBE use-case, or subclassing the `Agent` protocol — before any shared-surface change.
- Defers design intent to the Constitution + `openspec/specs/` rather than re-deriving it.

**Doc pointers** (extend the existing "defer to cube-standard" pattern)
- `CONTRIBUTING.md`: new **"Changing cube-harness"** section — gatekeeper-first, the upstream rule, proposal-vs-additive.
- `AGENTS.md`: **"Routing contributors"** pointer (Design Philosophy + Constitution + gatekeeper; default to the smaller change).
- `README.md`: "Want to change the harness itself?" pointer.

## Notes
- Markdown/skill only; no code or runtime changes.
- Cross-repo links use cube-standard's published-docs URL convention (same as that repo's own doc links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)