### PR TITLE
release prep: cube-harness 0.1.0rc1 + cube version bumps

### DIFF
--- a/cubes/miniwob/pyproject.toml
+++ b/cubes/miniwob/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "miniwob-cube"
-version = "1.0.0"
+version = "1.1.0"
 description = "MiniWob++ benchmark for cube"
 requires-python = ">=3.12"
 dependencies = [

--- a/cubes/osworld-cube/pyproject.toml
+++ b/cubes/osworld-cube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osworld-cube"
-version = "0.2.0"
+version = "0.3.0"
 description = "OSWorld benchmark ported to the CUBE protocol"
 requires-python = ">=3.12"
 dependencies = [

--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webarena-verified-cube"
-version = "1.0.0"
+version = "1.1.0"
 description = "WebArena-Verified benchmark cube — 812 verified web automation tasks"
 requires-python = ">=3.12"
 dependencies = [

--- a/cubes/workarena/pyproject.toml
+++ b/cubes/workarena/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workarena-cube"
-version = "1.0.0"
+version = "1.1.0"
 description = "WorkArena ServiceNow benchmark for cube"
 requires-python = ">=3.12,<3.13"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "cube-harness"
-version = "0.1.0"
+version = "0.1.0rc1"
 description = "cube-harness, open source agentic evaluation and data generation framework."
 readme = "README.md"
 authors = [
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "cube-standard",
+    "cube-standard>=0.1.0rc9",
     "cube-browser-playwright>=0.2.0",  # used by cubes/workarena (PlaywrightSessionConfig)
     "pydantic~=2.0",
     "litellm~=1.80.8",


### PR DESCRIPTION
Prep for cube-harness's first PyPI publish (tier 4).

- version `0.1.0` → `0.1.0rc1` (onto the rc line, matching cube-standard).
- dependency `cube-standard` → `cube-standard>=0.1.0rc9` (the published floor; `0.1.0rc9` is live on PyPI). The `[tool.uv.sources]` git/dev override stays for local dev and is stripped from the built wheel.

Part of the cross-repo release per [RELEASING.md](https://github.com/The-AI-Alliance/cube-standard/blob/main/RELEASING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)