### PR TITLE
fix(webarena): widen tool_config type so the default config imports

### DIFF
--- a/cubes/webarena-verified/src/webarena_verified_cube/benchmark.py
+++ b/cubes/webarena-verified/src/webarena_verified_cube/benchmark.py
@@ -8,7 +8,8 @@ from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
 from cube.infra_local import LocalInfraConfig
 from cube.resource import DockerServiceConfig, InfraConfig, ResourceHandle
 from cube.task import TaskConfig
-from cube.tool import ToolboxConfig
+from cube.tool import ToolboxConfig, ToolConfig
+from pydantic import SerializeAsAny
 from webarena_verified.types.config import EnvironmentConfig, WebArenaVerifiedConfig
 from webarena_verified.types.task import WebArenaSite
 
@@ -185,8 +186,12 @@ class WebArenaVerifiedBenchmarkConfig(BenchmarkConfig[WebArenaVerifiedTaskMetada
     (sites, expected_action, intent_template_id). No heavy execution data exists."""
     task_config_class: ClassVar[type[TaskConfig]] = WebArenaVerifiedTaskConfig
     benchmark_class: ClassVar[type[Benchmark]] = WebArenaVerifiedBenchmark
-    tool_config: ToolboxConfig = ToolboxConfig(tool_configs=[HarPlaywrightConfig(), SubmitResponseConfig()])  # type: ignore
-    """Default ToolboxConfig with tools for HAR-based environment observation and agent response submission."""
+    tool_config: SerializeAsAny[ToolConfig] = ToolboxConfig(
+        tool_configs=[HarPlaywrightConfig(), SubmitResponseConfig()]
+    )
+    """Tool config applied to every task. Any ToolConfig is accepted (the canonical
+    "default" config in configs.py uses a BgymToolConfig); the field default here is a
+    ToolboxConfig with HAR-based observation + agent response submission."""
 
     wav_config: WebArenaVerifiedConfig = WebArenaVerifiedConfig()
     """WAV client configuration.


### PR DESCRIPTION
### Problem
`webarena-verified-cube` fails to **import** on any fresh install:
```
tool_config → Input should be a valid dictionary or instance of ToolboxConfig
              [input_value=BgymToolConfig(...)]
```
`WebArenaVerifiedBenchmarkConfig.tool_config` was narrowed to `ToolboxConfig`, but
`configs.py` sets the canonical default to `tool_config=BgymToolConfig(...)`.
`BgymToolConfig` and `ToolboxConfig` are **sibling** `ToolConfig` subclasses, so
pydantic rejects it. CI missed this because the cube package is never imported in
the cube-harness test job; the registry quick-check caught it.

### Fix
Widen to `SerializeAsAny[ToolConfig]` (matching the base
`BenchmarkConfig.tool_config: SerializeAsAny[ToolConfig] | None`), keeping the
`ToolboxConfig` field default. `tool_config` is only passed through
(`benchmark.py:223`), never accessed as a `ToolboxConfig`, so widening is safe.

### Verified
Clean 3.12 venv, `pip install` of the patched cube against the published deps
(`cube-standard==0.1.0rc10`, `cube-browser-tool==0.3.0`): `WEBARENA_CONFIGS["default"]`
imports and `tool_config` resolves to `BgymToolConfig`. Unblocks registry cube-registry#64.

**Needs a cube republish** (e.g. 1.1.1) after merge so the PyPI package imports cleanly.