### PR TITLE
feat(reproducibility): EEE submission with real HF-dataset upload + validation

### DIFF
--- a/scripts/smoke/eee_submit.py
+++ b/scripts/smoke/eee_submit.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Smoke: an EEE record built from an experiment validates against EEE's own schema.
+
+Builds a synthetic-but-consistent experiment, runs ``build_eee_record``, and
+validates the result with the real ``every-eval-ever`` package — proving the
+emitted record is exactly what EEE accepts. Also confirms the upload path is
+wired (``huggingface_hub`` importable + ``HfApi.upload_file`` present); it does
+*not* actually open a PR (that needs auth and would spam the community dataset —
+verified manually instead).
+
+SKIPs cleanly when ``every-eval-ever`` isn't installed.
+
+    SMOKE OK / FAIL / SKIP: eee_submit   (exit 0 / 1 / 2)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from cube_harness.eval_log import EvalLog
+from cube_harness.reproducibility.eee import build_eee_record
+
+NAME = "eee_submit"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _skip(msg: str) -> None:
+    print(f"SMOKE SKIP: {NAME} — {msg}")
+    sys.exit(2)
+
+
+def main() -> int:
+    if subprocess.run([sys.executable, "-c", "import every_eval_ever"], capture_output=True).returncode != 0:
+        _skip("every-eval-ever not installed (pip install every-eval-ever)")
+
+    sys.path.insert(0, str(_REPO_ROOT))
+    from tests.test_reproducibility import _ep_record, _exp_record, _write_status  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="eee-smoke-") as tmp:
+        exp_dir = Path(tmp) / "exp"
+        scores = [1.0, 0.0, 1.0, 1.0, 0.0]
+        EvalLog(
+            experiment=_exp_record(n_tasks=len(scores)), episodes=[_ep_record(f"t{i}", s) for i, s in enumerate(scores)]
+        ).save(exp_dir)
+        for i, s in enumerate(scores):
+            _write_status(exp_dir, f"t{i}", "COMPLETED", reward=s)
+
+        record = build_eee_record(exp_dir, source_organization_name="smoke")
+        target = Path(tmp) / "record.json"
+        target.write_text(json.dumps(record, indent=2))
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "every_eval_ever", "validate", str(target)],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            print(proc.stdout + proc.stderr)
+            print(f"SMOKE FAIL: {NAME} — EEE validation failed")
+            return 1
+
+    # Upload path wired?
+    try:
+        from huggingface_hub import HfApi  # noqa: PLC0415
+
+        assert callable(HfApi().upload_file)
+    except Exception as e:  # noqa: BLE001
+        print(f"SMOKE FAIL: {NAME} — upload path not wired: {e}")
+        return 1
+
+    print("  ✓ record validates against EEE schema; upload path wired (huggingface_hub)")
+    print(f"SMOKE OK: {NAME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/submit_to_eee.py
+++ b/scripts/submit_to_eee.py
@@ -15,6 +15,8 @@ Usage:
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import uuid
 from pathlib import Path
 from typing import Annotated
@@ -23,6 +25,10 @@ import typer
 
 from cube_harness.reproducibility import submissions
 from cube_harness.reproducibility.eee import EEE_SCHEMA_VERSION, build_eee_record
+
+# The community EEE datastore. `--upload` opens a PR here (which EEE's own
+# validation + a maintainer review then process). Override for a private dataset.
+DEFAULT_EEE_DATASET = "evaleval/EEE_datastore"
 
 
 def _eee_path(out_dir: Path, record: dict) -> Path:
@@ -33,6 +39,52 @@ def _eee_path(out_dir: Path, record: dict) -> Path:
     target_dir = out_dir / "data" / benchmark / developer / model
     target_dir.mkdir(parents=True, exist_ok=True)
     return target_dir / f"{uuid.uuid4().hex}.json"
+
+
+def _validate_record(target: Path) -> None:
+    """Validate *target* against EEE's schema via the ``every-eval-ever`` package.
+
+    Raises ``typer.Exit(1)`` on a validation failure. Skips (with a warning) when
+    the package isn't installed — it's an optional dev dependency; the upstream PR
+    runs the same validation, so this is a fast local pre-check, not the gate."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "every_eval_ever", "validate", str(target)],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        typer.echo("  (every-eval-ever not installed — skipping local schema check)", err=True)
+        return
+    if "No module named" in proc.stderr:
+        typer.echo("  (every-eval-ever not installed — skipping local schema check)", err=True)
+        return
+    if proc.returncode != 0:
+        typer.echo(proc.stdout + proc.stderr, err=True)
+        typer.echo("EEE schema validation failed — not uploading.", err=True)
+        raise typer.Exit(code=1)
+    typer.echo("  ✓ validates against the EEE schema")
+
+
+def _upload_to_eee(target: Path, out_dir: Path, dataset_id: str) -> str:
+    """Open a PR adding *target* to the EEE HF dataset. Returns the PR url.
+
+    Lazy-imports ``huggingface_hub`` (optional, upload-only dep). Uses
+    ``create_pr=True`` so it lands as a reviewable PR — never a direct push to the
+    community dataset's main branch. Auth via the standard HF token resolution
+    (``HF_TOKEN`` / ``huggingface-cli login``)."""
+    from huggingface_hub import HfApi  # noqa: PLC0415 — optional upload-only dependency
+
+    path_in_repo = str(target.relative_to(out_dir))
+    info = HfApi().upload_file(
+        path_or_fileobj=str(target),
+        path_in_repo=path_in_repo,
+        repo_id=dataset_id,
+        repo_type="dataset",
+        create_pr=True,
+        commit_message=f"results: add {target.stem} ({path_in_repo})",
+    )
+    return info.pr_url
 
 
 def main(
@@ -56,6 +108,18 @@ def main(
             help="Root for the EEE-expected on-disk layout (data/<benchmark>/<dev>/<model>/<uuid>.json).",
         ),
     ] = Path("./eee-out"),
+    upload: Annotated[
+        bool,
+        typer.Option(
+            "--upload/--no-upload",
+            help="Open a PR adding the record to the EEE HuggingFace dataset (an outward "
+            "publish). Without it, the record is only materialized locally.",
+        ),
+    ] = False,
+    dataset_id: Annotated[
+        str,
+        typer.Option("--dataset-id", help="EEE HF dataset to open the PR against."),
+    ] = DEFAULT_EEE_DATASET,
     force: Annotated[
         bool,
         typer.Option(
@@ -64,7 +128,8 @@ def main(
         ),
     ] = False,
 ) -> None:
-    """Build an EEE record from a completed experiment and write it under <out-dir>/data/."""
+    """Build an EEE record from a completed experiment, validate it, and optionally
+    open a PR to the EEE HuggingFace dataset (``--upload``)."""
     if not force and submissions.has_decision(experiment_dir, "eee"):
         prior = submissions.read(experiment_dir).get("eee", {})
         typer.echo(
@@ -88,16 +153,34 @@ def main(
         f"{record['model_info']['id']} · "
         f"score={record['evaluation_results'][0]['score_details']['score']:.3f}"
     )
-    typer.echo("")
-    typer.echo("To submit upstream:")
-    typer.echo(f"  huggingface-cli upload <hf-dataset-id> {target} {target.relative_to(out_dir)} --repo-type dataset")
+
+    _validate_record(target)
+
+    if not upload:
+        typer.echo("")
+        typer.echo("Materialized locally (not submitted). To publish, re-run with --upload, or by hand:")
+        typer.echo(f"  hf upload {dataset_id} {target} {target.relative_to(out_dir)} --repo-type dataset")
+        return
+
+    # Mark in-progress so a crash leaves a retryable 'pending', not a false 'submitted'.
+    submissions.record_pending(experiment_dir, "eee")
+    try:
+        pr_url = _upload_to_eee(target, out_dir, dataset_id)
+    except Exception as e:  # noqa: BLE001 — surface any HF/network failure as a recorded failure
+        submissions.record_failed(experiment_dir, "eee", reason=f"{type(e).__name__}: {e}")
+        typer.echo(f"EEE upload failed: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    typer.echo(f"PR opened: {pr_url}")
     submissions.record_submitted(
         experiment_dir,
         "eee",
         evaluation_id=record["evaluation_id"],
         schema_version=EEE_SCHEMA_VERSION,
+        pr_url=pr_url,
         local_path=str(target),
     )
+    typer.echo(f"recorded in {experiment_dir / submissions.SUBMISSIONS_FILENAME}")
 
 
 if __name__ == "__main__":

--- a/src/cube_harness/analyze/xray.py
+++ b/src/cube_harness/analyze/xray.py
@@ -1573,7 +1573,9 @@ def run_xray(
                     gr.update(value="Nothing selected to submit.", visible=True),
                 )
             if destination == "eee":
-                script, extra = "submit_to_eee.py", []
+                # Clicking Submit → EEE is an explicit publish: actually open the
+                # HF-dataset PR (the CLI defaults to --no-upload for safety).
+                script, extra = "submit_to_eee.py", ["--upload"]
             else:
                 script, extra = "submit_to_journal.py", ["--auto-pr", "--i-understand-this-is-not-a-leaderboard"]
             dest_key = "eee" if destination == "eee" else "journal"


### PR DESCRIPTION
Depends-on: cube-standard/dev

## EEE submission that actually uploads

`submit_to_eee.py` was materialize-only — it wrote a local JSON and marked the run
`submitted` before anything left the machine. Now it's a real submission path, at
parity with the registry, so **Submit → EEE works from the CLI and the XRay button**.

### What changes (`scripts/submit_to_eee.py`)
- **Validate** the built record against EEE's own schema via the `every-eval-ever`
  package (skipped with a notice if it's not installed — the upstream PR runs the
  same check, so this is a fast local pre-check).
- **`--upload`** opens a PR to the EEE HuggingFace dataset (`evaleval/EEE_datastore`,
  `create_pr=True` — never a direct push to their main). `--dataset-id` overrides
  for a private dataset.
- **Honest lifecycle**: `pending` → `submitted` (with the PR url) | `failed` —
  no more premature `submitted` on local write. The CLI defaults to `--no-upload`
  for safety; the XRay **Submit → EEE** button passes `--upload` (an explicit publish).

### Verification
- Built an EEE record from a real terminalbench2 run, validated it with
  `every-eval-ever` (✅), opened a real dataset PR (file confirmed present on the
  PR ref), then **closed the test PR** and cleared the record.
- `scripts/smoke/eee_submit.py` (build → EEE-validate → upload-path-wired); SKIPs
  without `every-eval-ever`. 165 reproducibility/samples/xray tests green; lint clean.

Completes the "submit to **both** registry and EEE, via CLI or buttons" goal
(registry full-data landed in #501 / cube-registry#56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
