### PR TITLE
chore: bump cube-harness dev to 0.1.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "cube-harness"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "cube-harness, open source agentic evaluation and data generation framework."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Post-rc1 dev hygiene (carry next unreleased). Also serves as the OIDC trusted-publisher verification for cube-harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)