### PR TITLE
fix(auto-cube): use Experiment budget API in recipe templates

### DIFF
--- a/src/cube_harness/agents/genny_configs.py
+++ b/src/cube_harness/agents/genny_configs.py
@@ -5,7 +5,7 @@
 
     agent = GENNY_CONFIGS["swe"]
     agent.llm_config = LLMConfig(model_name="gpt-5.4-mini", temperature=1.0)
-    agent.budget.cost_limit = 2.0
+    # Budget caps live on Experiment (max_steps, max_cost_usd), not the agent.
 
 Every lookup returns a fresh deep copy (see `ConfigRegistry`). The building
 blocks below (`INSTANCE_TEMPLATES`, `make_agent_config`) stay public for

--- a/src/cube_harness/auto_cube/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/templates/exp_config.py
@@ -30,21 +30,24 @@ TASK_IDS = [
 ]
 MODEL = "gpt-5.4-mini"  # cheap; bump only with a reason in notes.md
 COST_PER_TASK = 0.50
+MAX_STEPS = 60
 
 # --- assemble -------------------------------------------------------------
 
 agent = GENNY_CONFIGS["swe"]
 agent.llm_config = LLMConfig(model_name=MODEL, temperature=1.0)
-agent.budget.cost_limit = COST_PER_TASK
 
 benchmark = TERMINALBENCH2_CONFIGS["default"].subset_from_list(TASK_IDS)
 
+# Budget caps live on Experiment, not the agent config: max_steps →
+# Budget.max_agent_steps, max_cost_usd → Budget.max_cost_usd.
 exp = Experiment(
     name="auto-cube-tbench2-r<N>",
     agent_config=agent,
     benchmark_config=benchmark,
     infra=INFRA_CONFIGS["local"],
-    max_steps=agent.budget.max_actions or 60,
+    max_steps=MAX_STEPS,
+    max_cost_usd=COST_PER_TASK,
     is_official=False,  # Auto-CUBE iteration run — never a submittable evaluation.
 )
 

--- a/src/cube_harness/auto_cube/use_cases/profile/templates/exp_config.py
+++ b/src/cube_harness/auto_cube/use_cases/profile/templates/exp_config.py
@@ -28,23 +28,26 @@ from cube_harness.recipe import run
 TASK_IDS: list[str] = []  # empty = full benchmark; or an explicit subset to profile
 MODEL = "gpt-5.4-mini"  # cheap; you're profiling infra/harness, not the model
 COST_PER_TASK = 0.50
+MAX_STEPS = 60
 
 # --- assemble -------------------------------------------------------------
 
 agent = GENNY_CONFIGS["swe"]
 agent.llm_config = LLMConfig(model_name=MODEL, temperature=1.0)
-agent.budget.cost_limit = COST_PER_TASK
 
 benchmark = TERMINALBENCH2_CONFIGS["default"]
 if TASK_IDS:
     benchmark = benchmark.subset_from_list(TASK_IDS)
 
+# Budget caps live on Experiment, not the agent config: max_steps →
+# Budget.max_agent_steps, max_cost_usd → Budget.max_cost_usd.
 exp = Experiment(
     name="auto-cube-profile-r<N>",
     agent_config=agent,
     benchmark_config=benchmark,
     infra=INFRA_CONFIGS["local"],
-    max_steps=agent.budget.max_actions or 60,
+    max_steps=MAX_STEPS,
+    max_cost_usd=COST_PER_TASK,
     is_official=False,  # Auto-CUBE iteration run — never a submittable evaluation.
     # Always-on profiling: phase wall-clock + host resource sampling. Set
     # gpu=True only when a self-hosted inference server shares this host (RL).


### PR DESCRIPTION
## What
The Auto-CUBE round-config templates and the `genny_configs` module docstring still document the **removed** `agent.budget.cost_limit` / `agent.budget.max_actions` API. Copy-pasting the documented pattern raises `AttributeError` — `AgentConfig`/`GennyConfig` have no `budget` attribute (the live budget lives on `recorder.budget`, and the caps live on `Experiment`).

This surfaced during a downstream UX test: install everything from PyPI, copy the shipped `auto_cube/templates/exp_config.py`, run it → `AttributeError: 'GennyConfig' object has no attribute 'budget'`.

## Fix
Mirror the canonical `recipes/swe_agent_recipe.py`: set caps on `Experiment`.

- `agent.budget.cost_limit = COST_PER_TASK` → `Experiment(max_cost_usd=COST_PER_TASK)`
- `max_steps=agent.budget.max_actions or 60` → `Experiment(max_steps=MAX_STEPS)`

Files:
- `src/cube_harness/auto_cube/templates/exp_config.py`
- `src/cube_harness/auto_cube/use_cases/profile/templates/exp_config.py`
- `src/cube_harness/agents/genny_configs.py` (docstring example)

## Notes
Docs/template only — no runtime code changed. `ruff check` + `ruff format` clean; all three files `py_compile` cleanly. The agent-owns-loop migration note (`max_steps → Budget.max_agent_steps`, `max_cost_usd → Budget.max_cost_usd`) is preserved inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)