### PR TITLE
fix(reproducibility): exclude archived retry attempts from published scores + EEE/journal hardening

### DIFF
--- a/scripts/submit_to_eee.py
+++ b/scripts/submit_to_eee.py
@@ -32,10 +32,15 @@ DEFAULT_EEE_DATASET = "evaleval/EEE_datastore"
 
 
 def _eee_path(out_dir: Path, record: dict) -> Path:
-    """Render the EEE-expected file path ``data/{benchmark}/{developer}/{model}/{uuid}.json``."""
+    """Render the EEE datastore path ``data/{benchmark}/{developer}/{model}/{uuid}.json``.
+
+    Mirrors the live datastore's layout: lowercase developer slug, model
+    directory without the provider prefix — e.g.
+    ``data/GAIA/anthropic/claude-3-7-sonnet-20250219/<uuid>.json``.
+    """
     benchmark = record["evaluation_results"][0]["evaluation_name"].split("[", 1)[0]
     developer = record["model_info"].get("developer") or "unknown"
-    model = record["model_info"]["id"].replace("/", "__") or "unknown"
+    model = record["model_info"]["id"].split("/")[-1] or "unknown"
     target_dir = out_dir / "data" / benchmark / developer / model
     target_dir.mkdir(parents=True, exist_ok=True)
     return target_dir / f"{uuid.uuid4().hex}.json"

--- a/scripts/submit_to_journal.py
+++ b/scripts/submit_to_journal.py
@@ -91,7 +91,23 @@ def _confirm_not_a_leaderboard(*, acknowledged: bool) -> None:
 
 
 def _git_user_handle() -> str:
-    """Best-effort GitHub handle: ``GIT_AUTHOR_NAME`` env > ``git config user.name``."""
+    """Best-effort GitHub handle for the ``evaluation_id`` namespace.
+
+    Tries the *actual* GitHub login first (``gh api user`` — gh is required for
+    ``--auto-pr`` anyway), then ``GIT_AUTHOR_NAME``/``USER`` env, then
+    ``git config user.name``. The last two are heuristics: a user.name like
+    "Ada Lovelace" contains a space and fails the registry's evaluation_id
+    pattern — ``build_journal_record`` rejects it locally with a pointer to
+    ``--submitter``, rather than letting registry CI reject the opened PR.
+    """
+    try:
+        login = subprocess.check_output(
+            ["gh", "api", "user", "--jq", ".login"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        if login:
+            return login
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
     env = os.environ.get("GIT_AUTHOR_NAME") or os.environ.get("USER")
     if env:
         return env
@@ -223,7 +239,8 @@ def main(
         str | None,
         typer.Option(
             "--submitter",
-            help="GitHub handle for the evaluation_id namespace (defaults to git config user.name).",
+            help="GitHub handle for the evaluation_id namespace "
+            "(default: gh api user login, then $GIT_AUTHOR_NAME/$USER, then git config user.name).",
         ),
     ] = None,
     cube_id: Annotated[
@@ -306,7 +323,15 @@ def main(
         return
 
     branch = f"results/{record['benchmark_name']}/{sanitize_filename(record['evaluation_id'])}"
-    pr_url = _open_pr([summary_path, bundle_path], record, branch)
+    # Mark in-progress so a crash leaves a retryable 'pending', not a false
+    # 'submitted' — same lifecycle as submit_to_eee.py.
+    submissions.record_pending(experiment_dir, "journal")
+    try:
+        pr_url = _open_pr([summary_path, bundle_path], record, branch)
+    except Exception as e:  # noqa: BLE001 — surface any gh/git failure as a recorded failure
+        submissions.record_failed(experiment_dir, "journal", reason=f"{type(e).__name__}: {e}")
+        typer.echo(f"journal submission failed: {e}", err=True)
+        raise typer.Exit(code=1) from e
     typer.echo(f"PR opened: {pr_url}")
     # Stamp idempotency so a repeat invocation (or the scan script) sees that
     # this experiment has already been submitted to the journal.

--- a/src/cube_harness/eval_log.py
+++ b/src/cube_harness/eval_log.py
@@ -41,6 +41,7 @@ from cube.benchmark import BenchmarkConfig
 from cube.core import TypedBaseModel
 from pydantic import Field
 
+from cube_harness.storage import ARCHIVED_MARKER as _ARCHIVED_MARKER
 from cube_harness.storage import EPISODES_DIR as _EPISODES_DIR
 
 if TYPE_CHECKING:
@@ -840,7 +841,14 @@ class EvalLog(TypedBaseModel):
 
     @classmethod
     def load(cls, output_dir: Path) -> "EvalLog":
-        """Load experiment_record.json and all per-trajectory episode_record.json files."""
+        """Load experiment_record.json and all per-trajectory episode_record.json files.
+
+        Archived episode dirs (the ``ARCHIVED_MARKER`` suffix a retry leaves behind
+        via ``storage.archive_episode``) are skipped — they hold the *superseded*
+        attempt's record, and counting both attempts would double-count the task in
+        every consumer (journal/EEE avg_score, samples bundle). Mirrors
+        ``ExperimentResult.iter_episode_statuses``.
+        """
         output_dir = Path(output_dir)
         experiment = ExperimentRecord.model_validate_json((output_dir / EXPERIMENT_RECORD_FILENAME).read_text())
         episodes: list[EpisodeRecord] = []
@@ -848,7 +856,7 @@ class EvalLog(TypedBaseModel):
         if episodes_dir.exists():
             for ep_dir in sorted(episodes_dir.iterdir()):
                 record_path = ep_dir / EPISODE_RECORD_FILENAME
-                if ep_dir.is_dir() and record_path.exists():
+                if ep_dir.is_dir() and _ARCHIVED_MARKER not in ep_dir.name and record_path.exists():
                     episodes.append(EpisodeRecord.model_validate_json(record_path.read_text()))
         return cls(experiment=experiment, episodes=episodes)
 

--- a/src/cube_harness/reproducibility/eee.py
+++ b/src/cube_harness/reproducibility/eee.py
@@ -18,13 +18,32 @@ This module is pure — no I/O beyond the experiment directory.
 
 from __future__ import annotations
 
+import importlib.resources
+import json
 import statistics
 from pathlib import Path
 from typing import Any
 
 from cube_harness.eval_log import EvalLog
 
-EEE_SCHEMA_VERSION = "0.2.2"
+
+def _installed_schema_version() -> str | None:
+    """The ``version`` embedded in the installed ``every-eval-ever`` schema.
+
+    The record's ``schema_version`` must state the schema it actually conforms
+    to — and validation (smoke + submit script) runs against whatever package is
+    installed, so a hard-coded constant drifts silently when that package is
+    bumped. None when the package isn't installed (it's an optional dep).
+    """
+    try:
+        text = importlib.resources.files("every_eval_ever").joinpath("schemas/eval.schema.json").read_text()
+        version = json.loads(text).get("version")
+        return version if isinstance(version, str) else None
+    except Exception:
+        return None
+
+
+EEE_SCHEMA_VERSION = _installed_schema_version() or "0.2.2"
 
 
 def _to_string_kvs(d: dict[str, Any]) -> dict[str, str]:
@@ -32,49 +51,46 @@ def _to_string_kvs(d: dict[str, Any]) -> dict[str, str]:
     return {k: str(v) for k, v in d.items() if v is not None}
 
 
-# Curated provider-prefix → display-name mapping. `str.title()` mangles
-# common prefixes (`openai` → `Openai`, `vertex_ai` → `Vertex_Ai`,
-# `huggingface` → `Huggingface`) and doesn't model multi-segment prefixes
-# where the model's actual developer is one level deeper (e.g.
-# `openrouter/anthropic/claude-*` is an Anthropic model served via
-# OpenRouter). Keep the map small + explicit; fall back to the prefix
-# verbatim when an unknown provider appears.
-_PROVIDER_DISPLAY_NAME: dict[str, str] = {
-    "openai": "OpenAI",
-    "azure": "Azure",
-    "anthropic": "Anthropic",
-    "google": "Google",
-    "vertex_ai": "Google Vertex AI",
-    "gemini": "Google",
-    "mistral": "Mistral",
-    "cohere": "Cohere",
-    "huggingface": "HuggingFace",
-    "bedrock": "AWS Bedrock",
-    "together_ai": "Together AI",
-    "fireworks_ai": "Fireworks AI",
-    "groq": "Groq",
-    "replicate": "Replicate",
-    "ollama": "Ollama",
+# EEE's schema splits who *made* the model (``model_info.developer``) from
+# whose API *served* it (``model_info.inference_platform``), and the live
+# datastore keys directories by lowercase developer slugs
+# (``data/GAIA/anthropic/…``, ``data/IFEval/meta-llama/…``). LiteLLM ids
+# conflate the two in the prefix, so map explicitly:
+#   anthropic/claude-*            → developer=anthropic,  platform=anthropic
+#   azure/gpt-*                   → developer=openai,     platform=azure
+#   openrouter/anthropic/claude-* → developer=anthropic,  platform=openrouter
+#   together_ai/meta-llama/L-3-*  → developer=meta-llama, platform=together_ai
+_HOST_IMPLIES_DEVELOPER: dict[str, str] = {
+    # LiteLLM's `azure/` prefix is Azure OpenAI — the models are OpenAI's.
+    "azure": "openai",
+}
+# Developer-owned API prefixes whose slug differs from the developer's
+# canonical (datastore) name.
+_DEVELOPER_ALIASES: dict[str, str] = {
+    "gemini": "google",
+    "vertex_ai": "google",
 }
 
 
-def _llm_developer(llm_model: str | None) -> str:
-    """Best-effort extraction of the model developer from a LiteLLM-style id.
+def _developer_and_platform(llm_model: str | None) -> tuple[str, str]:
+    """Best-effort ``(developer, inference_platform)`` slugs from a LiteLLM id.
 
-    Handles the common single-prefix case (``openai/gpt-4o`` → ``OpenAI``)
-    and the routed-provider case (``openrouter/anthropic/claude-3-5`` →
-    ``Anthropic``). Falls back to the verbatim prefix when neither segment
-    matches a known provider, and to ``""`` when no prefix is present.
+    Returns ``("", "")`` when no provider prefix is present. Unknown prefixes
+    pass through lowercased rather than being dropped — a wrong-but-present
+    slug is reviewable in the EEE PR; an empty one is silently lost.
     """
     if not llm_model or "/" not in llm_model:
-        return ""
+        return "", ""
     segments = llm_model.split("/")
-    # Routed prefixes (openrouter, bedrock proxy, etc.) put the actual
-    # developer in segment 1; check that first, then fall back to segment 0.
-    if len(segments) >= 3 and segments[1].lower() in _PROVIDER_DISPLAY_NAME:
-        return _PROVIDER_DISPLAY_NAME[segments[1].lower()]
-    first = segments[0].lower()
-    return _PROVIDER_DISPLAY_NAME.get(first, segments[0])
+    platform = segments[0].lower()
+    if len(segments) >= 3:
+        # Routed provider (openrouter, together_ai, huggingface, …): the
+        # actual developer is the middle segment.
+        developer = segments[1].lower()
+        return _DEVELOPER_ALIASES.get(developer, developer), platform
+    if platform in _HOST_IMPLIES_DEVELOPER:
+        return _HOST_IMPLIES_DEVELOPER[platform], platform
+    return _DEVELOPER_ALIASES.get(platform, platform), platform
 
 
 def build_eee_record(
@@ -112,6 +128,10 @@ def build_eee_record(
 
     provenance = _to_string_kvs(
         {
+            # The harness run name — no longer part of evaluation_id (which
+            # follows EEE's eval/model/timestamp convention), so keep it here
+            # to link the record back to the experiment dir.
+            "cube_harness_run_id": exp.evaluation_id,
             "cube_harness_version": exp.eval_library.version,
             "cube_harness_git_commit": exp.agent.git_commit,
             "cube_harness_git_remote_url": exp.agent.git_remote_url,
@@ -137,19 +157,24 @@ def build_eee_record(
         "name": exp.agent.llm_model or "",
         "id": exp.agent.llm_model or "",
     }
-    developer = _llm_developer(exp.agent.llm_model)
+    developer, inference_platform = _developer_and_platform(exp.agent.llm_model)
     if developer:
         model_info["developer"] = developer
+    if inference_platform:
+        model_info["inference_platform"] = inference_platform
 
     # `exp.agent.llm_model` can be None when the harness couldn't infer the
     # model name from the agent config. Stringify defensively so the EEE id
     # doesn't end up as "miniwob/None/…" (W3) — "unknown" is a clearer signal
     # to a reader and collides less catastrophically than the literal "None".
-    llm_model_segment = exp.agent.llm_model or "unknown"
+    # EEE's id convention is ``eval_name/model_id/timestamp`` with the model's
+    # slashes flattened to ``_`` (e.g. ``GAIA/anthropic_claude-3-7-sonnet-
+    # 20250219/1744624699.0`` in the live datastore).
+    llm_model_segment = (exp.agent.llm_model or "unknown").replace("/", "_")
 
     record: dict[str, Any] = {
         "schema_version": EEE_SCHEMA_VERSION,
-        "evaluation_id": f"{cube_id}/{llm_model_segment}/{exp.evaluation_id}",
+        "evaluation_id": f"{cube_id}/{llm_model_segment}/{exp.evaluation_timestamp}",
         "retrieved_timestamp": str(int(exp.evaluation_timestamp)),
         "evaluation_timestamp": str(int(exp.evaluation_timestamp)),
         "source_metadata": source_metadata,

--- a/src/cube_harness/reproducibility/journal.py
+++ b/src/cube_harness/reproducibility/journal.py
@@ -11,6 +11,7 @@ This module is pure — no I/O beyond reading the experiment directory.
 from __future__ import annotations
 
 import json
+import re
 import statistics
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,11 @@ JOURNAL_SCHEMA_VERSION = "1.0"
 # Slash → __ when sanitizing evaluation_id into a filename stem (matches
 # cube-registry's results_check.py).
 _FILENAME_REPLACE = str.maketrans({"/": "__"})
+
+# Mirrors results-schema.json's evaluation_id pattern. Checked locally so a bad
+# submitter handle (e.g. a git user.name with spaces) fails before a PR is
+# opened, not in registry CI after.
+_EVALUATION_ID_RE = re.compile(r"^[A-Za-z0-9_./-]{1,128}$")
 
 
 @dataclass
@@ -202,9 +208,17 @@ def build_journal_record(
     if max_steps is not None:
         results_dict["max_steps_per_episode"] = max_steps
 
+    evaluation_id = f"{submitter}/{exp.evaluation_id}"
+    if not _EVALUATION_ID_RE.match(evaluation_id):
+        raise ValueError(
+            f"evaluation_id {evaluation_id!r} does not match the registry's "
+            f"{_EVALUATION_ID_RE.pattern!r} pattern — pass --submitter with a plain "
+            "GitHub handle (no spaces or special characters)"
+        )
+
     record: dict[str, Any] = {
         "schema_version": JOURNAL_SCHEMA_VERSION,
-        "evaluation_id": f"{submitter}/{exp.evaluation_id}",
+        "evaluation_id": evaluation_id,
         "evaluation_timestamp": exp.evaluation_timestamp,
         "eval_library": {
             "name": exp.eval_library.name,
@@ -250,7 +264,27 @@ def build_journal_submission(
     """
     record = build_journal_record(experiment_dir, submitter=submitter, cube_id=cube_id)
     bundle = samples.build_samples_bundle(experiment_dir)
-    agg = samples.aggregate_from_samples(samples.iter_samples(bundle))
+    rows = samples.iter_samples(bundle)
+    agg = samples.aggregate_from_samples(rows)
+
+    # A task must contribute exactly one sample. Duplicates mean stale data made
+    # it into the episode records (e.g. an archived retry attempt) — averaging
+    # them silently misreports the score, and no downstream gate can catch it
+    # because the summary and the bundle would be consistently wrong together.
+    sample_ids = [row.get("sample_id") for row in rows]
+    duplicates = sorted({sid for sid in sample_ids if sample_ids.count(sid) > 1})
+    if duplicates:
+        raise ValueError(
+            f"samples bundle has {len(duplicates)} duplicate sample_id(s) "
+            f"({duplicates[:5]}{'…' if len(duplicates) > 5 else ''}) — "
+            "each task must contribute exactly one episode record"
+        )
+    n_tasks = record["benchmark_subset"]["n_tasks"]
+    if len(rows) > n_tasks:
+        raise ValueError(
+            f"samples bundle has {len(rows)} rows but the subset only has {n_tasks} tasks — "
+            "episode records outnumber tasks"
+        )
 
     summary_avg = record["results"]["avg_score"]
     if agg["n_scored"] and agg["avg_score"] != summary_avg:

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -186,6 +187,12 @@ class TestBuildJournalRecord:
         record = build_journal_record(populated_exp_dir, submitter="alacoste")
         assert record["evaluation_id"] == "alacoste/20260404_195953_genny_miniwob"
 
+    def test_submitter_with_spaces_rejected_locally(self, populated_exp_dir: Path) -> None:
+        # A git user.name like "Ada Lovelace" fails the registry's evaluation_id
+        # pattern — must be caught before a PR is opened, not by registry CI.
+        with pytest.raises(ValueError, match="--submitter"):
+            build_journal_record(populated_exp_dir, submitter="Ada Lovelace")
+
     def test_schema_version_pinned(self, populated_exp_dir: Path) -> None:
         record = build_journal_record(populated_exp_dir, submitter="alacoste")
         assert record["schema_version"] == JOURNAL_SCHEMA_VERSION
@@ -231,35 +238,46 @@ class TestBuildEEERecord:
         assert extras["cube_harness_git_commit"] == "f" * 40
         assert extras["cube_standard_git_commit"] == "8" * 40
 
-    def test_model_developer_extracted_from_provider_prefix(self, populated_exp_dir: Path) -> None:
+    def test_developer_and_platform_split(self, populated_exp_dir: Path) -> None:
+        # azure/gpt-* is an OpenAI model served by Azure — EEE's schema keeps
+        # those in separate fields (developer vs inference_platform).
         record = build_eee_record(populated_exp_dir)
-        assert record["model_info"]["developer"] == "Azure"
+        assert record["model_info"]["developer"] == "openai"
+        assert record["model_info"]["inference_platform"] == "azure"
+
+    def test_evaluation_id_follows_eee_convention(self, populated_exp_dir: Path) -> None:
+        # eval_name/model_id/timestamp, model slashes flattened to "_" — the
+        # shape used by records in the live EEE datastore. The harness run
+        # name moves to source_metadata.additional_details.
+        record = build_eee_record(populated_exp_dir)
+        assert record["evaluation_id"] == "miniwob/azure_gpt-5.4-mini/1748560000.0"
+        extras = record["source_metadata"]["additional_details"]
+        assert extras["cube_harness_run_id"] == "20260404_195953_genny_miniwob"
 
 
 class TestProviderPrefixMapping:
-    """Coverage for the explicit prefix → display-name table (W4)."""
+    """Coverage for the (developer, inference_platform) slug extraction (W4)."""
 
     @pytest.mark.parametrize(
         "llm_model,expected",
         [
-            ("openai/gpt-4o", "OpenAI"),  # was "Openai"
-            ("azure/gpt-5.4-mini", "Azure"),
-            ("anthropic/claude-opus-4-7", "Anthropic"),
-            ("vertex_ai/gemini-2.0", "Google Vertex AI"),  # was "Vertex_Ai"
-            ("huggingface/llama", "HuggingFace"),  # was "Huggingface"
-            ("bedrock/anthropic.claude-3-5", "AWS Bedrock"),  # was "Bedrock"
-            ("openrouter/anthropic/claude-3-5-sonnet", "Anthropic"),  # 2-deep routing
-            ("together_ai/llama", "Together AI"),
-            ("groq/llama-3-70b", "Groq"),
-            ("nonexistent_provider/model", "nonexistent_provider"),  # fallback
-            ("", ""),
-            ("no-slash-model", ""),
+            ("openai/gpt-4o", ("openai", "openai")),
+            ("azure/gpt-5.4-mini", ("openai", "azure")),  # host implies developer
+            ("anthropic/claude-opus-4-7", ("anthropic", "anthropic")),
+            ("vertex_ai/gemini-2.0", ("google", "vertex_ai")),  # alias
+            ("gemini/gemini-2.5-pro", ("google", "gemini")),  # alias
+            ("openrouter/anthropic/claude-3-5-sonnet", ("anthropic", "openrouter")),  # routed
+            ("together_ai/meta-llama/Llama-3-70b", ("meta-llama", "together_ai")),  # routed
+            ("bedrock/anthropic.claude-3-5", ("bedrock", "bedrock")),  # best-effort passthrough
+            ("nonexistent_provider/model", ("nonexistent_provider", "nonexistent_provider")),
+            ("", ("", "")),
+            ("no-slash-model", ("", "")),
         ],
     )
-    def test_llm_developer_mapping(self, llm_model: str, expected: str) -> None:
-        from cube_harness.reproducibility.eee import _llm_developer
+    def test_developer_and_platform_mapping(self, llm_model: str, expected: tuple[str, str]) -> None:
+        from cube_harness.reproducibility.eee import _developer_and_platform
 
-        assert _llm_developer(llm_model) == expected
+        assert _developer_and_platform(llm_model) == expected
 
 
 class TestEEEEvaluationIdNoneSafety:
@@ -287,3 +305,34 @@ class TestEEEEvaluationIdNoneSafety:
         assert result["score_details"]["score"] == pytest.approx(0.25)
         assert "uncertainty" in result["score_details"]
         assert result["score_details"]["uncertainty"]["num_samples"] == 4
+
+
+class TestArchivedAttemptsExcluded:
+    """A retry archives the prior attempt's episode dir (``storage.archive_episode``)
+    with its episode_record.json still inside. EvalLog.load must skip those dirs,
+    or every consumer (journal/EEE avg_score, samples bundle) double-counts the task."""
+
+    def _archive_first_attempt(self, exp_dir: Path, task_id: str, new_score: float) -> None:
+        """Simulate _pre_claim: archive the live attempt, then write a fresh one."""
+        ep_dir = exp_dir / EPISODES_DIR / f"{task_id}_ep0"
+        shutil.copytree(ep_dir, ep_dir.parent / f"{ep_dir.name}.archived_1749000000.0")
+        retry = _ep_record(task_id, new_score)
+        (ep_dir / "episode_record.json").write_text(retry.model_dump_json(indent=2))
+
+    def test_load_skips_archived_episode_dirs(self, populated_exp_dir: Path) -> None:
+        self._archive_first_attempt(populated_exp_dir, "t_success", new_score=0.0)
+        log = EvalLog.load(populated_exp_dir)
+        assert len(log.episodes) == 4  # one per live attempt, archived copy ignored
+        assert sorted(ep.sample_id for ep in log.episodes) == [
+            "t_failure",
+            "t_max_steps",
+            "t_success",
+            "t_system_error",
+        ]
+
+    def test_journal_score_reflects_only_live_attempts(self, populated_exp_dir: Path) -> None:
+        # First attempt of t_success scored 1.0; the retry scored 0.0. Only the
+        # retry may count: avg over {0.0, 0.0, 0.0, 0.0} — not 1/5 (stale mixed in).
+        self._archive_first_attempt(populated_exp_dir, "t_success", new_score=0.0)
+        record = build_journal_record(populated_exp_dir, submitter="alacoste")
+        assert record["results"]["avg_score"] == 0.0

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -7,6 +7,8 @@ import json
 import statistics
 from pathlib import Path
 
+import pytest
+
 from cube_harness.eval_log import EvalLog
 from cube_harness.reproducibility import samples
 
@@ -95,3 +97,25 @@ class TestJournalSubmission:
         sub = build_journal_submission(tmp_path, submitter="tester")
         agg = samples.aggregate_from_samples(samples.iter_samples(sub.bundle))
         assert agg["avg_score"] == sub.record["results"]["avg_score"]
+
+    def test_duplicate_sample_ids_rejected(self, tmp_path: Path) -> None:
+        # Two episode records for the same task (e.g. a stale retry attempt that
+        # leaked into the episode set) must refuse to build — averaging both
+        # silently misreports the score and no downstream gate can catch it.
+        from cube_harness.reproducibility.journal import build_journal_submission  # noqa: PLC0415
+
+        exp = _exp_record(n_tasks=2)
+        episodes = [_ep_record("t0", 1.0), _ep_record("t1", 0.0), _ep_record("t0", 0.0)]
+        episodes[2].trajectory_id = "t0_ep1"  # distinct dir, same task
+        EvalLog(experiment=exp, episodes=episodes).save(tmp_path)
+        with pytest.raises(ValueError, match="duplicate sample_id"):
+            build_journal_submission(tmp_path, submitter="tester")
+
+    def test_more_samples_than_tasks_rejected(self, tmp_path: Path) -> None:
+        from cube_harness.reproducibility.journal import build_journal_submission  # noqa: PLC0415
+
+        exp = _exp_record(n_tasks=2)
+        episodes = [_ep_record(f"t{i}", 1.0) for i in range(3)]
+        EvalLog(experiment=exp, episodes=episodes).save(tmp_path)
+        with pytest.raises(ValueError, match="outnumber"):
+            build_journal_submission(tmp_path, submitter="tester")


### PR DESCRIPTION
Follow-up to #501/#502 — a review of the full EEE + registry submission path found one real correctness bug and several convention gaps. This PR fixes all of them.

## The bug: archived retry attempts corrupt published scores

`EvalLog.load` read `episode_record.json` from **archived** episode dirs (the `.archived_<ts>` copies `_pre_claim` leaves behind on a retry via `storage.archive_episode`), while `iter_episode_statuses` correctly skips them. Any resumed/retried run therefore double-counted the retried task in every consumer:

- journal + EEE `avg_score` averaged the stale attempt with the live one (repro: 3-task run with one retry published **0.5 instead of the true 0.333**),
- the samples bundle carried duplicate `sample_id` rows (`n_samples=4` vs `n_tasks=3`).

Nothing caught it: the local summary-vs-bundle consistency check and the registry CI verifier both re-derive the average from the *same poisoned episode set*, and the outcomes block (built from the correctly-filtered status files) still summed to `n_tasks`.

**Fix:** `EvalLog.load` skips `ARCHIVED_MARKER` dirs, mirroring `iter_episode_statuses`.

## Defense in depth (journal)

- `build_journal_submission` rejects duplicate `sample_id`s and bundles with more rows than `n_tasks` — fails fast locally instead of publishing a silently-wrong score if stale data ever leaks in again by another path.
- `evaluation_id` is validated against the registry's `^[A-Za-z0-9_./-]{1,128}$` pattern locally — a submitter handle with spaces (a typical `git user.name`) now fails with a pointer to `--submitter` *before* a PR is opened, not in registry CI after.
- `submit_to_journal.py` defaults the submitter to the actual GitHub login (`gh api user`) before the env/git-config heuristics, and gains the same `pending`/`failed` submission lifecycle `submit_to_eee.py` already had.

## EEE convention alignment

Verified against the live `evaleval/EEE_datastore` and the installed `every-eval-ever` schema:

- **developer vs inference_platform**: EEE's schema separates who *made* the model from whose API *served* it. `azure/gpt-*` now reports `developer=openai, inference_platform=azure` (was `developer="Azure"`, no platform). Routed ids (`openrouter/anthropic/...`) attribute the middle segment. Slugs are lowercase, matching datastore convention (`anthropic`, `meta-llama`, …).
- **evaluation_id** follows EEE's `eval/model/timestamp` shape with model slashes flattened (e.g. `miniwob/azure_gpt-5.4-mini/1748560000.0`); the harness run name moves to `source_metadata.additional_details.cube_harness_run_id` for back-reference.
- **datastore path layout**: `data/{benchmark}/{developer-slug}/{model-without-prefix}/{uuid}.json` — previously emitted display names with spaces (`Google Vertex AI`) and provider-prefixed model dirs (`azure__gpt-5.4-mini`).
- **EEE_SCHEMA_VERSION** is read from the installed package's embedded schema `version` instead of a hard-coded constant that drifts when the package is bumped.

## Verification

- `pytest tests/test_reproducibility.py tests/test_samples.py tests/test_eval_log.py tests/test_scan.py` — 146 passed (new: archived-attempt regression, dup-sample/over-count guards, submitter pattern rejection, developer/platform mapping table).
- Full suite: 1009 passed; the 4 failures present are pre-existing on clean `dev` (test_monitored_tool_compat async bridging + one recipe import; local-env, unrelated).
- Smokes: `eee_submit` OK (record validates against the real `every-eval-ever` schema with the new fields), `registry_full_submit` OK (valid accepted, tampered bundle rejected by the real registry verifier).

Deferred (noted for follow-up): emitting EEE `detailed_evaluation_results` (`<uuid>_samples.jsonl`, which the datastore supports) — we already build per-task bundles for the registry; and a registry-side duplicate-`sample_id` check in `results_check.py` (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)