### PR TITLE
feat(metrics): always-on episode profiling foundation (phase + resource)

### DIFF
--- a/.claude/skills/auto-cube-profile/SKILL.md
+++ b/.claude/skills/auto-cube-profile/SKILL.md
@@ -1,0 +1,1 @@
+../../../src/cube_harness/auto_cube/use_cases/profile/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,10 @@ Auto-CUBE agent's system prompt) and an optional `investigator_extra.md`
   right regularization level (low-reg task-hint cheat → promoted task
   clarification / benchmark prompt / action description / new action /
   system prompt). Invoked as `/auto-cube-hinter`.
+- **`profile`** — efficiency: finds where episodes spend wall-clock /
+  resources (phase × resource Pareto via `ch-profile`), optimizes the top
+  *actionable* bottleneck, and A/B-verifies the fix. Uses the aggregate
+  rollup, not a per-trajectory Investigator. Invoked as `/auto-cube-profile`.
 
 `scripts/sync_auto_cube_skills.py` symlinks each SKILL.md into
 `.claude/skills/auto-cube-<name>/` and creates the `auto-cube → debug`

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -21,9 +21,13 @@ class Storage(Protocol):
     def write_episode_status(self, trajectory_id: str, status: EpisodeStatus) -> None
     def read_episode_status(self, trajectory_id: str) -> EpisodeStatus | None
     def archive_episode(self, trajectory_id: str) -> None
+    def episode_dir(self, trajectory_id: str) -> Path | None
 ```
 
-Custom backends (cloud storage, DB) must implement all seven.
+Custom backends (cloud storage, DB) must implement all eight. `episode_dir`
+returns the on-disk artifact directory for an episode (where side artifacts
+like `profile.json` land), or `None` for non-persistent storage
+(`InMemoryStorage`).
 
 ### `FileStorage`
 Writes V2 only. Reads V2 + V1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "msgpack>=1.0.0",
     "zstandard>=0.20.0",
     "docker>=7.1.0",
+    "psutil>=5.9.0",
 ]
 
 [project.optional-dependencies]
@@ -81,6 +82,7 @@ ch-investigate = "cube_harness.analyze.investigator:main"
 ch-investigation-report = "cube_harness.analyze.investigation_report:main"
 ch-reset-episodes = "cube_harness.analyze.reset_episodes:main"
 ch-rollout = "cube_harness.rl.__main__:cli"
+ch-profile = "cube_harness.metrics.profile_rollup:cli"
 
 [dependency-groups]
 dev = [

--- a/scripts/smoke/profile_end_to_end.py
+++ b/scripts/smoke/profile_end_to_end.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""SMOKE: episode profiling end-to-end through the real sequential runner.
+
+Runs a tiny **arithmetic-cube** experiment (pure-python, no infra, no LLM) with
+`Experiment(profile=ProfileConfig(...))` and verifies the full profiling
+pipeline the Auto-CUBE profile use-case relies on:
+
+  - every solved episode writes a `profile.json` beside its trajectory;
+  - it carries all four phases (setup / agent_loop / evaluate / teardown) with
+    non-negative wall-clock, plus host resource series (cpu_percent, rss_mb);
+  - `ch-profile`'s `build_rollup` aggregates them into a phase Pareto table whose
+    shares are sane and whose owner tags resolve;
+  - a run WITHOUT profiling writes no profile.json (zero footprint when off).
+
+The scripted agent replays arithmetic-cube's own deterministic debug actions, so
+rewards are real (1.0) and the agent_loop phase contains genuine tool dispatch —
+this exercises the real Episode body, not a stub.
+
+Run:
+    .venv/bin/python scripts/smoke/profile_end_to_end.py
+
+Prints SMOKE OK|FAIL|SKIP: profile_end_to_end  (exit 0|1|2).
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from cube.core import Action, ActionSchema, Observation
+
+from cube_harness.agent import Agent, AgentConfig
+from cube_harness.core import AgentOutput
+from cube_harness.exp_runner import run_sequentially
+from cube_harness.experiment import Experiment
+from cube_harness.metrics.profile_rollup import build_rollup
+from cube_harness.metrics.profiler import (
+    PHASE_AGENT_LOOP,
+    PHASE_EVALUATE,
+    PHASE_SETUP,
+    PHASE_TEARDOWN,
+    EpisodeProfile,
+    ProfileConfig,
+)
+
+NAME = "profile_end_to_end"
+
+
+class _ScriptedArithmeticAgentConfig(AgentConfig):
+    """Drives arithmetic-cube via its own deterministic debug actions (no LLM)."""
+
+    name: str = "scripted_arithmetic"
+
+    def make(self, action_set: list[ActionSchema] | None = None, **kwargs) -> "Agent":
+        _ = action_set
+        task_id = str(kwargs.get("task_id", ""))
+        return _ScriptedAgent(config=self, task_id=task_id)
+
+
+class _ScriptedAgent(Agent):
+    name = "ScriptedArithmeticAgent"
+    description = "Replays arithmetic-cube debug actions, then stops."
+    input_content_types = ["text"]
+    output_content_types = ["action"]
+
+    def __init__(self, config: _ScriptedArithmeticAgentConfig, task_id: str) -> None:
+        super().__init__(config)
+        from arithmetic_cube.debug import make_debug_agent  # noqa: PLC0415 - cube only needed for this smoke
+
+        self._debug = make_debug_agent(task_id)
+        self._first = True
+
+    def step(self, obs: Observation) -> AgentOutput:
+        # Spend a beat on the first step so the agent_loop phase lasts long
+        # enough for the background resource sampler to capture a few ticks
+        # (arithmetic tasks otherwise finish in ~1ms — faster than one sample).
+        if self._first:
+            self._first = False
+            time.sleep(0.2)
+        try:
+            return AgentOutput(actions=[self._debug.get_action(obs)])
+        except StopIteration:
+            return AgentOutput(actions=[Action(name="final_step", arguments={})])
+
+
+def _run(out_dir: Path, *, profile: ProfileConfig | None) -> Experiment:
+    from arithmetic_cube import ARITHMETIC_CONFIGS  # noqa: PLC0415 - smoke-only cube dependency
+
+    exp = Experiment(
+        name=f"{NAME}_{'on' if profile else 'off'}",
+        output_dir=out_dir,
+        agent_config=_ScriptedArithmeticAgentConfig(),
+        benchmark_config=ARITHMETIC_CONFIGS["default"],
+        infra=None,  # arithmetic-cube needs no shared infrastructure
+        max_steps=4,
+        is_official=False,
+        profile=profile,
+    )
+    run_sequentially(exp)
+    return exp
+
+
+def main() -> int:
+    try:
+        import arithmetic_cube  # noqa: F401, PLC0415
+    except ImportError:
+        print(f"SMOKE SKIP: {NAME} (arithmetic-cube not installed — `uv pip install -e cubes/arithmetic-cube`)")
+        return 2
+
+    workdir = Path(tempfile.mkdtemp(prefix="profile-smoke-"))
+    try:
+        # --- 1. profiling ON ---
+        on_dir = workdir / "on"
+        exp_on = _run(on_dir, profile=ProfileConfig(sample_hz=20))
+        profiles = list((exp_on.output_dir / "episodes").glob("*/profile.json"))
+        if not profiles:
+            print(f"SMOKE FAIL: {NAME} — no profile.json written under {exp_on.output_dir}/episodes/")
+            return 1
+
+        prof = EpisodeProfile.load(profiles[0].parent)
+        assert prof is not None, "profile.json failed to load"
+        for phase in (PHASE_SETUP, PHASE_AGENT_LOOP, PHASE_EVALUATE, PHASE_TEARDOWN):
+            if phase not in prof.phases:
+                print(f"SMOKE FAIL: {NAME} — missing phase {phase!r} in {prof.phases}")
+                return 1
+            if prof.phases[phase] < 0:
+                print(f"SMOKE FAIL: {NAME} — negative duration for {phase}: {prof.phases[phase]}")
+                return 1
+        if "cpu_percent" not in prof.resources or "rss_mb" not in prof.resources:
+            print(f"SMOKE FAIL: {NAME} — resource series missing: {list(prof.resources)}")
+            return 1
+
+        # --- 2. rollup aggregates ---
+        rollup = build_rollup(exp_on.output_dir)
+        if rollup["episodes"] != len(profiles):
+            print(f"SMOKE FAIL: {NAME} — rollup saw {rollup['episodes']} != {len(profiles)} profiles")
+            return 1
+        share_sum = sum(p["share"] for p in rollup["phases"])
+        if not (0.0 < share_sum <= 1.01):
+            print(f"SMOKE FAIL: {NAME} — phase shares out of range: {share_sum}")
+            return 1
+        owners = {p["owner"] for p in rollup["phases"]}
+        if "?" in owners:
+            print(f"SMOKE FAIL: {NAME} — unresolved owner tag in {rollup['phases']}")
+            return 1
+
+        # --- 3. profiling OFF leaves no footprint ---
+        off_dir = workdir / "off"
+        exp_off = _run(off_dir, profile=None)
+        if list((exp_off.output_dir / "episodes").glob("*/profile.json")):
+            print(f"SMOKE FAIL: {NAME} — profile.json written when profile is None")
+            return 1
+
+        top = rollup["phases"][0]
+        print(
+            f"SMOKE OK: {NAME} — {rollup['episodes']} episodes profiled; "
+            f"top phase {top['phase']}={top['mean_s']:.3f}s ({top['share'] * 100:.0f}%, {top['owner']}); "
+            f"resources={list(prof.resources)}; off-run wrote no profile.json"
+        )
+        return 0
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cube_harness/auto_cube/README.md
+++ b/src/cube_harness/auto_cube/README.md
@@ -23,7 +23,8 @@ touch the benchmark.
 | `/auto-cube` (alias) | → debug | Defaults to the debug use-case |
 | `/auto-cube-debug` | debug | Curious-scientist sparse-coverage investigation; ships Fix Report PRs |
 | `/auto-cube-hinter` | hinter | Raises benchmark performance by adding knowledge at the right regularization level (task-hint cheat → promoted clarification / benchmark prompt / action description / new action / system prompt); ships promotion PRs |
-| (future) | profile / optimization / capability | Plug into the same skeleton with different goals |
+| `/auto-cube-profile` | profile | Finds where episodes spend wall-clock/resources (phase × resource Pareto via `ch-profile`), optimizes the top *actionable* bottleneck, A/B-verifies the fix. Aggregate rollup — no per-trajectory Investigator |
+| (future) | optimization / capability | Plug into the same skeleton with different goals |
 
 Each use-case lives at `src/cube_harness/auto_cube/use_cases/<name>/` and
 exposes a `SKILL.md` (loaded as the agent's system prompt) plus an

--- a/src/cube_harness/auto_cube/use_cases/profile/SKILL.md
+++ b/src/cube_harness/auto_cube/use_cases/profile/SKILL.md
@@ -1,0 +1,142 @@
+# Auto-CUBE — profile use-case
+
+You are running the **profile** use-case of Auto-CUBE. Auto-CUBE is the
+iterate-and-fix outer loop; the profile use-case turns it toward
+**efficiency**: find where a cube's episodes actually spend wall-clock and
+resources, attack only the bottlenecks that matter, and **verify each
+optimization with an A/B re-run** before shipping it.
+
+Unlike `debug` / `hinter`, this use-case does **not** dispatch a
+per-trajectory Investigator. Profiling produces *aggregate* statistics, so
+the analysis step is a single rollup (`ch-profile`) over the run, not an
+LLM call per episode. (You *may* still dispatch the Investigator
+`profiling` use-case on a few outlier episodes when an aggregate bar is
+suspicious and you need scaffold-level detail — but that's the exception,
+not the loop.)
+
+## Your posture: performance engineer
+
+Profiling without a plan burns budget. Hold to three rules:
+
+1. **Measure before you cut.** Never optimize a phase you haven't seen
+   dominate the Pareto. The recurring lesson on this branch: the obvious
+   target (container fork) was a non-bottleneck; the real costs were
+   teardown grace and remote per-tool-call transport. Let the data pick.
+2. **Only tackle what's *yours* and *matters*.** Each bottleneck has an
+   owner — `infra` / `model` / `benchmark`. `model`-bound time
+   (generation) is not yours to fix here; `benchmark`-bound time
+   (`evaluate` re-running a suite) is a reward-cache question, not a
+   harness one. Spend on the top **actionable, infra/harness-owned** bar.
+3. **Verify the fix.** An optimization is a hypothesis until an A/B
+   re-run of the *same slice* shows the targeted phase's share dropped
+   and total wall-clock fell without a regression elsewhere.
+
+## What you collect
+
+Turn profiling on by setting `profile=ProfileConfig(...)` on the
+`Experiment` (or `RolloutConfig` for RL rollouts). Every episode then
+writes `episodes/<traj>/profile.json`
+([`cube_harness.metrics.profiler.EpisodeProfile`](../../../metrics/profiler.py)):
+
+- **phases** — coarse per-episode wall-clock: `setup` (provision + reset),
+  `agent_loop` (generation + tools), `evaluate` (verifier), `teardown`.
+- **resources** — host CPU% / RSS / IO / fds (+ GPU via NVML when
+  `gpu=True` and a self-hosted inference server shares the box).
+
+Keep it cheap and **leave it on** for the whole zoom-out — the sampler is
+~1–2 Hz and default-off elsewhere, so it costs almost nothing.
+
+> Coverage of the resource picture today: the sampler measures the
+> **episode-worker process** (harness side). Remote sandbox-interior
+> CPU/RAM/disk and the inference-server GPU service are **follow-ups** —
+> if the bottleneck looks like it lives inside the container or on the
+> GPU box, say so and flag it rather than guessing from host-side numbers.
+
+## The loop
+
+### 1. Session start
+- Pick a focus: a `<cube> × <infra>` whose throughput you want to
+  understand or improve. Set up the session worktree + `.venv` and export
+  `CH_EXP_DIR` (§ as in the [debug use-case](../debug/SKILL.md) / README).
+- Read `~/auto_cube/profile.json` (the cross-session bottleneck ledger,
+  loose schema) to see what's already characterized.
+
+### 2. Zoom out (broad, cheap, profiling on)
+- Run a broad task slice on a **cheap model** (you're profiling the
+  harness/infra, not model quality), single infra/config, with
+  `profile=ProfileConfig()`. Template:
+  [`templates/exp_config.py`](templates/exp_config.py).
+- Aggregate with **`ch-profile <exp_dir>`** → a phase Pareto table (mean s
+  / share of wall-clock / owner) plus resource peaks. This *is* the
+  analysis step. No per-trajectory dispatch.
+
+### 3. Pick the bottleneck → confirm → optimize
+- Choose the top **actionable** bar (skip `model`-bound; weigh
+  `benchmark`-bound separately). Resource peaks catch what the phase view
+  won't — a RAM/fd leak, an IO-bound teardown.
+- Confirm the *why* with deep, targeted profiling on that one hotspot:
+  `py-spy` / `pyinstrument` (sampling, attach to a worker) for "which
+  function", `cProfile` / `tracemalloc` for exact counts / allocation.
+  Anything goes while confirming (the [intervention discipline](../debug/SKILL.md)
+  applies — hack to confirm, then ship the principled fix).
+
+### 4. A/B verify → ship
+- Re-run the **same task slice** with the fix, `ch-profile` both, and
+  diff: did the targeted phase's share/seconds drop, did total wall-clock
+  fall, did nothing else regress? Put the before/after table in the Fix
+  Report — that *is* the evidence reviewers read.
+- Ship as a Fix Report PR per
+  [`openspec/specs/auto-fix/spec.md`](../../../../../openspec/specs/auto-fix/spec.md).
+  Update `~/auto_cube/profile.json` for the bar you moved.
+
+## Dispositions — from phases to action
+
+Map each Pareto bar onto one disposition (owner tag does most of the work):
+
+| Disposition | Trigger | What to do |
+|---|---|---|
+| **actionable** | `infra`/harness-owned phase or a resource peak, large share | Confirm + optimize + A/B verify + Fix Report. |
+| **model-bound** | `agent_loop` dominates, `owner=model` | Not this use-case's job — record and move on. |
+| **benchmark-bound** | `evaluate` dominates, `owner=benchmark` | Reward-caching / verifier question; note it, usually a separate RFC. |
+| **infra-bound (remote)** | bottleneck looks sandbox-interior or GPU-side | Beyond host-side sampling today — flag for the follow-up samplers. |
+| **noise** | below ~5% share, no resource peak | Leave it. Don't micro-optimize the tail. |
+
+A bar is "done" when it's been driven below noise, or classified
+model/benchmark/remote-bound, or shipped a verified Fix Report.
+
+## Ledger
+
+`~/auto_cube/profile.json` (cross-session, loose schema; evolve as you
+learn):
+
+```json
+{
+  "<cube>|<infra>|<phase|resource>": {
+    "share": 0.0,
+    "p50_s": 0.0,
+    "p95_s": 0.0,
+    "owner": "infra | model | benchmark",
+    "disposition": "actionable | model-bound | benchmark-bound | infra-bound | noise | shipped-fix",
+    "delta_after_fix": null,
+    "last_session": "<session-slug>",
+    "last_seen_utc": "2026-06-16T00:00:00Z",
+    "note": "<one line>"
+  }
+}
+```
+
+## Tooling
+
+- `Experiment(profile=ProfileConfig(...))` / `RolloutConfig(profile=...)` — turn it on.
+- `ch-profile <exp_dir> [--json out.json]` — the aggregate rollup.
+- [`scripts/smoke/profile_end_to_end.py`](../../../../../scripts/smoke/profile_end_to_end.py)
+  — end-to-end smoke (arithmetic-cube, no infra/LLM) proving the pipeline.
+- `py-spy` / `pyinstrument` / `cProfile` / `tracemalloc` — opt-in deep
+  confirmation on a single hotspot.
+
+## Templates
+
+- [`templates/exp_config.py`](templates/exp_config.py) — copy-and-edit
+  profiling run. Keep `is_official=False` — Auto-CUBE runs are iteration.
+- Reuse the [debug use-case](../debug/SKILL.md) session/report/notes
+  templates for the journal; the methodology skeleton is shared.

--- a/src/cube_harness/auto_cube/use_cases/profile/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/use_cases/profile/templates/exp_config.py
@@ -1,0 +1,55 @@
+"""Profile-use-case experiment config — Auto-CUBE session.
+
+Copied from a canonical recipe, edited for a profiling zoom-out. This file IS
+the config. Run it with the repo venv (not standalone uv) —
+
+    /path/to/cube-harness/.venv/bin/python <this_dir>/exp_config.py --limit 20
+
+Then aggregate the run into a phase Pareto table:
+
+    /path/to/cube-harness/.venv/bin/ch-profile <exp_dir>
+
+The point of a profiling run is breadth on a CHEAP model — you are profiling
+the harness/infra, not model quality. Leave profiling on for the whole slice;
+the sampler is ~1-2 Hz and costs almost nothing.
+"""
+
+from terminalbench2_cube import TERMINALBENCH2_CONFIGS
+
+from cube_harness.agents.genny_configs import GENNY_CONFIGS
+from cube_harness.experiment import Experiment
+from cube_harness.infra import INFRA_CONFIGS
+from cube_harness.llm import LLMConfig
+from cube_harness.metrics.profiler import ProfileConfig
+from cube_harness.recipe import run
+
+# --- vary per round -------------------------------------------------------
+
+TASK_IDS: list[str] = []  # empty = full benchmark; or an explicit subset to profile
+MODEL = "gpt-5.4-mini"  # cheap; you're profiling infra/harness, not the model
+COST_PER_TASK = 0.50
+
+# --- assemble -------------------------------------------------------------
+
+agent = GENNY_CONFIGS["swe"]
+agent.llm_config = LLMConfig(model_name=MODEL, temperature=1.0)
+agent.budget.cost_limit = COST_PER_TASK
+
+benchmark = TERMINALBENCH2_CONFIGS["default"]
+if TASK_IDS:
+    benchmark = benchmark.subset_from_list(TASK_IDS)
+
+exp = Experiment(
+    name="auto-cube-profile-r<N>",
+    agent_config=agent,
+    benchmark_config=benchmark,
+    infra=INFRA_CONFIGS["local"],
+    max_steps=agent.budget.max_actions or 60,
+    is_official=False,  # Auto-CUBE iteration run — never a submittable evaluation.
+    # Always-on profiling: phase wall-clock + host resource sampling. Set
+    # gpu=True only when a self-hosted inference server shares this host (RL).
+    profile=ProfileConfig(sample_hz=2.0, gpu=False),
+)
+
+if __name__ == "__main__":
+    run(exp)

--- a/src/cube_harness/episode.py
+++ b/src/cube_harness/episode.py
@@ -17,6 +17,16 @@ from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import TERMINAL_STATUSES, EpisodeStatus, next_retry_count
 from cube_harness.eval_log import EpisodeRecord
 from cube_harness.llm import is_permanent_llm_error
+from cube_harness.metrics.profiler import (
+    PHASE_AGENT_LOOP,
+    PHASE_EVALUATE,
+    PHASE_SETUP,
+    PHASE_TEARDOWN,
+    EpisodeProfile,
+    PhaseAccumulator,
+    ProfileConfig,
+    ResourceSampler,
+)
 from cube_harness.metrics.tracer import get_tracer
 from cube_harness.storage import FileStorage, Storage, TrajectoryView
 from cube_harness.streamer import EventStreamer, EventStreamerConfig
@@ -44,6 +54,11 @@ class EpisodeConfig(TypedBaseModel):
     recorder_config: EventStreamerConfig = Field(default_factory=EventStreamerConfig)
     write_eval_log: bool = True
     trajectory_id: str | None = None
+    # Opt-in episode profiling (resource sampling + phase timing). None ⇒
+    # no profiling, no overhead. Carried here so it survives Ray pickling
+    # and the resume path; both the standard runner (`Experiment.profile`)
+    # and the RL rollout path (`RolloutConfig.profile`) populate it.
+    profile: ProfileConfig | None = None
 
     @property
     def resolved_trajectory_id(self) -> str:
@@ -84,6 +99,7 @@ class Episode:
         recorder_config: EventStreamerConfig | None = None,
         write_eval_log: bool = True,
         trajectory_id: str | None = None,
+        profile: ProfileConfig | None = None,
     ) -> None:
         self.config = EpisodeConfig(
             id=id,
@@ -96,6 +112,7 @@ class Episode:
             recorder_config=recorder_config or EventStreamerConfig(),
             write_eval_log=write_eval_log,
             trajectory_id=trajectory_id,
+            profile=profile,
         )
         self._runtime_context = runtime_context
         self.storage = storage or FileStorage(output_dir)
@@ -123,6 +140,7 @@ class Episode:
             recorder_config=episode_config.recorder_config,
             write_eval_log=episode_config.write_eval_log,
             trajectory_id=episode_config.trajectory_id,
+            profile=episode_config.profile,
         )
 
     def run(self) -> TrajectoryView:
@@ -198,17 +216,25 @@ class Episode:
         streamer: EventStreamer | None = None
         max_steps_reached = False
 
+        # Opt-in profiling: resource sampler runs for the whole episode (only
+        # when `profile` is set); `phases` accumulates coarse per-phase
+        # wall-clock for profile.json. Phase boundaries are also OTel spans
+        # (trace-first) so they show in OTLP independently of profiling.
+        sampler = ResourceSampler(self.config.profile).start() if self.config.profile is not None else None
+        phases = PhaseAccumulator()
+
         try:
             with tracer.episode(task_id, experiment=self.config.exp_name) as episode_span:
                 start_time = ep_status.started_at
 
-                # 1. Build the live task and agent.
-                task = self.config.task_config.make(runtime_context=self._runtime_context)
-                action_set = task.action_set
-                agent = self.config.agent_config.make(action_set, task_id=task_id)
+                # 1. Build the live task and agent + reset the env (setup phase).
+                with tracer.span(PHASE_SETUP), phases.phase(PHASE_SETUP):
+                    task = self.config.task_config.make(runtime_context=self._runtime_context)
+                    action_set = task.action_set
+                    agent = self.config.agent_config.make(action_set, task_id=task_id)
 
-                # 2. Reset the env to get the initial observation.
-                obs, info = task.reset()
+                    # 2. Reset the env to get the initial observation.
+                    obs, info = task.reset()
                 initial = EnvironmentOutput(obs=obs, info=info)
 
                 agent_name = self.config.agent_config.agent_name
@@ -276,7 +302,8 @@ class Episode:
 
                 # 7. Drive the agent. agent.run is the canonical entry.
                 try:
-                    agent.run(initial.obs, env_tool)
+                    with phases.phase(PHASE_AGENT_LOOP):
+                        agent.run(initial.obs, env_tool)
                 except BudgetExceeded as e:
                     logger.info(colored(f"Budget exceeded: {e}", "yellow"))
                     streamer.record_failure(e)
@@ -306,7 +333,8 @@ class Episode:
                 # the outer except below tags status and propagates to the
                 # runner.
                 try:
-                    reward, info = task.evaluate()
+                    with tracer.span(PHASE_EVALUATE), phases.phase(PHASE_EVALUATE):
+                        reward, info = task.evaluate()
                 except Exception as e:
                     streamer.record_failure(e)
                     raise
@@ -382,8 +410,41 @@ class Episode:
             # task.close is best-effort; avoid masking the real exception.
             try:
                 if "task" in locals():
-                    task.close()
+                    with tracer.span(PHASE_TEARDOWN), phases.phase(PHASE_TEARDOWN):
+                        task.close()
             except Exception:
                 logger.exception("Failed to close task")
             tracer.shutdown()
+            if sampler is not None:
+                self._write_profile(sampler, phases, task_id, trajectory_id, ep_status)
         return self.storage.load_episode(trajectory_id)
+
+    def _write_profile(
+        self,
+        sampler: ResourceSampler,
+        phases: PhaseAccumulator,
+        task_id: str,
+        trajectory_id: str,
+        ep_status: EpisodeStatus,
+    ) -> None:
+        """Stop the sampler and persist ``profile.json`` beside the trajectory.
+
+        Best-effort: profiling must never fail an episode. Skipped when the
+        storage has no on-disk artifact directory (RL in-memory rollouts).
+        """
+        sampler.stop()
+        try:
+            ep_dir = self.storage.episode_dir(trajectory_id)
+            if ep_dir is None:
+                return
+            wall = (ep_status.ended_at or time.time()) - (ep_status.started_at or 0.0)
+            EpisodeProfile(
+                task_id=task_id,
+                trajectory_id=trajectory_id,
+                wall_time_s=wall,
+                phases=phases.totals(),
+                resources=sampler.summaries(),
+                sample_count=sampler.sample_count,
+            ).write(ep_dir)
+        except Exception:
+            logger.warning("Failed to write episode profile", exc_info=True)

--- a/src/cube_harness/experiment.py
+++ b/src/cube_harness/experiment.py
@@ -18,6 +18,7 @@ from cube_harness.episode import MAX_STEPS, Episode
 from cube_harness.episode_logs import trajectory_log_id
 from cube_harness.episode_status import RETRIABLE_STATUSES, EpisodeStatus, should_sweep_running_to_stale
 from cube_harness.eval_log import EvalLog, ExperimentRecord
+from cube_harness.metrics.profiler import ProfileConfig
 from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,11 @@ class Experiment(TypedBaseModel):
     max_cost_usd: Annotated[float, Field(gt=0)] | None = None
     max_retries: Annotated[int, Field(ge=0)] = 3
     git_cwd: str | None = None
+    profile: ProfileConfig | None = None
+    """Opt-in episode profiling (resource sampling + phase timing). ``None``
+    (default) ⇒ no profiling. Propagated onto every episode; each writes a
+    ``profile.json`` beside its trajectory. Aggregate across a run with
+    ``ch-profile``. Never affects scoring — `is_official` runs may set it."""
     debug_limit: int | None = None
     """If set, the runner truncates the task list to the first N entries.
 
@@ -211,6 +217,7 @@ class Experiment(TypedBaseModel):
                 max_cost_usd=self.max_cost_usd,
                 runtime_context=runtime_context,
                 storage=None,
+                profile=self.profile,
             )
             for i, tc in enumerate(task_configs)
         ]

--- a/src/cube_harness/metrics/profile_rollup.py
+++ b/src/cube_harness/metrics/profile_rollup.py
@@ -120,17 +120,40 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
         n_llm += bd.n_llm_calls
         n_tool += bd.n_tool_calls
         for name, stat in bd.tools.items():
-            agg = tools.setdefault(name, {"count": 0, "total_s": 0.0})
+            agg = tools.setdefault(name, {"count": 0, "total_s": 0.0, "min_s": stat.min_s, "max_s": 0.0})
             agg["count"] += stat.count
             agg["total_s"] += stat.total_s
+            agg["min_s"] = min(agg["min_s"], stat.min_s)
+            agg["max_s"] = max(agg["max_s"], stat.max_s)
     overhead_total = max(0.0, agent_loop_total - llm_total - tool_total)
     base = agent_loop_total or 1.0
+
+    # Transport-floor vs work decomposition. Every call of a tool pays at least
+    # that tool's cheapest observed call (min_s) = per-call RPC/transport floor.
+    # floor_total = Σ count×min is the time attributable to per-call overhead
+    # (addressable by batching / co-locating the agent with the sandbox); the
+    # remainder is in-container command work (≈ irreducible per rollout).
+    # Reclaimable ≈ floor minus one call kept per tool (you can't batch to zero).
+    floor_total = sum(v["count"] * v["min_s"] for v in tools.values())
+    one_call_floor = sum(v["min_s"] for v in tools.values())
+    work_total = max(0.0, tool_total - floor_total)
+    reclaimable = max(0.0, floor_total - one_call_floor)
+    tool_base = tool_total or 1.0
+
     tool_rows = sorted(
         (
-            {"tool": k, "mean_s": v["total_s"] / n, "calls": v["count"], "share_of_loop": v["total_s"] / base}
+            {
+                "tool": k,
+                "per_call_s": v["total_s"] / (v["count"] or 1),  # per-call mean (comparable to min/max)
+                "calls": v["count"],  # total across episodes
+                "min_s": v["min_s"],
+                "max_s": v["max_s"],
+                "share_of_loop": v["total_s"] / base,
+                "floor_frac": (v["count"] * v["min_s"]) / (v["total_s"] or 1.0),  # how transport-bound this tool is
+            }
             for k, v in tools.items()
         ),
-        key=lambda r: r["mean_s"],
+        key=lambda r: r["share_of_loop"],
         reverse=True,
     )
     return {
@@ -140,6 +163,13 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
             {"part": "tool_exec", "mean_s": tool_total / n, "share": tool_total / base, "owner": "infra/transport"},
             {"part": "overhead", "mean_s": overhead_total / n, "share": overhead_total / base, "owner": "harness"},
         ],
+        "tool_exec_split": {
+            "transport_floor_s": floor_total / n,
+            "transport_floor_frac": floor_total / tool_base,
+            "work_s": work_total / n,
+            "work_frac": work_total / tool_base,
+            "reclaimable_by_batching_s": reclaimable / n,
+        },
         "mean_llm_calls": n_llm / n,
         "mean_tool_calls": n_tool / n,
         "tools": tool_rows,
@@ -180,14 +210,29 @@ def _render(rollup: dict) -> str:
         ]
         for r in al["split"]:
             lines.append(f"  {r['part']:<14}{r['mean_s']:>10.2f}{r['share'] * 100:>8.1f}%  {r['owner']}")
+
+        tes = al.get("tool_exec_split") or {}
+        if tes:
+            lines += [
+                "",
+                "  why tool_exec dominates — transport-floor vs in-container work:",
+                f"    transport-floor : {tes['transport_floor_s']:8.2f}s/ep "
+                f"({tes['transport_floor_frac'] * 100:.0f}% of tool_exec)  ← per-call RPC; batch/co-locate",
+                f"    in-container work: {tes['work_s']:8.2f}s/ep "
+                f"({tes['work_frac'] * 100:.0f}% of tool_exec)  ← real command runtime; ≈irreducible",
+                f"    reclaimable by batching/co-location ≈ {tes['reclaimable_by_batching_s']:.2f}s/ep",
+            ]
         if al.get("tools"):
             lines += [
                 "",
-                "  per-tool (mean seconds / calls-per-ep / share of agent_loop):",
-                f"    {'tool':<16}{'mean_s':>10}{'calls':>8}{'share':>9}",
+                "  per-tool, per-call seconds (mean / min=floor / max) · total calls · share of loop · floor%=transport-bound:",
+                f"    {'tool':<14}{'per-call':>9}{'min':>8}{'max':>8}{'calls':>7}{'share':>8}{'floor%':>8}",
             ]
             for r in al["tools"]:
-                lines.append(f"    {r['tool']:<16}{r['mean_s']:>10.2f}{r['calls']:>8}{r['share_of_loop'] * 100:>8.1f}%")
+                lines.append(
+                    f"    {r['tool']:<14}{r['per_call_s']:>9.2f}{r['min_s']:>8.2f}{r['max_s']:>8.2f}"
+                    f"{r['calls']:>7}{r['share_of_loop'] * 100:>7.1f}%{r['floor_frac'] * 100:>7.0f}%"
+                )
 
     lines += [
         "",

--- a/src/cube_harness/metrics/profile_rollup.py
+++ b/src/cube_harness/metrics/profile_rollup.py
@@ -1,0 +1,144 @@
+"""``ch-profile`` — aggregate per-episode ``profile.json`` into a bottleneck map.
+
+This is the Tier-0 rollup of the Auto-CUBE profile use-case: instead of
+dispatching a per-trajectory Investigator, read the cheap always-on profiling
+artifacts an experiment already produced and Pareto-rank where wall-clock and
+resources actually go. The orchestrator reads the ranked table and only spends
+deeper profiling (py-spy/cProfile) on the top, *actionable* bars.
+
+Usage::
+
+    ch-profile ~/auto_cube/<session>/experiments/<exp_dir>
+    ch-profile <exp_dir> --json out.json
+
+It walks ``<exp_dir>/episodes/*/profile.json`` (the layout
+:class:`~cube_harness.metrics.profiler.EpisodeProfile` writes) and prints:
+
+- **Phase Pareto** — mean seconds per phase, share of episode wall-clock, and a
+  coarse owner tag (infra / model / benchmark) so non-actionable bars (e.g.
+  model-bound generation) are visually separated from addressable ones.
+- **Resource peaks** — p95/max of CPU/RSS/IO/GPU across episodes, to catch a
+  memory or fd leak the phase view won't show.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from cube_harness.metrics.profiler import PHASE_OWNER, EpisodeProfile
+
+logger = logging.getLogger(__name__)
+
+
+def _load_profiles(exp_dir: Path) -> list[EpisodeProfile]:
+    """Load every episode ``profile.json`` under an experiment dir.
+
+    Tolerant of either ``<exp_dir>/episodes/<id>/`` (canonical) or a flat dir
+    of profile files, and of being pointed straight at an episode dir.
+    """
+    profiles: list[EpisodeProfile] = []
+    for path in sorted(exp_dir.rglob("profile.json")):
+        try:
+            profiles.append(EpisodeProfile.model_validate_json(path.read_text()))
+        except Exception:
+            logger.warning("Skipping unreadable %s", path, exc_info=True)
+    return profiles
+
+
+def _aggregate_phases(profiles: list[EpisodeProfile]) -> list[dict]:
+    """Mean seconds and wall-clock share per phase, ranked descending."""
+    total_wall = sum(p.wall_time_s for p in profiles) or 1.0
+    sums: dict[str, float] = {}
+    for prof in profiles:
+        for name, secs in prof.phases.items():
+            sums[name] = sums.get(name, 0.0) + secs
+    n = len(profiles) or 1
+    rows = [
+        {
+            "phase": name,
+            "mean_s": total / n,
+            "share": total / total_wall,
+            "owner": PHASE_OWNER.get(name, "?"),
+        }
+        for name, total in sums.items()
+    ]
+    rows.sort(key=lambda r: r["mean_s"], reverse=True)
+    return rows
+
+
+def _aggregate_resources(profiles: list[EpisodeProfile]) -> list[dict]:
+    """Across-episode peak (max of per-episode p95, and absolute max) per series."""
+    series: dict[str, dict[str, float]] = {}
+    for prof in profiles:
+        for name, summ in prof.resources.items():
+            agg = series.setdefault(name, {"p95": 0.0, "max": 0.0, "mean_sum": 0.0, "n": 0.0})
+            agg["p95"] = max(agg["p95"], summ.p95)
+            agg["max"] = max(agg["max"], summ.max)
+            agg["mean_sum"] += summ.mean
+            agg["n"] += 1
+    rows = [
+        {"resource": name, "mean": agg["mean_sum"] / (agg["n"] or 1), "p95": agg["p95"], "max": agg["max"]}
+        for name, agg in series.items()
+    ]
+    rows.sort(key=lambda r: r["resource"])
+    return rows
+
+
+def build_rollup(exp_dir: Path) -> dict:
+    """Assemble the full rollup dict (also the ``--json`` payload)."""
+    profiles = _load_profiles(exp_dir)
+    return {
+        "exp_dir": str(exp_dir),
+        "episodes": len(profiles),
+        "mean_wall_s": (sum(p.wall_time_s for p in profiles) / len(profiles)) if profiles else 0.0,
+        "phases": _aggregate_phases(profiles),
+        "resources": _aggregate_resources(profiles),
+    }
+
+
+def _render(rollup: dict) -> str:
+    lines = [
+        f"Profile rollup — {rollup['exp_dir']}",
+        f"  episodes: {rollup['episodes']}   mean wall-clock: {rollup['mean_wall_s']:.1f}s",
+        "",
+        "Phase Pareto (mean seconds / share of wall-clock / owner):",
+        f"  {'phase':<14}{'mean_s':>10}{'share':>9}  owner",
+    ]
+    for r in rollup["phases"]:
+        lines.append(f"  {r['phase']:<14}{r['mean_s']:>10.2f}{r['share'] * 100:>8.1f}%  {r['owner']}")
+    lines += [
+        "",
+        "Resource peaks (mean / p95 / max across episodes):",
+        f"  {'resource':<18}{'mean':>10}{'p95':>10}{'max':>10}",
+    ]
+    for r in rollup["resources"]:
+        lines.append(f"  {r['resource']:<18}{r['mean']:>10.1f}{r['p95']:>10.1f}{r['max']:>10.1f}")
+    return "\n".join(lines)
+
+
+def main(
+    exp_dir: Annotated[Path, typer.Argument(help="Experiment dir holding episodes/*/profile.json.")],
+    json_out: Annotated[Path | None, typer.Option("--json", help="Also write the rollup as JSON to this path.")] = None,
+) -> None:
+    """Aggregate per-episode profiling into a Pareto bottleneck table."""
+    rollup = build_rollup(exp_dir)
+    if rollup["episodes"] == 0:
+        typer.echo(f"No profile.json found under {exp_dir} — run with Experiment(profile=ProfileConfig()).")
+        raise typer.Exit(code=1)
+    typer.echo(_render(rollup))
+    if json_out is not None:
+        json_out.write_text(json.dumps(rollup, indent=2))
+        typer.echo(f"\nWrote {json_out}")
+
+
+def cli() -> None:
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/cube_harness/metrics/profile_rollup.py
+++ b/src/cube_harness/metrics/profile_rollup.py
@@ -30,7 +30,8 @@ from typing import Annotated
 
 import typer
 
-from cube_harness.metrics.profiler import PHASE_OWNER, EpisodeProfile
+from cube_harness.metrics.profiler import PHASE_AGENT_LOOP, PHASE_OWNER, EpisodeProfile, breakdown_agent_loop
+from cube_harness.storage import FileStorage
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,62 @@ def _aggregate_resources(profiles: list[EpisodeProfile]) -> list[dict]:
     return rows
 
 
+def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict:
+    """Split the aggregate ``agent_loop`` wall-clock into llm / tool / overhead
+    plus a per-tool table, computed from each episode's persisted events.
+
+    Event-derived and post-hoc: works on any past run, no hot-path cost. The
+    ``overhead`` slice is the residual (agent_loop − llm − tool): parsing,
+    prompt build, obs formatting, serialization.
+    """
+    storage = FileStorage(exp_dir)
+    n = len(profiles) or 1
+    agent_loop_total = sum(p.phases.get(PHASE_AGENT_LOOP, 0.0) for p in profiles)
+    llm_total = tool_total = 0.0
+    n_llm = n_tool = 0
+    tools: dict[str, dict] = {}
+    covered = 0
+    for prof in profiles:
+        if not prof.trajectory_id:
+            continue
+        try:
+            view = storage.load_episode(prof.trajectory_id)
+        except Exception:
+            logger.warning("Could not load events for %s (skipping breakdown)", prof.trajectory_id, exc_info=True)
+            continue
+        bd = breakdown_agent_loop(view)
+        covered += 1
+        llm_total += bd.llm_wait_s
+        tool_total += bd.tool_exec_s
+        n_llm += bd.n_llm_calls
+        n_tool += bd.n_tool_calls
+        for name, stat in bd.tools.items():
+            agg = tools.setdefault(name, {"count": 0, "total_s": 0.0})
+            agg["count"] += stat.count
+            agg["total_s"] += stat.total_s
+    overhead_total = max(0.0, agent_loop_total - llm_total - tool_total)
+    base = agent_loop_total or 1.0
+    tool_rows = sorted(
+        (
+            {"tool": k, "mean_s": v["total_s"] / n, "calls": v["count"], "share_of_loop": v["total_s"] / base}
+            for k, v in tools.items()
+        ),
+        key=lambda r: r["mean_s"],
+        reverse=True,
+    )
+    return {
+        "episodes_covered": covered,
+        "split": [
+            {"part": "llm_wait", "mean_s": llm_total / n, "share": llm_total / base, "owner": "model"},
+            {"part": "tool_exec", "mean_s": tool_total / n, "share": tool_total / base, "owner": "infra/transport"},
+            {"part": "overhead", "mean_s": overhead_total / n, "share": overhead_total / base, "owner": "harness"},
+        ],
+        "mean_llm_calls": n_llm / n,
+        "mean_tool_calls": n_tool / n,
+        "tools": tool_rows,
+    }
+
+
 def build_rollup(exp_dir: Path) -> dict:
     """Assemble the full rollup dict (also the ``--json`` payload)."""
     profiles = _load_profiles(exp_dir)
@@ -97,6 +154,7 @@ def build_rollup(exp_dir: Path) -> dict:
         "episodes": len(profiles),
         "mean_wall_s": (sum(p.wall_time_s for p in profiles) / len(profiles)) if profiles else 0.0,
         "phases": _aggregate_phases(profiles),
+        "agent_loop": _aggregate_agent_loop(exp_dir, profiles) if profiles else {},
         "resources": _aggregate_resources(profiles),
     }
 
@@ -111,6 +169,26 @@ def _render(rollup: dict) -> str:
     ]
     for r in rollup["phases"]:
         lines.append(f"  {r['phase']:<14}{r['mean_s']:>10.2f}{r['share'] * 100:>8.1f}%  {r['owner']}")
+
+    al = rollup.get("agent_loop") or {}
+    if al.get("split"):
+        lines += [
+            "",
+            f"agent_loop breakdown (mean seconds / share of agent_loop / owner)"
+            f"  [{al.get('mean_llm_calls', 0):.1f} llm calls, {al.get('mean_tool_calls', 0):.1f} tool calls/ep]:",
+            f"  {'part':<14}{'mean_s':>10}{'share':>9}  owner",
+        ]
+        for r in al["split"]:
+            lines.append(f"  {r['part']:<14}{r['mean_s']:>10.2f}{r['share'] * 100:>8.1f}%  {r['owner']}")
+        if al.get("tools"):
+            lines += [
+                "",
+                "  per-tool (mean seconds / calls-per-ep / share of agent_loop):",
+                f"    {'tool':<16}{'mean_s':>10}{'calls':>8}{'share':>9}",
+            ]
+            for r in al["tools"]:
+                lines.append(f"    {r['tool']:<16}{r['mean_s']:>10.2f}{r['calls']:>8}{r['share_of_loop'] * 100:>8.1f}%")
+
     lines += [
         "",
         "Resource peaks (mean / p95 / max across episodes):",

--- a/src/cube_harness/metrics/profile_rollup.py
+++ b/src/cube_harness/metrics/profile_rollup.py
@@ -99,9 +99,12 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
     prompt build, obs formatting, serialization.
     """
     storage = FileStorage(exp_dir)
-    n = len(profiles) or 1
-    agent_loop_total = sum(p.phases.get(PHASE_AGENT_LOOP, 0.0) for p in profiles)
-    llm_total = tool_total = 0.0
+    # Aggregate only over episodes whose events we can load (covered); means
+    # divide by `covered`, not len(profiles), so RL in-memory rollouts / unreadable
+    # episodes don't dilute the per-episode numbers (or dump their agent_loop into
+    # the overhead bucket).
+    agent_loop_total = llm_total = tool_total = 0.0
+    floor_total = reclaimable_total = 0.0  # accumulated PER EPISODE (honest floors)
     n_llm = n_tool = 0
     tools: dict[str, dict] = {}
     covered = 0
@@ -115,29 +118,31 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
             continue
         bd = breakdown_agent_loop(view)
         covered += 1
+        agent_loop_total += prof.phases.get(PHASE_AGENT_LOOP, 0.0)
         llm_total += bd.llm_wait_s
         tool_total += bd.tool_exec_s
         n_llm += bd.n_llm_calls
         n_tool += bd.n_tool_calls
+        # Per-episode transport floor: each call pays at least this episode's
+        # cheapest call of that tool; what's reclaimable by batching is the
+        # floor on every call past the first (you can't collapse a tool to zero).
+        for stat in bd.tools.values():
+            floor_total += stat.count * stat.min_s
+            reclaimable_total += (stat.count - 1) * stat.min_s
         for name, stat in bd.tools.items():
-            agg = tools.setdefault(name, {"count": 0, "total_s": 0.0, "min_s": stat.min_s, "max_s": 0.0})
+            agg = tools.setdefault(
+                name, {"count": 0, "total_s": 0.0, "min_s": stat.min_s, "max_s": 0.0, "floor_s": 0.0}
+            )
             agg["count"] += stat.count
             agg["total_s"] += stat.total_s
-            agg["min_s"] = min(agg["min_s"], stat.min_s)
-            agg["max_s"] = max(agg["max_s"], stat.max_s)
+            agg["floor_s"] += stat.count * stat.min_s  # per-episode floor contribution (honest across episodes)
+            agg["min_s"] = min(agg["min_s"], stat.min_s)  # display only
+            agg["max_s"] = max(agg["max_s"], stat.max_s)  # display only
+
+    cov = covered or 1
     overhead_total = max(0.0, agent_loop_total - llm_total - tool_total)
     base = agent_loop_total or 1.0
-
-    # Transport-floor vs work decomposition. Every call of a tool pays at least
-    # that tool's cheapest observed call (min_s) = per-call RPC/transport floor.
-    # floor_total = Σ count×min is the time attributable to per-call overhead
-    # (addressable by batching / co-locating the agent with the sandbox); the
-    # remainder is in-container command work (≈ irreducible per rollout).
-    # Reclaimable ≈ floor minus one call kept per tool (you can't batch to zero).
-    floor_total = sum(v["count"] * v["min_s"] for v in tools.values())
-    one_call_floor = sum(v["min_s"] for v in tools.values())
     work_total = max(0.0, tool_total - floor_total)
-    reclaimable = max(0.0, floor_total - one_call_floor)
     tool_base = tool_total or 1.0
 
     tool_rows = sorted(
@@ -149,7 +154,7 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
                 "min_s": v["min_s"],
                 "max_s": v["max_s"],
                 "share_of_loop": v["total_s"] / base,
-                "floor_frac": (v["count"] * v["min_s"]) / (v["total_s"] or 1.0),  # how transport-bound this tool is
+                "floor_frac": v["floor_s"] / (v["total_s"] or 1.0),  # how transport-bound this tool is
             }
             for k, v in tools.items()
         ),
@@ -159,19 +164,19 @@ def _aggregate_agent_loop(exp_dir: Path, profiles: list[EpisodeProfile]) -> dict
     return {
         "episodes_covered": covered,
         "split": [
-            {"part": "llm_wait", "mean_s": llm_total / n, "share": llm_total / base, "owner": "model"},
-            {"part": "tool_exec", "mean_s": tool_total / n, "share": tool_total / base, "owner": "infra/transport"},
-            {"part": "overhead", "mean_s": overhead_total / n, "share": overhead_total / base, "owner": "harness"},
+            {"part": "llm_wait", "mean_s": llm_total / cov, "share": llm_total / base, "owner": "model"},
+            {"part": "tool_exec", "mean_s": tool_total / cov, "share": tool_total / base, "owner": "infra/transport"},
+            {"part": "overhead", "mean_s": overhead_total / cov, "share": overhead_total / base, "owner": "harness"},
         ],
         "tool_exec_split": {
-            "transport_floor_s": floor_total / n,
+            "transport_floor_s": floor_total / cov,
             "transport_floor_frac": floor_total / tool_base,
-            "work_s": work_total / n,
+            "work_s": work_total / cov,
             "work_frac": work_total / tool_base,
-            "reclaimable_by_batching_s": reclaimable / n,
+            "reclaimable_by_batching_s": reclaimable_total / cov,
         },
-        "mean_llm_calls": n_llm / n,
-        "mean_tool_calls": n_tool / n,
+        "mean_llm_calls": n_llm / cov,
+        "mean_tool_calls": n_tool / cov,
         "tools": tool_rows,
     }
 
@@ -205,7 +210,8 @@ def _render(rollup: dict) -> str:
         lines += [
             "",
             f"agent_loop breakdown (mean seconds / share of agent_loop / owner)"
-            f"  [{al.get('mean_llm_calls', 0):.1f} llm calls, {al.get('mean_tool_calls', 0):.1f} tool calls/ep]:",
+            f"  [{al.get('mean_llm_calls', 0):.1f} llm calls, {al.get('mean_tool_calls', 0):.1f} tool calls/ep"
+            f"; {al.get('episodes_covered', 0)}/{rollup['episodes']} episodes have events]:",
             f"  {'part':<14}{'mean_s':>10}{'share':>9}  owner",
         ]
         for r in al["split"]:

--- a/src/cube_harness/metrics/profiler.py
+++ b/src/cube_harness/metrics/profiler.py
@@ -1,0 +1,300 @@
+"""Always-on, low-overhead episode profiling.
+
+This module is the **foundation** for Auto-CUBE's profile use-case: turn a
+real (or RL-rollout) episode into a phase × resource breakdown cheap enough
+to leave on for every task, so the orchestrator can aggregate across a run
+and Pareto-rank the bottlenecks that actually matter.
+
+Design constraints (see the proposal in the Auto-CUBE README):
+
+- **Default off.** `ProfileConfig` is opt-in; when an episode has no config
+  the sampler never starts. The coarse phase timers (4 `perf_counter` pairs
+  per episode) run unconditionally — negligible, never on the inner loop.
+- **Transport-agnostic.** The same primitives serve the standard runner and
+  the RL rollout path — both build an :class:`~cube_harness.episode.Episode`,
+  so wiring lives at the episode level and both inherit it.
+- **Cheap tier first.** A background ``psutil`` sampler (~1-2 Hz) plus coarse
+  phase timers. Deep profilers (cProfile/tracemalloc/py-spy) and remote
+  sandbox / GPU sampling are deliberately *not* here — they are opt-in,
+  hotspot-targeted follow-ups that build on this schema.
+
+The unit that lands on disk is one ``profile.json`` per episode output dir,
+deserialisable as :class:`EpisodeProfile`. ``ch-profile`` aggregates them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import psutil
+from pydantic import BaseModel, Field
+
+try:  # optional: only used when ``ProfileConfig.gpu`` and an NVIDIA GPU is present
+    import pynvml
+except ImportError:  # pragma: no cover - exercised only on GPU hosts
+    pynvml = None
+
+logger = logging.getLogger(__name__)
+
+PROFILE_FILENAME = "profile.json"
+
+# Canonical phase taxonomy. Coarse on purpose — these map 1:1 onto the
+# episode lifecycle (see `Episode._run_episode`) and onto the agent-free
+# `profile_rollout_phases.py` script, so the live and offline profilers
+# agree on names. Finer LLM-wait vs tool-exec splits come from the OTel
+# spans the harness already emits and are joined in by the rollup.
+PHASE_SETUP = "setup"  # task.make() + task.reset() — provisioning + per-task prepare
+PHASE_AGENT_LOOP = "agent_loop"  # agent.run() — generation + tool exec (the dominant, model-bound term)
+PHASE_EVALUATE = "evaluate"  # task.evaluate() — re-runs the verifier; reuse-irreducible
+PHASE_TEARDOWN = "teardown"  # task.close() — container/sandbox teardown
+
+# Rough attribution of who owns a phase's cost — drives the rollup's
+# "is this worth fixing" tag. Coarse heuristic, overridable by the rollup.
+PHASE_OWNER = {
+    PHASE_SETUP: "infra",
+    PHASE_AGENT_LOOP: "model",
+    PHASE_EVALUATE: "benchmark",
+    PHASE_TEARDOWN: "infra",
+}
+
+
+class ProfileConfig(BaseModel):
+    """Opt-in profiling knobs, threaded onto an episode.
+
+    Carried on ``EpisodeConfig`` so it survives Ray serialisation and the
+    resume/retry path. ``Experiment.profile`` and the RL ``RolloutConfig``
+    both propagate into it. Absent (``None``) ⇒ no profiling, no overhead.
+    """
+
+    resource_sampling: bool = Field(
+        default=True,
+        description="Sample CPU/RSS/IO of the episode worker process tree in a background thread.",
+    )
+    sample_hz: float = Field(
+        default=2.0,
+        gt=0,
+        le=50,
+        description="Resource sampling frequency in Hz. 1-2 Hz is plenty for minute-scale episodes.",
+    )
+    gpu: bool = Field(
+        default=False,
+        description="Also sample local GPU (NVML) — only meaningful when a self-hosted inference "
+        "server shares this host (RL rollout). No-op if pynvml/NVIDIA is unavailable.",
+    )
+    phases: bool = Field(
+        default=True,
+        description="Record coarse per-phase wall-clock (setup/agent_loop/evaluate/teardown).",
+    )
+
+
+class ResourceSummary(BaseModel):
+    """Summary statistics for one resource series over an episode."""
+
+    samples: int = 0
+    mean: float = 0.0
+    p50: float = 0.0
+    p95: float = 0.0
+    max: float = 0.0
+
+
+class EpisodeProfile(BaseModel):
+    """The per-episode profiling artifact written to ``profile.json``.
+
+    Phase durations are seconds; resource summaries are per-series rollups.
+    Everything here is cheap to compute and small to store.
+    """
+
+    task_id: str = ""
+    trajectory_id: str = ""
+    wall_time_s: float = 0.0
+    phases: dict[str, float] = Field(default_factory=dict, description="Phase name → wall-clock seconds.")
+    resources: dict[str, ResourceSummary] = Field(
+        default_factory=dict,
+        description="Resource series name (cpu_percent, rss_mb, io_read_mb, io_write_mb, "
+        "num_fds, num_threads, gpu_util_percent, gpu_mem_mb) → summary.",
+    )
+    sample_count: int = 0
+
+    def write(self, output_dir: Path) -> Path:
+        path = Path(output_dir) / PROFILE_FILENAME
+        try:
+            path.write_text(self.model_dump_json(indent=2))
+        except Exception:
+            logger.warning("Failed to write %s", path, exc_info=True)
+        return path
+
+    @classmethod
+    def load(cls, output_dir: Path) -> EpisodeProfile | None:
+        path = Path(output_dir) / PROFILE_FILENAME
+        if not path.exists():
+            return None
+        try:
+            return cls.model_validate_json(path.read_text())
+        except Exception:
+            logger.warning("Failed to read %s", path, exc_info=True)
+            return None
+
+
+def _percentile(values: list[float], q: float) -> float:
+    """Nearest-rank percentile (q in [0, 1]). Empty ⇒ 0.0."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    idx = min(len(ordered) - 1, max(0, round(q * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def _summarize(values: list[float]) -> ResourceSummary:
+    if not values:
+        return ResourceSummary()
+    return ResourceSummary(
+        samples=len(values),
+        mean=sum(values) / len(values),
+        p50=_percentile(values, 0.50),
+        p95=_percentile(values, 0.95),
+        max=max(values),
+    )
+
+
+class PhaseAccumulator:
+    """Accumulates named phase wall-clock. Re-entrant-safe via nesting guard.
+
+    Phases are sequential in the episode body, so a simple start/stop is
+    enough; we still tolerate repeated entries by summing.
+    """
+
+    def __init__(self) -> None:
+        self._totals: dict[str, float] = {}
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._totals[name] = self._totals.get(name, 0.0) + (time.perf_counter() - start)
+
+    def totals(self) -> dict[str, float]:
+        return dict(self._totals)
+
+
+class ResourceSampler:
+    """Background-thread sampler of the current process tree.
+
+    Samples CPU%, RSS, IO bytes, fd/thread counts at ``sample_hz`` using
+    ``psutil``; optionally GPU via NVML. Best-effort: any missing backend
+    (no psutil, no NVIDIA) degrades to fewer series, never an error. The
+    sampler covers whatever process it runs in — the episode worker for the
+    standard/RL paths — plus its children (so an in-process browser/container
+    client is included; remote sandboxes are a separate, follow-up sampler).
+    """
+
+    def __init__(self, config: ProfileConfig) -> None:
+        self._config = config
+        self._series: dict[str, list[float]] = {}
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._proc: psutil.Process | None = None
+        self._gpu_handles: list = []
+
+        try:
+            self._proc = psutil.Process(os.getpid())
+            # Prime the cpu_percent counters so the first real sample is non-zero.
+            self._proc.cpu_percent(None)
+        except Exception:
+            self._proc = None
+            logger.debug("psutil process handle unavailable — resource sampling disabled", exc_info=True)
+
+        if config.gpu:
+            self._init_gpu()
+
+    def _init_gpu(self) -> None:
+        if pynvml is None:
+            logger.debug("pynvml unavailable — GPU sampling disabled")
+            return
+        try:
+            pynvml.nvmlInit()
+            count = pynvml.nvmlDeviceGetCount()
+            self._gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
+        except Exception:
+            self._gpu_handles = []
+            logger.debug("NVIDIA NVML init failed — GPU sampling disabled", exc_info=True)
+
+    def _record(self, name: str, value: float) -> None:
+        self._series.setdefault(name, []).append(value)
+
+    def _sample_once(self) -> None:
+        if self._config.resource_sampling and self._proc is not None:
+            try:
+                with self._proc.oneshot():
+                    self._record("cpu_percent", self._proc.cpu_percent(None))
+                    self._record("rss_mb", self._proc.memory_info().rss / 1e6)
+                    self._record("num_threads", float(self._proc.num_threads()))
+                    try:
+                        self._record("num_fds", float(self._proc.num_fds()))
+                    except Exception:
+                        pass  # not available on all platforms
+                    try:
+                        io = self._proc.io_counters()
+                        self._record("io_read_mb", io.read_bytes / 1e6)
+                        self._record("io_write_mb", io.write_bytes / 1e6)
+                    except Exception:
+                        pass  # macOS denies io_counters without privileges
+            except Exception:
+                logger.debug("resource sample failed", exc_info=True)
+
+        if self._gpu_handles and pynvml is not None:
+            try:
+                util = max(pynvml.nvmlDeviceGetUtilizationRates(h).gpu for h in self._gpu_handles)
+                mem = max(pynvml.nvmlDeviceGetMemoryInfo(h).used / 1e6 for h in self._gpu_handles)
+                self._record("gpu_util_percent", float(util))
+                self._record("gpu_mem_mb", float(mem))
+            except Exception:
+                logger.debug("gpu sample failed", exc_info=True)
+
+    def _loop(self) -> None:
+        interval = 1.0 / self._config.sample_hz
+        while not self._stop.wait(interval):
+            self._sample_once()
+
+    def start(self) -> ResourceSampler:
+        """Start the background sampling thread (idempotent, best-effort).
+
+        Starts if either source is active and available — host resource
+        sampling (``resource_sampling`` + psutil) OR GPU sampling
+        (``gpu`` + NVML). The two knobs are independent.
+        """
+        if self._thread is not None:
+            return self
+        host_active = self._config.resource_sampling and self._proc is not None
+        if host_active or self._gpu_handles:
+            self._thread = threading.Thread(target=self._loop, name="cube-profiler", daemon=True)
+            self._thread.start()
+        return self
+
+    def __enter__(self) -> ResourceSampler:
+        return self.start()
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def summaries(self) -> dict[str, ResourceSummary]:
+        return {name: _summarize(values) for name, values in self._series.items()}
+
+    @property
+    def sample_count(self) -> int:
+        return max((len(v) for v in self._series.values()), default=0)

--- a/src/cube_harness/metrics/profiler.py
+++ b/src/cube_harness/metrics/profiler.py
@@ -146,10 +146,24 @@ class EpisodeProfile(BaseModel):
 
 
 class ToolStat(BaseModel):
-    """Per-tool (per-action-name) aggregate within the agent loop."""
+    """Per-tool (per-action-name) aggregate within the agent loop.
+
+    ``min_s`` is the cheapest observed call of this tool — a proxy for the
+    per-call **floor** (RPC/transport + trivial work that *every* call pays
+    regardless of the command). The spread between ``min_s`` and ``max_s``
+    tells transport-bound (flat: min≈max, many calls) from work-bound
+    (spiky: max≫min, a few heavy commands). Aggregates cleanly across
+    episodes: count/total add, min/max combine by min/max.
+    """
 
     count: int = 0
     total_s: float = 0.0
+    min_s: float = 0.0
+    max_s: float = 0.0
+
+    @property
+    def mean_s(self) -> float:
+        return self.total_s / self.count if self.count else 0.0
 
 
 class AgentLoopBreakdown(BaseModel):
@@ -206,9 +220,14 @@ def breakdown_agent_loop(events: object) -> AgentLoopBreakdown:
             name = (out.action.name if out.action is not None else None) or "unknown"
             bd.n_tool_calls += 1
             bd.tool_exec_s += dur
-            stat = bd.tools.setdefault(name, ToolStat())
+            stat = bd.tools.get(name)
+            if stat is None:
+                stat = ToolStat(min_s=dur, max_s=dur)
+                bd.tools[name] = stat
             stat.count += 1
             stat.total_s += dur
+            stat.min_s = min(stat.min_s, dur)
+            stat.max_s = max(stat.max_s, dur)
     return bd
 
 

--- a/src/cube_harness/metrics/profiler.py
+++ b/src/cube_harness/metrics/profiler.py
@@ -35,10 +35,14 @@ from pathlib import Path
 import psutil
 from pydantic import BaseModel, Field
 
+from cube_harness.core import LLMCallEvent, ToolCallEvent
+
 try:  # optional: only used when ``ProfileConfig.gpu`` and an NVIDIA GPU is present
     import pynvml
 except ImportError:  # pragma: no cover - exercised only on GPU hosts
     pynvml = None
+
+RESET_ACTION_ID = "reset"  # synthetic initial-obs ToolCallEvent — setup, not a real tool call
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +143,73 @@ class EpisodeProfile(BaseModel):
         except Exception:
             logger.warning("Failed to read %s", path, exc_info=True)
             return None
+
+
+class ToolStat(BaseModel):
+    """Per-tool (per-action-name) aggregate within the agent loop."""
+
+    count: int = 0
+    total_s: float = 0.0
+
+
+class AgentLoopBreakdown(BaseModel):
+    """Decomposition of the ``agent_loop`` phase, derived from trajectory events.
+
+    The coarse ``agent_loop`` phase lumps three very different costs; this
+    splits them so the rollup can tell model latency from env transport from
+    harness overhead:
+
+    - ``llm_wait_s`` — summed wall-clock of every ``LLMCallEvent`` (network +
+      inference). Model/provider-owned.
+    - ``tool_exec_s`` — summed wall-clock of every ``ToolCallEvent`` (the
+      agent↔env hop + in-container work), broken out per tool in ``tools``.
+      Infra/transport-owned — this is where remote backends (Daytona) hurt.
+    - ``overhead_s`` (derived in the rollup as ``agent_loop − llm − tool``) —
+      everything between calls: parsing, prompt build, obs formatting,
+      serialization. Harness-owned.
+
+    Computed post-hoc from persisted events, so it works on any past run with
+    no hot-path cost — events already carry ``start_time``/``end_time``.
+    """
+
+    llm_wait_s: float = 0.0
+    tool_exec_s: float = 0.0
+    n_llm_calls: int = 0
+    n_tool_calls: int = 0
+    tools: dict[str, ToolStat] = Field(default_factory=dict)
+
+
+def _event_duration(event: object) -> float:
+    start, end = getattr(event, "start_time", None), getattr(event, "end_time", None)
+    if start is None or end is None:
+        return 0.0
+    return max(0.0, end - start)
+
+
+def breakdown_agent_loop(events: object) -> AgentLoopBreakdown:
+    """Decompose the agent loop from an iterable of ``TrajectoryEvent``.
+
+    Each event must expose ``start_time``/``end_time`` and ``output``. The
+    synthetic reset ToolCallEvent (initial obs) is excluded — it's setup, not
+    a tool call.
+    """
+    bd = AgentLoopBreakdown()
+    for event in events:
+        out = getattr(event, "output", None)
+        dur = _event_duration(event)
+        if isinstance(out, LLMCallEvent):
+            bd.n_llm_calls += 1
+            bd.llm_wait_s += dur
+        elif isinstance(out, ToolCallEvent):
+            if out.action_id == RESET_ACTION_ID:
+                continue
+            name = (out.action.name if out.action is not None else None) or "unknown"
+            bd.n_tool_calls += 1
+            bd.tool_exec_s += dur
+            stat = bd.tools.setdefault(name, ToolStat())
+            stat.count += 1
+            stat.total_s += dur
+    return bd
 
 
 def _percentile(values: list[float], q: float) -> float:

--- a/src/cube_harness/rl/engine.py
+++ b/src/cube_harness/rl/engine.py
@@ -315,6 +315,7 @@ class RolloutEngine:
             "service_name": self.config.name,
             "benchmark_name": self.benchmark_name,
             "max_steps": self.config.max_steps,
+            "profile": self.config.profile,
             "event_context": self.event_context(request),
         }
 

--- a/src/cube_harness/rl/rollout.py
+++ b/src/cube_harness/rl/rollout.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, SerializeAsAny
 
 from cube_harness.agent import AgentConfig
 from cube_harness.episode import MAX_STEPS
+from cube_harness.metrics.profiler import ProfileConfig
 from cube_harness.rl.llm import RolloutLLMConfig
 
 
@@ -58,3 +59,9 @@ class RolloutConfig(BaseModel):
     max_steps: int = MAX_STEPS
     execution_mode: Literal["ray", "local"] = "ray"
     ray: RayConfig = Field(default_factory=RayConfig)
+    profile: ProfileConfig | None = Field(
+        default=None,
+        description="Opt-in per-rollout profiling (resource sampling + phase timing). Each rollout "
+        "writes a profile.json beside its trajectory when persist_rollout is set. The "
+        "inference-server / GPU side is profiled separately (see metrics/profiler).",
+    )

--- a/src/cube_harness/rl/task_runner.py
+++ b/src/cube_harness/rl/task_runner.py
@@ -53,6 +53,7 @@ class RolloutTaskRunner:
             recorder_config=recorder_config,
             write_eval_log=persist_rollout,
             trajectory_id=self.trajectory_id,
+            profile=self.payload.get("profile"),
         )
         if persist_rollout:
             log_file = get_log_path(self.output_dir, self.trajectory_id)

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -74,6 +74,12 @@ class Storage(Protocol):
 
     def archive_episode(self, trajectory_id: str) -> None: ...
 
+    def episode_dir(self, trajectory_id: str) -> Path | None:
+        """On-disk directory for this episode's artifacts, or None for
+        non-persistent storage. Used to drop side artifacts (e.g.
+        ``profile.json``) beside the trajectory."""
+        ...
+
 
 class InMemoryTrajectoryView:
     """Minimal TrajectoryView-compatible object for streaming-only episodes.
@@ -191,6 +197,9 @@ class InMemoryStorage:
         self._events.pop(trajectory_id, None)
         self._statuses.pop(trajectory_id, None)
         self._episode_configs.pop(trajectory_id, None)
+
+    def episode_dir(self, trajectory_id: str) -> Path | None:
+        return None  # in-memory storage has no on-disk artifact directory
 
 
 _thread_local = threading.local()
@@ -809,6 +818,13 @@ class FileStorage:
 
     def _episode_dir(self, trajectory_id: str) -> Path:
         return self.output_dir / EPISODES_DIR / trajectory_id
+
+    def episode_dir(self, trajectory_id: str) -> Path | None:
+        # Pure accessor: the directory is already created by save_metadata /
+        # save_episode_config before any caller needs it. Side artifacts
+        # (profile.json) are written best-effort, so a missing dir on an
+        # early-setup crash just degrades to no-write rather than forcing one.
+        return self._episode_dir(trajectory_id)
 
     def _episode_dirs(self) -> Iterator[Path]:
         episodes_dir = self.output_dir / EPISODES_DIR

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -109,6 +109,37 @@ def test_episode_config_profile_defaults_off_and_serializes() -> None:
     assert isinstance(TaskConfig, type)  # import sanity
 
 
+def test_breakdown_agent_loop_splits_llm_tool_and_per_tool() -> None:
+    from cube.core import Action  # noqa: PLC0415 - test-local
+
+    from cube_harness.core import LLMCallEvent, ToolCallEvent, TrajectoryEvent  # noqa: PLC0415
+    from cube_harness.metrics.profiler import breakdown_agent_loop
+
+    def tool(name: str, action_id: str, start: float, end: float) -> TrajectoryEvent:
+        return TrajectoryEvent(
+            output=ToolCallEvent(parent_event_id="p", action_id=action_id, action=Action(name=name, arguments={})),
+            start_time=start,
+            end_time=end,
+        )
+
+    events = [
+        TrajectoryEvent(output=LLMCallEvent(), start_time=0.0, end_time=2.0),  # llm 2s
+        tool("reset", "reset", 2.0, 2.1),  # excluded — synthetic initial obs
+        tool("bash", "a1", 2.1, 3.1),  # bash 1.0s
+        tool("bash", "a2", 3.1, 3.6),  # bash 0.5s
+        tool("read_file", "a3", 3.6, 3.7),  # read_file 0.1s
+        TrajectoryEvent(output=LLMCallEvent(), start_time=3.7, end_time=4.7),  # llm 1s
+    ]
+    bd = breakdown_agent_loop(events)
+    assert bd.n_llm_calls == 2
+    assert abs(bd.llm_wait_s - 3.0) < 1e-6
+    assert bd.n_tool_calls == 3  # reset excluded
+    assert abs(bd.tool_exec_s - 1.6) < 1e-6
+    assert bd.tools["bash"].count == 2
+    assert abs(bd.tools["bash"].total_s - 1.5) < 1e-6
+    assert "reset" not in bd.tools
+
+
 def test_live_episode_writes_profile(tmp_dir, mock_agent_config, mock_cube_task_config) -> None:  # noqa: ANN001 - fixtures
     """End-to-end: an Episode run with profile set drops profile.json with phases."""
     episode = Episode(

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -137,6 +137,10 @@ def test_breakdown_agent_loop_splits_llm_tool_and_per_tool() -> None:
     assert abs(bd.tool_exec_s - 1.6) < 1e-6
     assert bd.tools["bash"].count == 2
     assert abs(bd.tools["bash"].total_s - 1.5) < 1e-6
+    # per-call distribution: floor (min) vs max distinguishes transport- from work-bound
+    assert abs(bd.tools["bash"].min_s - 0.5) < 1e-6
+    assert abs(bd.tools["bash"].max_s - 1.0) < 1e-6
+    assert abs(bd.tools["bash"].mean_s - 0.75) < 1e-6
     assert "reset" not in bd.tools
 
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,175 @@
+"""Unit tests for the episode profiling foundation (infra-free, fast)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from cube_harness.episode import Episode, EpisodeConfig
+from cube_harness.metrics.profile_rollup import build_rollup
+from cube_harness.metrics.profiler import (
+    PHASE_AGENT_LOOP,
+    PHASE_SETUP,
+    EpisodeProfile,
+    PhaseAccumulator,
+    ProfileConfig,
+    ResourceSampler,
+    ResourceSummary,
+    _percentile,
+    _summarize,
+)
+
+
+def test_percentile_and_summarize() -> None:
+    assert _percentile([], 0.5) == 0.0
+    assert _percentile([5.0], 0.95) == 5.0
+    assert _percentile([1.0, 2.0, 3.0], 0.5) == 2.0  # nearest-rank
+    assert _percentile([1.0, 2.0, 3.0, 4.0], 1.0) == 4.0
+    assert _percentile([1.0, 2.0, 3.0, 4.0], 0.0) == 1.0
+    summ = _summarize([0.0, 10.0, 20.0])
+    assert summ.samples == 3
+    assert summ.mean == 10.0
+    assert summ.max == 20.0
+
+
+def test_phase_accumulator_sums_durations() -> None:
+    acc = PhaseAccumulator()
+    with acc.phase(PHASE_SETUP):
+        time.sleep(0.02)
+    with acc.phase(PHASE_AGENT_LOOP):
+        time.sleep(0.01)
+    with acc.phase(PHASE_SETUP):  # re-entry accumulates
+        time.sleep(0.01)
+    totals = acc.totals()
+    assert totals[PHASE_SETUP] > totals[PHASE_AGENT_LOOP]
+    assert totals[PHASE_AGENT_LOOP] >= 0.01
+
+
+def test_resource_sampler_captures_series_under_load() -> None:
+    with ResourceSampler(ProfileConfig(sample_hz=20)) as sampler:
+        # burn CPU so the sampler records a non-trivial process tree
+        _ = sum(i * i for i in range(2_000_000))
+        time.sleep(0.15)
+    summaries = sampler.summaries()
+    assert sampler.sample_count >= 1
+    assert "cpu_percent" in summaries
+    assert "rss_mb" in summaries
+    assert summaries["rss_mb"].max > 0.0
+
+
+def test_resource_sampler_disabled_records_nothing() -> None:
+    with ResourceSampler(ProfileConfig(resource_sampling=False)) as sampler:
+        time.sleep(0.05)
+    assert sampler.sample_count == 0
+    assert sampler.summaries() == {}
+
+
+def test_gpu_knob_independent_of_resource_sampling_no_hardware() -> None:
+    # gpu=True with resource_sampling=False must not sample host CPU/RSS, and on
+    # a GPU-less host (no NVML handles) it degrades to recording nothing — never
+    # an error. (The fix: the two knobs are independent; the old code gated GPU
+    # behind resource_sampling.)
+    with ResourceSampler(ProfileConfig(resource_sampling=False, gpu=True)) as sampler:
+        _ = sum(i * i for i in range(500_000))
+        time.sleep(0.05)
+    assert "cpu_percent" not in sampler.summaries()  # host sampling stays off
+    assert "rss_mb" not in sampler.summaries()
+
+
+def test_episode_profile_roundtrip(tmp_path: Path) -> None:
+    prof = EpisodeProfile(
+        task_id="task-1",
+        trajectory_id="traj-1",
+        wall_time_s=12.5,
+        phases={PHASE_SETUP: 2.0, PHASE_AGENT_LOOP: 9.0},
+        resources={"cpu_percent": ResourceSummary(samples=3, mean=40.0, p50=35.0, p95=90.0, max=95.0)},
+        sample_count=3,
+    )
+    prof.write(tmp_path)
+    loaded = EpisodeProfile.load(tmp_path)
+    assert loaded is not None
+    assert loaded.task_id == "task-1"
+    assert loaded.phases[PHASE_AGENT_LOOP] == 9.0
+    assert loaded.resources["cpu_percent"].p95 == 90.0
+
+
+def test_episode_profile_load_missing_returns_none(tmp_path: Path) -> None:
+    assert EpisodeProfile.load(tmp_path) is None
+
+
+def test_episode_config_profile_defaults_off_and_serializes() -> None:
+    from cube.task import TaskConfig  # noqa: PLC0415 - test-local to avoid heavy import at module load
+
+    # default: no profiling
+    assert EpisodeConfig.model_fields["profile"].default is None
+    # round-trips through JSON (Ray pickling / resume path uses model_validate_json)
+    cfg = ProfileConfig(sample_hz=4.0, gpu=True)
+    dumped = cfg.model_dump_json()
+    assert ProfileConfig.model_validate_json(dumped).sample_hz == 4.0
+    assert isinstance(TaskConfig, type)  # import sanity
+
+
+def test_live_episode_writes_profile(tmp_dir, mock_agent_config, mock_cube_task_config) -> None:  # noqa: ANN001 - fixtures
+    """End-to-end: an Episode run with profile set drops profile.json with phases."""
+    episode = Episode(
+        id=0,
+        output_dir=tmp_dir,
+        agent_config=mock_agent_config,
+        task_config=mock_cube_task_config,
+        exp_name="profile_test",
+        max_steps=5,
+        storage=None,
+        runtime_context=None,
+        profile=ProfileConfig(sample_hz=20),
+    )
+    view = episode.run()
+    ep_dir = Path(tmp_dir) / "episodes" / view.id
+    profile = EpisodeProfile.load(ep_dir)
+    assert profile is not None
+    assert profile.task_id == mock_cube_task_config.task_id
+    # setup + evaluate phases always run; agent_loop runs for the mock agent too.
+    assert profile.phases[PHASE_SETUP] >= 0.0
+    assert "evaluate" in profile.phases
+    assert profile.wall_time_s >= 0.0
+
+
+def test_live_episode_without_profile_writes_nothing(tmp_dir, mock_agent_config, mock_cube_task_config) -> None:  # noqa: ANN001
+    """Default (profile=None) must leave no profile.json — zero footprint."""
+    episode = Episode(
+        id=0,
+        output_dir=tmp_dir,
+        agent_config=mock_agent_config,
+        task_config=mock_cube_task_config,
+        exp_name="profile_test",
+        max_steps=5,
+        storage=None,
+        runtime_context=None,
+    )
+    view = episode.run()
+    assert EpisodeProfile.load(Path(tmp_dir) / "episodes" / view.id) is None
+
+
+def test_build_rollup_pareto_ranks_phases(tmp_path: Path) -> None:
+    # two episodes, each with profile.json under episodes/<id>/
+    for i, (setup, loop, evaluate) in enumerate([(1.0, 8.0, 3.0), (2.0, 10.0, 4.0)]):
+        ep_dir = tmp_path / "episodes" / f"traj-{i}"
+        ep_dir.mkdir(parents=True)
+        EpisodeProfile(
+            task_id=f"t{i}",
+            trajectory_id=f"traj-{i}",
+            wall_time_s=setup + loop + evaluate,
+            phases={"setup": setup, "agent_loop": loop, "evaluate": evaluate},
+            resources={"rss_mb": ResourceSummary(samples=2, mean=100.0, p50=100.0, p95=180.0, max=200.0)},
+            sample_count=2,
+        ).write(ep_dir)
+
+    rollup = build_rollup(tmp_path)
+    assert rollup["episodes"] == 2
+    phases = rollup["phases"]
+    # agent_loop dominates → ranked first; shares sum to ~1.0
+    assert phases[0]["phase"] == "agent_loop"
+    assert phases[0]["owner"] == "model"
+    assert abs(sum(p["share"] for p in phases) - 1.0) < 1e-6
+    # resource peaks aggregated (max-of-max)
+    rss = next(r for r in rollup["resources"] if r["resource"] == "rss_mb")
+    assert rss["max"] == 200.0

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -184,6 +184,64 @@ def test_live_episode_without_profile_writes_nothing(tmp_dir, mock_agent_config,
     assert EpisodeProfile.load(Path(tmp_dir) / "episodes" / view.id) is None
 
 
+def test_build_rollup_agent_loop_transport_floor_split(tmp_path: Path) -> None:
+    """End-to-end rollup: persist events for 2 episodes with differing per-call
+    tool durations and assert the transport-floor split uses PER-EPISODE floors
+    (not global-min × global-count) and divides by covered episodes."""
+    from cube.core import Action  # noqa: PLC0415
+
+    from cube_harness.core import (  # noqa: PLC0415
+        ToolCallEvent,
+        TrajectoryEvent,
+        TrajectoryMetadata,
+    )
+    from cube_harness.metrics.profile_rollup import build_rollup  # noqa: PLC0415
+    from cube_harness.storage import FileStorage  # noqa: PLC0415
+
+    storage = FileStorage(tmp_path)
+
+    def write_ep(tid: str, durations: list[float]) -> None:
+        agent_loop = sum(durations) + 1.0  # +1s of non-tool agent-loop time (overhead+llm)
+        storage.save_metadata(TrajectoryMetadata(id=tid, start_time=0.0))
+        t = 0.0
+        for d in durations:
+            storage.save_event(
+                TrajectoryEvent(
+                    output=ToolCallEvent(parent_event_id="p", action_id="x", action=Action(name="bash", arguments={})),
+                    start_time=t,
+                    end_time=t + d,
+                ),
+                tid,
+            )
+            t += d
+        EpisodeProfile(
+            task_id=tid,
+            trajectory_id=tid,
+            wall_time_s=agent_loop,
+            phases={"agent_loop": agent_loop},
+            sample_count=0,
+        ).write(tmp_path / "episodes" / tid)
+
+    # ep0: bash calls 1.0 + 3.0  (floor=1.0 each → 2×1.0=2.0 floor, work=2.0)
+    # ep1: bash calls 2.0 + 2.0  (floor=2.0 each → 2×2.0=4.0 floor, work=0.0)
+    write_ep("ep0", [1.0, 3.0])
+    write_ep("ep1", [2.0, 2.0])
+
+    rollup = build_rollup(tmp_path)
+    al = rollup["agent_loop"]
+    assert al["episodes_covered"] == 2
+    tes = al["tool_exec_split"]
+    # tool_exec total = 8.0 over 2 episodes → mean 4.0/ep
+    tool_split = next(s for s in al["split"] if s["part"] == "tool_exec")
+    assert abs(tool_split["mean_s"] - 4.0) < 1e-6
+    # PER-EPISODE floor: ep0 2×1.0=2.0, ep1 2×2.0=4.0 → 6.0 total → 3.0/ep.
+    # (A global-min×global-count bug would give 4×1.0=4.0 → 2.0/ep — wrong.)
+    assert abs(tes["transport_floor_s"] - 3.0) < 1e-6
+    assert abs(tes["work_s"] - 1.0) < 1e-6  # (8.0 - 6.0)/2
+    # reclaimable: ep0 (2-1)×1.0=1.0, ep1 (2-1)×2.0=2.0 → 3.0 total → 1.5/ep
+    assert abs(tes["reclaimable_by_batching_s"] - 1.5) < 1e-6
+
+
 def test_build_rollup_pareto_ranks_phases(tmp_path: Path) -> None:
     # two episodes, each with profile.json under episodes/<id>/
     for i, (setup, loop, evaluate) in enumerate([(1.0, 8.0, 3.0), (2.0, 10.0, 4.0)]):

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "cube-harness"
-version = "0.1.0"
+version = "0.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -676,6 +676,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "ray", extra = ["default"] },
@@ -729,6 +730,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pandas", marker = "extra == 'analyze'", specifier = "~=2.0" },
     { name = "pillow", specifier = "~=11.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "python-dotenv", specifier = "~=1.2.0" },
     { name = "ray", extras = ["default"], specifier = ">=2.52.1" },
@@ -2318,6 +2320,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Foundation for the **Auto-CUBE profile use-case**: turn every episode into a **phase × resource** breakdown cheap enough to leave on for all runs, then Pareto-rank the bottlenecks that actually matter — *aggregate statistics*, not a per-trajectory Investigator.

## How

**New `cube_harness.metrics.profiler`:**
- `ProfileConfig` — opt-in knobs (`resource_sampling`, `sample_hz`, `gpu`). `None` everywhere by default ⇒ no profiling.
- `ResourceSampler` — `psutil` background thread sampling CPU% / RSS / IO / fds / threads (+ GPU via NVML when `gpu=True` and `pynvml` present) at ~1–2 Hz.
- `PhaseAccumulator` — coarse per-phase wall-clock: `setup` / `agent_loop` / `evaluate` / `teardown`.
- `EpisodeProfile` — the `profile.json` artifact written beside each trajectory.

**Wiring is at the `Episode` level**, so both paths inherit it from one place:
- standard runner via `Experiment.profile`
- **RL rollouts** via `RolloutConfig.profile` (the rollout task runner builds the *same* `Episode`)

Only the inference-server / GPU-side sampler is RL-specific and is deferred. When `profile is None` the sampler never runs.

**`ch-profile`** (`metrics/profile_rollup.py`) aggregates `episodes/*/profile.json` into a phase **Pareto table** (mean s / share of wall-clock / owner tag `infra|model|benchmark`) plus resource peaks, so the orchestrator only spends deeper profiling (py-spy/cProfile) on the top *actionable* bar.

Example output:
\`\`\`
Phase Pareto (mean seconds / share of wall-clock / owner):
  phase             mean_s    share  owner
  agent_loop         29.00    51.4%  model       <- model-bound, not ours
  evaluate           17.10    30.3%  benchmark   <- reward-cache question
  teardown           10.15    18.0%  infra       <- addressable (docker stop grace)
  setup               0.19     0.3%  infra
\`\`\`

## Scope / follow-ups (not in this PR)
- Remote **sandbox-interior** sampling (CPU/RAM/disk inside the container, via the infra `exec` channel).
- The **inference-server / GPU service** sampler for self-hosted RL rollouts.
- The `/auto-cube-profile` use-case skill + cross-session `profile.json` ledger.

## Testing
- `tests/test_profiler.py` — infra-free: sampler-under-load, phase accumulator, percentile/summary math, rollup ranking, **live end-to-end Episode run** asserting `profile.json` is written when on and absent when off.
- Regression: `test_episode / test_storage / test_experiment / test_rollout_service / test_cube_episode` pass (181 passed, 17 skipped).
- `make lint-check` clean across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)