### PR TITLE
feat(reproducibility): full-data registry submission (per-task samples bundle)

### DIFF
--- a/scripts/smoke/registry_full_submit.py
+++ b/scripts/smoke/registry_full_submit.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Smoke: a full-data registry submission validates against the real cube-registry verifier.
+
+Builds a synthetic-but-consistent experiment, runs ``build_journal_submission`` to
+produce the summary + samples bundle, then invokes cube-registry's
+``scripts/results_check.py`` (in its own venv) on the pair — proving the harness
+output is exactly what the registry CI accepts, and that a tampered bundle is
+rejected by the consistency / sha256 gates.
+
+Discovers the registry checkout via ``$CUBE_REGISTRY_DIR`` (default: the sibling
+``../cube-registry``). SKIPs cleanly when the checkout or its venv is absent.
+
+    SMOKE OK / FAIL / SKIP: registry_full_submit   (exit 0 / 1 / 2)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from cube_harness.eval_log import EvalLog
+from cube_harness.reproducibility.journal import build_journal_submission
+
+NAME = "registry_full_submit"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _skip(msg: str) -> None:
+    print(f"SMOKE SKIP: {NAME} — {msg}")
+    sys.exit(2)
+
+
+def _registry_dir() -> Path:
+    d = Path(os.environ.get("CUBE_REGISTRY_DIR", Path(__file__).resolve().parents[2].parent / "cube-registry"))
+    if not (d / "scripts" / "results_check.py").exists():
+        _skip(f"cube-registry not found at {d} (set $CUBE_REGISTRY_DIR)")
+    py = d / ".venv" / "bin" / "python"
+    if not py.exists():
+        _skip(f"cube-registry venv not found at {py}")
+    return d
+
+
+def _build_experiment(exp_dir: Path, scores: list[float]) -> None:
+    """A minimal, internally-consistent EvalLog (one COMPLETED episode per score).
+
+    Reuses the reproducibility test fixtures so the records stay valid as the
+    models evolve."""
+    sys.path.insert(0, str(_REPO_ROOT))
+    from tests.test_reproducibility import _ep_record, _exp_record, _write_status  # noqa: PLC0415
+
+    exp = _exp_record(n_tasks=len(scores))
+    EvalLog(experiment=exp, episodes=[_ep_record(f"t{i}", s) for i, s in enumerate(scores)]).save(exp_dir)
+    for i, s in enumerate(scores):
+        _write_status(exp_dir, f"t{i}", "COMPLETED", reward=s)
+
+
+_VALIDATE_SNIPPET = r"""
+import sys, gzip, glob
+from pathlib import Path
+sys.path.insert(0, "scripts")
+import results_check as rc
+SMOKE = Path(sys.argv[1])
+for attr, val in [("REPO_ROOT", SMOKE), ("SCHEMA_PATH", SMOKE/"results-schema.json"),
+                  ("SAMPLES_SCHEMA_PATH", SMOKE/"samples-schema.json"),
+                  ("ENTRIES_DIR", SMOKE/"entries"), ("RESULTS_DIR", SMOKE/"results")]:
+    setattr(rc, attr, val)
+schema, samples = rc._load_schema(), rc._load_samples_schema()
+summary = Path(glob.glob(str(SMOKE/"results/miniwob/*.json"))[0])
+ok = rc.check_file(summary, schema, samples_schema=samples)
+bundle = next(SMOKE.glob("results/miniwob/*.samples.jsonl.gz"))
+bundle.write_bytes(gzip.compress(b'{"sample_id":"t0","score":1.0}\n', mtime=0))
+bad = rc.check_file(summary, schema, samples_schema=samples)
+print("valid_ok=%s tamper_rejected=%s" % (ok == [], bool(bad)))
+if ok: print("  valid failures:", ok)
+sys.exit(0 if (ok == [] and bad) else 1)
+"""
+
+
+def main() -> int:
+    registry = _registry_dir()
+    with tempfile.TemporaryDirectory(prefix="cubereg-smoke-") as tmp:
+        smoke = Path(tmp)
+        (smoke / "results" / "miniwob").mkdir(parents=True)
+        (smoke / "entries").mkdir()
+        shutil.copy(registry / "results-schema.json", smoke / "results-schema.json")
+        shutil.copy(registry / "samples-schema.json", smoke / "samples-schema.json")
+
+        scores = [1.0, 0.0, 1.0, 1.0, 0.0]
+        _build_experiment(smoke / "_exp", scores)
+        sub = build_journal_submission(smoke / "_exp", submitter="tester", cube_id="miniwob")
+        cube_dir = smoke / "results" / "miniwob"
+        (cube_dir / sub.summary_filename).write_text(json.dumps(sub.record, indent=2) + "\n")
+        (cube_dir / sub.bundle_filename).write_bytes(sub.bundle)
+        ver = sub.record["benchmark_version"]
+        (smoke / "entries" / "miniwob.yaml").write_text(
+            f"id: miniwob\nname: MiniWob\nversion: {ver}\ndescription: smoke\npackage: miniwob-cube\n"
+            "authors:\n  - github: tester\nlegal:\n  wrapper_license: MIT\ntask_count: 125\n"
+        )
+
+        proc = subprocess.run(
+            [str(registry / ".venv" / "bin" / "python"), "-c", _VALIDATE_SNIPPET, str(smoke)],
+            cwd=registry,
+            capture_output=True,
+            text=True,
+        )
+        print(proc.stdout.strip())
+        if proc.returncode != 0:
+            print(proc.stderr.strip())
+            print(f"SMOKE FAIL: {NAME}")
+            return 1
+
+    print(f"SMOKE OK: {NAME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -30,7 +30,8 @@ import typer
 
 from cube_harness.reproducibility import (
     JOURNAL_SCHEMA_VERSION,
-    build_journal_record,
+    JournalSubmission,
+    build_journal_submission,
     sanitize_filename,
     submissions,
 )
@@ -101,18 +102,20 @@ def _git_user_handle() -> str:
         return "submitter"
 
 
-def _write_record(record: dict, out_root: Path) -> Path:
-    cube_id = record["benchmark_name"]
-    eid = record["evaluation_id"]
-    target_dir = out_root / "results" / cube_id
+def _write_submission(sub: JournalSubmission, out_root: Path) -> list[Path]:
+    """Write the summary record + its samples bundle under
+    ``<out_root>/results/<cube-id>/``. Returns ``[summary_path, bundle_path]``."""
+    target_dir = out_root / "results" / sub.record["benchmark_name"]
     target_dir.mkdir(parents=True, exist_ok=True)
-    target_path = target_dir / f"{sanitize_filename(eid)}.json"
-    target_path.write_text(json.dumps(record, indent=2) + "\n")
-    return target_path
+    summary_path = target_dir / sub.summary_filename
+    bundle_path = target_dir / sub.bundle_filename
+    summary_path.write_text(json.dumps(sub.record, indent=2) + "\n")
+    bundle_path.write_bytes(sub.bundle)
+    return [summary_path, bundle_path]
 
 
-def _open_pr(record_path: Path, record: dict, branch: str) -> str:
-    """Fork cube-registry, copy *record_path* into the fork, push, gh pr create.
+def _open_pr(files: list[Path], record: dict, branch: str) -> str:
+    """Fork cube-registry, copy *files* into the fork, push, gh pr create.
 
     Uses ``gh repo fork --clone`` so this works for any GitHub user, not just
     members of The-AI-Alliance org. The fork is idempotent — gh detects an
@@ -146,15 +149,15 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
             raise FileNotFoundError(f"expected `gh repo fork` to create {clone_dir}; got {list(Path(tmp).iterdir())}")
 
         subprocess.run(["git", "-C", str(clone_dir), "checkout", "-b", branch], check=True)
-        cube_id = record["benchmark_name"]
-        dst_dir = clone_dir / "results" / cube_id
+        dst_dir = clone_dir / "results" / record["benchmark_name"]
         dst_dir.mkdir(parents=True, exist_ok=True)
-        dst_path = dst_dir / record_path.name
-        shutil.copyfile(record_path, dst_path)
-        subprocess.run(
-            ["git", "-C", str(clone_dir), "add", str(dst_path.relative_to(clone_dir))],
-            check=True,
-        )
+        for src in files:
+            dst_path = dst_dir / src.name
+            shutil.copyfile(src, dst_path)
+            subprocess.run(
+                ["git", "-C", str(clone_dir), "add", str(dst_path.relative_to(clone_dir))],
+                check=True,
+            )
         subprocess.run(
             [
                 "git",
@@ -185,7 +188,10 @@ def _open_pr(record_path: Path, record: dict, branch: str) -> str:
             f"± {record['results']['std_err']:.3f}\n"
             f"- subset: `{record['benchmark_subset']['name']}` "
             f"({record['benchmark_subset']['n_tasks']} tasks)\n"
-            f"- outcomes: {record['results']['outcomes']}\n\n"
+            f"- outcomes: {record['results']['outcomes']}\n"
+            f"- detailed results: `{record['detailed_results']['file']}` "
+            f"({record['detailed_results']['n_samples']} samples, sha256 "
+            f"`{record['detailed_results']['sha256'][:12]}…`)\n\n"
             f"_Submitted via cube-harness `scripts/submit_to_journal.py`._"
         )
         # Target the canonical repo with --repo, and name the head branch as
@@ -278,10 +284,12 @@ def main(
     typer.echo(f"submitter: {submitter}")
     typer.echo(f"experiment_dir: {experiment_dir}")
 
-    record = build_journal_record(experiment_dir, submitter=submitter, cube_id=cube_id)
+    sub = build_journal_submission(experiment_dir, submitter=submitter, cube_id=cube_id)
+    record = sub.record
     assert record["schema_version"] == JOURNAL_SCHEMA_VERSION
-    target_path = _write_record(record, out_dir)
-    typer.echo(f"wrote: {target_path}")
+    summary_path, bundle_path = _write_submission(sub, out_dir)
+    typer.echo(f"wrote: {summary_path}")
+    typer.echo(f"       {bundle_path}  ({len(sub.bundle):,} B, {record['detailed_results']['n_samples']} samples)")
     typer.echo(
         f"  {record['benchmark_name']} v{record['benchmark_version']} · "
         f"{record['agent']['config_type']} / {record['agent']['llm_model']} · "
@@ -292,13 +300,13 @@ def main(
         typer.echo("")
         typer.echo("To submit by hand:")
         typer.echo("  1. Fork https://github.com/The-AI-Alliance/cube-registry and clone it locally.")
-        typer.echo(f"  2. Copy {target_path} into <clone>/results/{record['benchmark_name']}/")
+        typer.echo(f"  2. Copy both files into <clone>/results/{record['benchmark_name']}/")
         typer.echo("  3. Commit (with -s) and open a PR — CI will validate + auto-merge.")
         typer.echo("Or re-run with --auto-pr.")
         return
 
     branch = f"results/{record['benchmark_name']}/{sanitize_filename(record['evaluation_id'])}"
-    pr_url = _open_pr(target_path, record, branch)
+    pr_url = _open_pr([summary_path, bundle_path], record, branch)
     typer.echo(f"PR opened: {pr_url}")
     # Stamp idempotency so a repeat invocation (or the scan script) sees that
     # this experiment has already been submitted to the journal.
@@ -309,7 +317,7 @@ def main(
         schema_version=record["schema_version"],
         submitted_by=submitter,
         pr_url=pr_url,
-        local_path=str(target_path),
+        local_path=str(summary_path),
     )
     typer.echo(f"recorded in {experiment_dir / submissions.SUBMISSIONS_FILENAME}")
 

--- a/src/cube_harness/reproducibility/__init__.py
+++ b/src/cube_harness/reproducibility/__init__.py
@@ -16,17 +16,21 @@ from cube_harness.reproducibility import submissions
 from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
 from cube_harness.reproducibility.journal import (
     JOURNAL_SCHEMA_VERSION,
+    JournalSubmission,
     Outcomes,
     build_journal_record,
+    build_journal_submission,
     sanitize_filename,
 )
 
 __all__ = [
     "EEE_SCHEMA_VERSION",
     "JOURNAL_SCHEMA_VERSION",
+    "JournalSubmission",
     "Outcomes",
     "build_eee_record",
     "build_journal_record",
+    "build_journal_submission",
     "sanitize_filename",
     "submissions",
 ]

--- a/src/cube_harness/reproducibility/journal.py
+++ b/src/cube_harness/reproducibility/journal.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from cube_harness.episode_status import EpisodeStatus, Status
 from cube_harness.eval_log import EvalLog
+from cube_harness.reproducibility import samples
 from cube_harness.results import ExperimentResult
 
 JOURNAL_SCHEMA_VERSION = "1.0"
@@ -216,3 +217,59 @@ def build_journal_record(
         "results": results_dict,
     }
     return record
+
+
+@dataclass
+class JournalSubmission:
+    """A registry submission: the small summary record + its companion bundle.
+
+    Both files land under ``results/<cube-id>/`` — ``summary_filename`` (the
+    human-reviewable, table-driving record, with a ``detailed_results`` pointer)
+    and ``bundle_filename`` (the gzipped per-task samples the verifier re-derives
+    the summary from).
+    """
+
+    record: dict[str, Any]
+    bundle: bytes
+    summary_filename: str
+    bundle_filename: str
+
+
+def build_journal_submission(
+    experiment_dir: Path,
+    *,
+    submitter: str,
+    cube_id: str | None = None,
+) -> JournalSubmission:
+    """Build the full registry submission: summary record + per-task bundle.
+
+    The summary gains a ``detailed_results`` pointer (file / format / sha256 /
+    n_samples). Fails fast if the summary's aggregate doesn't match the bundle —
+    the same consistency invariant the registry verifier re-checks in CI, caught
+    locally before anything is published.
+    """
+    record = build_journal_record(experiment_dir, submitter=submitter, cube_id=cube_id)
+    bundle = samples.build_samples_bundle(experiment_dir)
+    agg = samples.aggregate_from_samples(samples.iter_samples(bundle))
+
+    summary_avg = record["results"]["avg_score"]
+    if agg["n_scored"] and agg["avg_score"] != summary_avg:
+        raise ValueError(
+            f"summary/bundle mismatch: results.avg_score={summary_avg} but "
+            f"bundle recomputes {agg['avg_score']} over {agg['n_scored']} scored samples"
+        )
+
+    stem = sanitize_filename(record["evaluation_id"])
+    bundle_filename = f"{stem}{samples.SAMPLES_SUFFIX}"
+    record["detailed_results"] = {
+        "file": bundle_filename,
+        "format": samples.SAMPLES_FORMAT,
+        "sha256": samples.sha256_hex(bundle),
+        "n_samples": agg["n_samples"],
+    }
+    return JournalSubmission(
+        record=record,
+        bundle=bundle,
+        summary_filename=f"{stem}.json",
+        bundle_filename=bundle_filename,
+    )

--- a/src/cube_harness/reproducibility/samples.py
+++ b/src/cube_harness/reproducibility/samples.py
@@ -1,0 +1,77 @@
+"""Per-task *samples* bundle for the cube-registry journal.
+
+The journal record (:mod:`cube_harness.reproducibility.journal`) is the small,
+human-reviewable **summary** that lives in the registry git repo and drives the
+UI table. This module produces its companion **detailed** bundle: one JSON line
+per episode (the eval-level :class:`~cube_harness.eval_log.EpisodeRecord` — score,
+usage, steps, etc.; *no* trajectory blobs), gzipped into a single file.
+
+`aggregate_from_samples` is the integrity check shared by *both* sides: the
+harness uses it to assert the summary it emits matches the bundle, and
+cube-registry's ``results_check.py`` re-runs the same computation in CI to prove
+a submitted summary is consistent with its raw per-task data. Keeping the one
+function here (and a dependency-light mirror in the registry) is what lets the
+self-reported headline number become verifiable.
+
+The gzip stream is written with ``mtime=0`` so the same experiment always
+produces byte-identical bundles — the ``sha256`` is stable, and a re-submission
+is a no-op rather than a spurious diff.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+from cube_harness.eval_log import EvalLog
+
+SAMPLES_FORMAT = "jsonl.gz"
+SAMPLES_SUFFIX = ".samples.jsonl.gz"
+
+
+def build_samples_bundle(experiment_dir: Path) -> bytes:
+    """Return the gzipped JSONL bundle for *experiment_dir*.
+
+    One line per episode — the full eval-level ``EpisodeRecord`` (no trajectory
+    blobs, which live separately in ``episodes/<id>/steps``). Deterministic:
+    ``mtime=0`` makes the bytes (and thus the sha256) reproducible.
+    """
+    eval_log = EvalLog.load(Path(experiment_dir))
+    lines = [json.dumps(ep.model_dump(mode="json"), separators=(",", ":"), sort_keys=True) for ep in eval_log.episodes]
+    raw = ("\n".join(lines) + "\n").encode("utf-8") if lines else b""
+    return gzip.compress(raw, mtime=0)
+
+
+def iter_samples(bundle_gz: bytes) -> list[dict[str, Any]]:
+    """Decode a gzipped JSONL bundle into a list of per-task sample dicts."""
+    raw = gzip.decompress(bundle_gz).decode("utf-8")
+    return [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+
+def aggregate_from_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute the headline aggregate from per-task samples.
+
+    The shared integrity check: the harness asserts this matches the summary it
+    builds, and the registry verifier re-runs it in CI to confirm a submitted
+    summary derives from its bundle. ``avg_score`` / ``std_err`` mirror the
+    journal record's ``results`` block exactly (same rounding, same stdev).
+    """
+    scores = [float(s["score"]) for s in samples if s.get("score") is not None]
+    n_scored = len(scores)
+    avg = sum(scores) / n_scored if n_scored else 0.0
+    std_err = statistics.stdev(scores) / (n_scored**0.5) if n_scored > 1 else 0.0
+    return {
+        "n_samples": len(samples),
+        "n_scored": n_scored,
+        "avg_score": round(avg, 6),
+        "std_err": round(std_err, 6),
+    }
+
+
+def sha256_hex(data: bytes) -> str:
+    """Hex sha256 of *data* — recorded in the summary, re-checked by the verifier."""
+    return hashlib.sha256(data).hexdigest()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -71,3 +71,27 @@ class TestAggregateFromSamples:
         rec = build_journal_record(tmp_path, submitter="tester")
         assert agg["avg_score"] == rec["results"]["avg_score"]
         assert agg["std_err"] == rec["results"]["std_err"]
+
+
+class TestJournalSubmission:
+    def test_summary_points_at_paired_bundle(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility.journal import build_journal_submission  # noqa: PLC0415
+
+        _save_eval_log(tmp_path, [1.0, 0.0, 1.0])
+        sub = build_journal_submission(tmp_path, submitter="tester")
+        # Paired filenames share a stem; summary references the bundle by name + hash.
+        assert sub.summary_filename.endswith(".json")
+        assert sub.bundle_filename == sub.summary_filename[: -len(".json")] + samples.SAMPLES_SUFFIX
+        dr = sub.record["detailed_results"]
+        assert dr["file"] == sub.bundle_filename
+        assert dr["format"] == "jsonl.gz"
+        assert dr["n_samples"] == 3
+        assert dr["sha256"] == samples.sha256_hex(sub.bundle)
+
+    def test_bundle_re_derives_the_summary(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility.journal import build_journal_submission  # noqa: PLC0415
+
+        _save_eval_log(tmp_path, [1.0, 0.0, 1.0, 1.0])
+        sub = build_journal_submission(tmp_path, submitter="tester")
+        agg = samples.aggregate_from_samples(samples.iter_samples(sub.bundle))
+        assert agg["avg_score"] == sub.record["results"]["avg_score"]

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,0 +1,73 @@
+"""Tests for cube_harness.reproducibility.samples (the per-task bundle)."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import statistics
+from pathlib import Path
+
+from cube_harness.eval_log import EvalLog
+from cube_harness.reproducibility import samples
+
+# Reuse the record fixtures from the reproducibility test module.
+from tests.test_reproducibility import _ep_record, _exp_record
+
+
+def _save_eval_log(exp_dir: Path, scores: list[float]) -> None:
+    exp = _exp_record(n_tasks=len(scores))
+    episodes = [_ep_record(f"t{i}", s) for i, s in enumerate(scores)]
+    EvalLog(experiment=exp, episodes=episodes).save(exp_dir)
+
+
+class TestSamplesBundle:
+    def test_bundle_is_deterministic(self, tmp_path: Path) -> None:
+        _save_eval_log(tmp_path, [1.0, 0.0, 1.0])
+        a = samples.build_samples_bundle(tmp_path)
+        b = samples.build_samples_bundle(tmp_path)
+        assert a == b  # mtime=0 + sorted keys → byte-identical
+        assert samples.sha256_hex(a) == samples.sha256_hex(b)
+
+    def test_bundle_is_gzipped_jsonl_one_line_per_episode(self, tmp_path: Path) -> None:
+        _save_eval_log(tmp_path, [1.0, 0.0, 0.5])
+        raw = gzip.decompress(samples.build_samples_bundle(tmp_path)).decode()
+        lines = [ln for ln in raw.splitlines() if ln.strip()]
+        assert len(lines) == 3
+        first = json.loads(lines[0])
+        assert first["sample_id"] == "t0" and first["score"] == 1.0
+
+    def test_roundtrip_iter_samples(self, tmp_path: Path) -> None:
+        _save_eval_log(tmp_path, [1.0, 0.0])
+        s = samples.iter_samples(samples.build_samples_bundle(tmp_path))
+        assert [x["score"] for x in s] == [1.0, 0.0]
+
+    def test_empty_experiment_bundles_cleanly(self, tmp_path: Path) -> None:
+        EvalLog(experiment=_exp_record(n_tasks=0), episodes=[]).save(tmp_path)
+        bundle = samples.build_samples_bundle(tmp_path)
+        assert samples.iter_samples(bundle) == []
+        assert samples.aggregate_from_samples([]) == {
+            "n_samples": 0,
+            "n_scored": 0,
+            "avg_score": 0.0,
+            "std_err": 0.0,
+        }
+
+
+class TestAggregateFromSamples:
+    def test_matches_hand_computed_mean_and_stderr(self, tmp_path: Path) -> None:
+        scores = [1.0, 0.0, 1.0, 1.0, 0.0]
+        _save_eval_log(tmp_path, scores)
+        agg = samples.aggregate_from_samples(samples.iter_samples(samples.build_samples_bundle(tmp_path)))
+        assert agg["n_samples"] == 5 and agg["n_scored"] == 5
+        assert agg["avg_score"] == round(sum(scores) / len(scores), 6)
+        assert agg["std_err"] == round(statistics.stdev(scores) / (len(scores) ** 0.5), 6)
+
+    def test_matches_journal_record(self, tmp_path: Path) -> None:
+        # The whole point: the bundle re-derives the summary's headline numbers.
+        from cube_harness.reproducibility.journal import build_journal_record  # noqa: PLC0415
+
+        _save_eval_log(tmp_path, [1.0, 0.0, 1.0, 0.5])
+        agg = samples.aggregate_from_samples(samples.iter_samples(samples.build_samples_bundle(tmp_path)))
+        rec = build_journal_record(tmp_path, submitter="tester")
+        assert agg["avg_score"] == rec["results"]["avg_score"]
+        assert agg["std_err"] == rec["results"]["std_err"]


### PR DESCRIPTION
Depends-on: cube-standard/dev

## Full-data registry submission (per-task samples bundle)

A cube-registry submission now carries its **full per-task data**, not just the
aggregate — so the headline score becomes verifiable and downstream consumers
(ATLAS) get the raw rows. Pairs with **cube-registry#56** (the verifier).

### What's here
- **`reproducibility/samples.py`** — `build_samples_bundle()`: a deterministic
  (`mtime=0`) gzipped JSONL, one eval-level `EpisodeRecord` per line, no trajectory
  blobs (586-task swebench run = 65 KB). `aggregate_from_samples()`: the integrity
  helper that re-derives `avg_score`/`std_err` — the *same* computation the
  registry verifier re-runs in CI.
- **`journal.build_journal_submission()`** — pairs the summary (UI/table record)
  with the bundle, embeds a `detailed_results` pointer (file/format/sha256/
  n_samples), and **fails fast** if the summary's aggregate doesn't match the
  bundle (the invariant the verifier re-checks).
- **`submit_to_journal.py`** — publishes **both** files under `results/<cube>/`
  (the `.json` + the `.samples.jsonl.gz`); PR body notes the bundle.
- **`scripts/smoke/registry_full_submit.py`** — cross-repo smoke: builds a real
  submission and runs cube-registry's verifier on it (accept + tamper-reject).

### Verification
49 reproducibility/samples tests pass; lint clean. Smoke verified end-to-end
against the cube-registry validator (`SMOKE OK`).

### Follow-up (separate PR)
Shared `reproducibility/submit.py` core (build→validate→pending→publish→
submitted/failed) reused by CLI + XRay buttons, and the EEE real-upload half
(→ `evaleval/EEE_datastore` PR via `--upload`). This PR keeps the registry path
focused; the EEE/shared-core refactor lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
