### PR TITLE
fix(webarena): migrate wikipedia to kiwix-serve:3.8.0 [BLOCKED — needs volume fix + fidelity check]

### DIFF
--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "WebArena-Verified benchmark cube — 812 verified web automation tasks"
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard>=0.1.0rc8",
+    "cube-standard>=0.1.0rc10",  # VolumeSpec.extract (used by the wikipedia volume)
     "cube-browser-tool[bgym]>=0.3.0",
     "webarena-verified",
     "Pillow",
@@ -19,12 +19,6 @@ build-backend = "uv_build"
 
 [tool.uv-build]
 include = ["src/webarena_verified_cube/task_metadata.json"]
-
-[tool.uv.sources]
-# TODO: drop once cube-browser-tool 0.3.0 ships to PyPI.
-# Until then, 0.3.0 lives on cube-standard's dev branch
-# (cube-tools/cube-browser-tool subdirectory); PyPI only has <=0.2.0.
-cube-browser-tool = { git = "https://github.com/The-AI-Alliance/cube-standard", subdirectory = "cube-tools/cube-browser-tool" }
 
 [tool.ruff]
 fix = true

--- a/cubes/webarena-verified/src/webarena_verified_cube/resources.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/resources.py
@@ -89,7 +89,7 @@ WEBARENA_GITLAB = DockerServiceConfig(
 WEBARENA_WIKIPEDIA = DockerServiceConfig(
     name="webarena-wikipedia",
     scope="benchmark",
-    docker_images=["am1n3e/webarena-verified-wikipedia"],
+    docker_images=["ghcr.io/kiwix/kiwix-serve:3.8.0"],
     services={
         "wikipedia": 8888,  # web UI  (container port 8080)
         "wikipedia_ctrl": 8889,  # env-ctrl (container port 8874)
@@ -184,7 +184,7 @@ WEBARENA_ALL = DockerServiceConfig(
         "am1n3e/webarena-verified-shopping",
         "am1n3e/webarena-verified-reddit",
         "am1n3e/webarena-verified-gitlab",
-        "am1n3e/webarena-verified-wikipedia",
+        "ghcr.io/kiwix/kiwix-serve:3.8.0",
         "am1n3e/webarena-verified-map",
     ],
     services={

--- a/cubes/webarena-verified/src/webarena_verified_cube/resources.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/resources.py
@@ -107,6 +107,9 @@ WEBARENA_WIKIPEDIA = DockerServiceConfig(
             name="webarena_wikipedia_data",
             mount_path="/data",
             source_url="http://metis.lti.cs.cmu.edu/webarena-images/wikipedia_en_all_maxi_2022-05.zim",
+            # Raw .zim, not a tarball — copy into the volume verbatim so kiwix-serve
+            # finds it at /data/wikipedia_en_all_maxi_2022-05.zim (not tar -xf'd).
+            extract=False,
         ),
     ],
     endpoint_to_site={"wikipedia": "wikipedia"},

--- a/cubes/webarena-verified/src/webarena_verified_cube/resources.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/resources.py
@@ -86,6 +86,14 @@ WEBARENA_GITLAB = DockerServiceConfig(
 # ── wikipedia ─────────────────────────────────────────────────────────────────
 # Kiwix Wikipedia server.  23 tasks.
 # The ZIM file (~80 GB) is downloaded during provision() via VolumeSpec.
+#
+# We use the upstream multi-arch ghcr.io/kiwix/kiwix-serve image rather than
+# am1n3e/webarena-verified-wikipedia (used for the other five sites): that image
+# is published arm64-only — the only one of the six am1n3e WebArena images not
+# built for amd64 — so it fails to start on the amd64 hosts where the rest of the
+# suite runs. kiwix-serve is the upstream server am1n3e wraps, so it serves the
+# same ZIM (only the am1n3e env-control service on :8874 is dropped, which
+# read-only wikipedia does not use).
 WEBARENA_WIKIPEDIA = DockerServiceConfig(
     name="webarena-wikipedia",
     scope="benchmark",
@@ -184,7 +192,7 @@ WEBARENA_ALL = DockerServiceConfig(
         "am1n3e/webarena-verified-shopping",
         "am1n3e/webarena-verified-reddit",
         "am1n3e/webarena-verified-gitlab",
-        "ghcr.io/kiwix/kiwix-serve:3.8.0",
+        "ghcr.io/kiwix/kiwix-serve:3.8.0",  # not am1n3e: that wikipedia image is arm64-only (see WEBARENA_WIKIPEDIA)
         "am1n3e/webarena-verified-map",
     ],
     services={

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/all_sites_launch.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/all_sites_launch.sh
@@ -29,7 +29,8 @@ docker run -d --name webarena_gitlab \
 docker run -d --name webarena_wikipedia \
     -p 8888:8080 -p 8889:8874 \
     -v webarena_wikipedia_data:/data \
-    am1n3e/webarena-verified-wikipedia
+    ghcr.io/kiwix/kiwix-serve:3.8.0 \
+    /data/wikipedia_en_all_maxi_2022-05.zim
 
 # ── map (OSM + Nominatim + OSRM — 9 volumes pre-populated by VolumeSpec) ─────
 docker run -d --name webarena_map \

--- a/cubes/webarena-verified/src/webarena_verified_cube/scripts/wikipedia_launch.sh
+++ b/cubes/webarena-verified/src/webarena_verified_cube/scripts/wikipedia_launch.sh
@@ -8,7 +8,8 @@ docker run -d \
     -p 8888:8080 \
     -p 8889:8874 \
     -v webarena_wikipedia_data:/data \
-    am1n3e/webarena-verified-wikipedia
+    ghcr.io/kiwix/kiwix-serve:3.8.0 \
+    /data/wikipedia_en_all_maxi_2022-05.zim
 
 healthy=0
 for i in $(seq 1 60); do


### PR DESCRIPTION
Split out of #464 (reddit + diagnostics landed there). Migrates the wikipedia
site to upstream multi-arch `ghcr.io/kiwix/kiwix-serve:3.8.0`.

Depends-on: cube-standard/fix/volume-raw-file

### Why (architecture)
`am1n3e/webarena-verified-wikipedia` is published **arm64-only** — the only one
of the six am1n3e WebArena images not built for amd64 — so it won't start on the
amd64 hosts the rest of the suite runs on, and there's no amd64 tag to fall back
to (both `latest` and `1.0.0` are arm64). `kiwix-serve` is the upstream multi-arch
server am1n3e wraps; it serves the same ZIM on amd64 + arm64. See
ServiceNow/webarena-verified#41 (asking upstream to republish amd64 — if they do,
this PR can be closed).

### Status of the original blockers
1. ~~Volume population (`tar -xf` on a bare `.zim`)~~ → **fixed** by
   cube-standard#230 (`VolumeSpec.extract=False`); this PR sets `extract=False`
   on the wikipedia volume so the raw ZIM is copied to
   `/data/wikipedia_en_all_maxi_2022-05.zim`. **Merge cube-standard#230 first.**
2. **Faithfulness** — largely de-risked: the only feature vanilla kiwix drops is
   the am1n3e env-control service on `:8874`, which this cube never uses
   (`benchmark.py` discards all `*_ctrl` endpoints; reset is Playwright re-nav;
   healthcheck probes the web UI). Remaining question is just whether kiwix-serve
   3.8.0 renders/searches the ZIM identically — worth one local smoke. cc @younik

### To merge
1. Merge cube-standard#230.
2. Local smoke: provision wikipedia, confirm the container serves articles.
3. Mark this ready & merge.