### PR TITLE
docs(arithmetic-cube): mark as registry-excluded demo cube

### DIFF
--- a/cubes/arithmetic-cube/README.md
+++ b/cubes/arithmetic-cube/README.md
@@ -1,0 +1,10 @@
+# arithmetic-cube
+
+A minimal arithmetic benchmark — the agent submits the correct answer to math
+problems. It exists as a **demo / reference cube** for examples, smoke tests, and
+documentation.
+
+> **Do NOT add this cube to [cube-registry](https://github.com/The-AI-Alliance/cube-registry).**
+> It is not a real benchmark for the public catalog. Skip it when running
+> `cube registry add` / bulk registry submissions. Intentionally excluded —
+> this note is for both humans and AI agents doing registry work.

--- a/cubes/arithmetic-cube/pyproject.toml
+++ b/cubes/arithmetic-cube/pyproject.toml
@@ -1,3 +1,6 @@
+# REGISTRY: do NOT add this cube to cube-registry (no `cube registry add` / `--submit`).
+# arithmetic-cube is a demo/reference benchmark for examples & tests only — not a real
+# benchmark for the public catalog. Intentionally excluded. (note for humans + AI agents)
 [project]
 name = "arithmetic-cube"
 version = "0.1.0"


### PR DESCRIPTION
arithmetic-cube is a demo/reference benchmark (examples, smoke tests, docs), not a catalog benchmark. Adds an explicit exclusion note — a top-of-`pyproject.toml` comment and a short README — so anyone (human or AI) doing `cube registry add` / bulk registry work knows to skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)