### PR TITLE
fix(browsercomp): export get_debug_benchmark from __init__ (0.1.2)

### DIFF
--- a/cubes/browsercomp/pyproject.toml
+++ b/cubes/browsercomp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "browsercomp-cube"
-version = "0.1.1"
+version = "0.1.2"
 description = "BrowseComp benchmark — web browsing information retrieval"
 requires-python = ">=3.12"
 authors = [

--- a/cubes/browsercomp/src/browsercomp_cube/__init__.py
+++ b/cubes/browsercomp/src/browsercomp_cube/__init__.py
@@ -3,9 +3,12 @@ from browsercomp_cube.task import BrowseCompExecutionInfo, BrowseCompTask, Brows
 from browsercomp_cube.tool import SubmitAnswerTool, SubmitAnswerToolConfig
 
 from browsercomp_cube.configs import BROWSECOMP_CONFIGS
+from browsercomp_cube.debug import get_debug_benchmark, make_debug_agent
 
 __all__ = [
     "BROWSECOMP_CONFIGS",
+    "get_debug_benchmark",
+    "make_debug_agent",
     "BrowseCompBenchmark",
     "BrowseCompBenchmarkConfig",
     "BrowseCompExecutionInfo",


### PR DESCRIPTION
Registry compliance imports the package and looks for `get_debug_benchmark()` on the module; browsercomp had it in `debug.py` but didn't re-export it (osworld/waa do). Add the export + bump to 0.1.2. Unblocks cube-registry #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)