### PR TITLE
feat(config): validate config fields so fat-fingers fail fast, not silently

### DIFF
--- a/src/cube_harness/agents/genny.py
+++ b/src/cube_harness/agents/genny.py
@@ -29,7 +29,7 @@ is a valid prefix of the next step, which starts the same way and appends one mo
 
 import json
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Annotated, Literal, cast
 
 if TYPE_CHECKING:
     from cube_harness.streamer import EventStreamer
@@ -179,28 +179,30 @@ class GennyConfig(AgentConfig):
     # Observation format for tool results (role="tool" messages).
     # "raw"        = send content unchanged (default).
     # "output_tag" = wrap content in <output>...</output>, matching mini-swe-agent format.
-    obs_format: str = "raw"
+    obs_format: Literal["raw", "output_tag"] = "raw"  # any other value was silently treated as "raw"
 
     # Context compaction — triggered when accumulated history exceeds this char threshold.
     # For flat_history=True: compacts self.history into a summary injected into the system message.
     # For enable_summarize=True (flat_history=False): compacts self.summaries into one entry.
     # None = disabled (default).
-    compact_threshold_chars: int | None = None
+    compact_threshold_chars: Annotated[int, Field(gt=0)] | None = None
     compact_prompt: str = _DEFAULT_COMPACT_PROMPT
 
     # Misc
-    max_obs_chars: int | None = None  # None = no truncation
+    # None = no truncation. Must be > 0: 0 truncates every observation to just
+    # "… [truncated]", silently blinding the agent on every step.
+    max_obs_chars: Annotated[int, Field(gt=0)] | None = None
     # How often to inject the framework `Budget` summary into the prompt
     # ("budget used: agent_steps 34/150 (23%), cost $1.20/$5.00 (24%), …").
     # The actual limits live on `cube_harness.budget.Budget` constructed by
     # Episode (max_agent_steps, max_cost_usd, max_prompt_tokens, …); Genny just
     # decides when to display the summary so the LLM can plan against
     # what's left. 0 disables injection entirely.
-    display_budget_every_k: int = 5
+    display_budget_every_k: Annotated[int, Field(ge=0)] = 5
     # Retry budget when the model returns no tool calls. On each retry the empty response
     # and a correction user message are appended; if still no tool calls after all retries,
     # a STOP action is returned. 0 = no retry (preserves current behavior).
-    max_format_errors: int = 0
+    max_format_errors: Annotated[int, Field(ge=0)] = 0
 
     @property
     def agent_name(self) -> str:

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Self
+from typing import Annotated, Self
 from uuid import uuid4
 
 from cube.benchmark import Benchmark, BenchmarkConfig
@@ -74,14 +74,14 @@ class Experiment(TypedBaseModel):
     benchmark_config: SerializeAsAny[BenchmarkConfig]
     infra: SerializeAsAny[InfraConfig] | None = None
     resume: bool = False
-    max_steps: int = MAX_STEPS
+    max_steps: Annotated[int, Field(gt=0)] = MAX_STEPS
     # Per-episode dollar cap on cumulative LLM cost. None = no cap.
     # Episode threads this into `Budget.max_cost_usd`; EventStreamer bumps
     # `Budget.cost_usd` from `LLMCall.usage.cost`; `MonitoredTool` raises
     # `BudgetExceeded` when the agent runs over. Agents (e.g. Genny) also
     # read it via `recorder.budget` for graceful self-stop.
-    max_cost_usd: float | None = None
-    max_retries: int = 3
+    max_cost_usd: Annotated[float, Field(gt=0)] | None = None
+    max_retries: Annotated[int, Field(ge=0)] = 3
     git_cwd: str | None = None
     debug_limit: int | None = None
     """If set, the runner truncates the task list to the first N entries.

--- a/src/cube_harness/llm.py
+++ b/src/cube_harness/llm.py
@@ -4,7 +4,7 @@ import pprint
 import time
 from datetime import datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, List, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Callable, List, Literal
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class Prompt(TypedBaseModel):
 class LLMConfig(ValidatedConfig):
     """Thin LLM wrapper around LiteLLM completion API."""
 
-    model_name: str
+    model_name: Annotated[str, Field(min_length=1)]  # empty = a typo that fails only at first API call
     temperature: float = 1.0
     max_tokens: int = 128000
     max_completion_tokens: int = 8192

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,82 @@
+"""Config field-validation: fat-fingered values must fail FAST (at construction),
+not silently or only at run time.
+
+Before these constraints, e.g. `max_obs_chars=0` silently blinded the agent every
+step, `obs_format="typo"` was silently treated as "raw", and `Experiment(max_steps=0)`
+ran a zero-step episode — all with no error.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from cube_harness.agents.genny import GennyConfig
+from cube_harness.agents.genny_configs import GENNY_CONFIGS
+from cube_harness.experiment import Experiment
+from cube_harness.llm import LLMConfig
+from tests.conftest import MockAgentConfig, MockCubeBenchmarkConfig
+
+
+def _swe() -> GennyConfig:
+    return GENNY_CONFIGS["swe"]
+
+
+def test_llm_model_name_rejects_empty() -> None:
+    with pytest.raises(ValidationError):
+        LLMConfig(model_name="")
+    LLMConfig(model_name="azure/gpt-5.4-mini")  # valid still constructs
+
+
+@pytest.mark.parametrize(
+    "field, bad",
+    [
+        ("obs_format", "nonsense"),  # not a Literal member → was silently treated as "raw"
+        ("max_obs_chars", 0),  # 0 truncates every obs to "… [truncated]" → blinds the agent
+        ("compact_threshold_chars", -5),
+        ("display_budget_every_k", -1),
+        ("max_format_errors", -1),
+    ],
+)
+def test_genny_config_rejects_bad_values(field: str, bad: object) -> None:
+    # validate_assignment=True (inherited) → assignment is the recipe pattern, must validate.
+    with pytest.raises(ValidationError):
+        setattr(_swe(), field, bad)
+
+
+def test_genny_config_valid_values_still_work() -> None:
+    a = _swe()
+    a.obs_format = "output_tag"
+    a.max_obs_chars = 1
+    a.compact_threshold_chars = 10_000
+    a.display_budget_every_k = 0  # 0 = disable (allowed)
+    a.max_format_errors = 0  # 0 = no retry (allowed)
+
+
+@pytest.mark.parametrize(
+    "field, bad",
+    [
+        ("max_steps", 0),
+        ("max_steps", -1),
+        ("max_cost_usd", 0),
+        ("max_cost_usd", -1),
+        ("max_retries", -1),
+    ],
+)
+def test_experiment_rejects_bad_budget(field: str, bad: object) -> None:
+    with pytest.raises(ValidationError):
+        Experiment(
+            name="t",
+            agent_config=MockAgentConfig(),
+            benchmark_config=MockCubeBenchmarkConfig(),
+            **{field: bad},
+        )
+
+
+def test_experiment_valid_budget_still_works() -> None:
+    Experiment(
+        name="t",
+        agent_config=MockAgentConfig(),
+        benchmark_config=MockCubeBenchmarkConfig(),
+        max_steps=1,
+        max_cost_usd=0.5,
+        max_retries=0,
+    )


### PR DESCRIPTION
## What

Add pydantic field constraints to `LLMConfig`, `GennyConfig`, and `Experiment` so mistyped recipe values raise a clear `ValidationError` at construction instead of failing silently or only at run time.

## Why (found by the Auto-CUBE config-UX audit)

The config layer accepted nonsense without complaint — a fat-fingered recipe value failed silently, or only much later (sometimes *after* paying to provision infra):

| Footgun | Before | After |
|---|---|---|
| `LLMConfig(model_name="")` | no error → fails at first API call | `ValidationError` (min_length=1) |
| `GennyConfig.obs_format="typo"` | silently treated as `"raw"` (bare `str`) | `ValidationError` (`Literal["raw","output_tag"]`) |
| `GennyConfig.max_obs_chars=0` | truncates every obs to `"… [truncated]"` → **silently blinds the agent** | `ValidationError` (gt=0) |
| `GennyConfig.compact_threshold_chars=-5` | accepted | `ValidationError` (gt=0) |
| `Experiment(max_steps=0 / -1)` | runs a 0/garbage-step episode | `ValidationError` (gt=0) |
| `Experiment(max_cost_usd=0 / -1)` | 0 = instant budget-exhaust | `ValidationError` (gt=0) |

This mirrors the registry/subset layer, which *already* fails fast helpfully (`KeyError: Unknown config 'daytna'. Available: ['daytona','local','toolkit']`; `ValueError: ... tasks do not exist: {'fix-gti'}`) — the config models just didn't.

## Scope / safety

- Constraints: `Literal[...]` for `obs_format`; `Field(gt=0)` for `max_obs_chars`, `compact_threshold_chars`, `max_steps`, `max_cost_usd`; `Field(ge=0)` for `display_budget_every_k`, `max_format_errors`, `max_retries` (0 = "disabled", legitimately allowed); `min_length=1` for `model_name`.
- Enforced on **construction and assignment** — `GennyConfig`/`LLMConfig` already inherit `validate_assignment=True` (the recipe `agent.field = ...` pattern); `Experiment` validates at construction (its only usage).
- **No false positives**: grepped the tree — no preset / recipe / test sets any of these to a now-invalid value. All `GENNY_CONFIGS` presets + baseline recipes still construct.
- `model_name` only rejects empty — LiteLLM's model space is too large to validate provider prefixes without false rejections.

## Test
`tests/test_config_validation.py` — 13 cases: each footgun raises `ValidationError`; valid edge values (`obs_format="output_tag"`, `display_budget_every_k=0`, `max_retries=0`, …) still construct. Full unit suite green (the 4 `live_api` `test_genny_caching_integration` failures are pre-existing #386 staleness — `AgentOutput.llm_calls` was removed — and fail identically on `dev`; unrelated to this PR). `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)