### PR TITLE
release(webarena): bump webarena-verified-cube to 1.1.1

### DIFF
--- a/cubes/webarena-verified/pyproject.toml
+++ b/cubes/webarena-verified/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webarena-verified-cube"
-version = "1.1.0"
+version = "1.1.1"
 description = "WebArena-Verified benchmark cube — 812 verified web automation tasks"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Bumps the cube to 1.1.1 so the `tool_config` import fix (#515) can be published —
the `1.1.0` on PyPI fails to import on a fresh install.

After merge, pushing the tag `cubes/webarena-verified/v1.1.1` triggers `release.yml`
(trusted publishing) to build + publish 1.1.1 to PyPI, which then unblocks the
registry bump (cube-registry#64 → 1.1.1).