### PR TITLE
docs: point CONTRIBUTING at canonical RELEASING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ recipes/            # Example experiment scripts
 tests/              # Test suite
 ```
 
+## Releases
+
+Releases are tag-driven and cross-repo (cube-harness packages publish in tiers 4–5, after cube-standard). The full runbook — promoting `dev`→`main`, the dependency tiers, and the `scripts/release.py` driver — is canonical in cube-standard's [`RELEASING.md`](https://github.com/The-AI-Alliance/cube-standard/blob/main/RELEASING.md).
+
 ## Licenses
 
 - **Code** — Apache 2.0 ([LICENSE.Apache-2.0](LICENSE.Apache-2.0))


### PR DESCRIPTION
Adds a short **Releases** pointer in `CONTRIBUTING.md` to cube-standard's [`RELEASING.md`](https://github.com/The-AI-Alliance/cube-standard/blob/main/RELEASING.md) (added in cube-standard #224).

The release runbook is inherently cross-repo (cube-harness packages publish in tiers 4–5, after cube-standard; the `scripts/release.py` driver lives in cube-standard). A pointer keeps a single source of truth and avoids the two copies drifting — consistent with how this CONTRIBUTING already defers upstream for philosophy/RFC/DCO.

Docs only. Pairs with cube-standard #224 (merge that first so the link resolves on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)