### PR TITLE
fix(storage): own episode-dir detection; investigator delegates

### DIFF
--- a/src/cube_harness/analyze/investigator/episode_discovery.py
+++ b/src/cube_harness/analyze/investigator/episode_discovery.py
@@ -1,8 +1,10 @@
 """Scan and filter the episodes inside an experiment directory.
 
 `discover_episodes(<experiment_dir>)` walks `<experiment_dir>/episodes/` and
-returns one `EpisodeRef` per subdirectory; if the path itself looks like a
-single episode (has `steps/`), it is returned as the only ref.
+returns one `EpisodeRef` per subdirectory; if the path itself is a single
+episode dir (per `storage.is_episode_dir`), it is returned as the only ref.
+The on-disk layout (`events/` vs legacy `steps/`) is owned by `storage`, not
+re-derived here.
 
 `select_episodes(refs, *, ids=..., failures_only=..., overwrite=...)` filters
 the pool. Selection is intentionally explicit — random sampling was removed
@@ -23,6 +25,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from cube_harness.eval_log import EPISODE_RECORD_FILENAME, EpisodeRecord
+from cube_harness.storage import EVENTS_DIR, STEPS_DIR, is_episode_dir
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +53,7 @@ def discover_episodes(experiment_dir: Path) -> list[EpisodeRef]:
     episodes_dir = experiment_dir / "episodes"
     if not episodes_dir.exists():
         # Maybe the user passed a single episode directory.
-        if (experiment_dir / "steps").exists():
+        if is_episode_dir(experiment_dir):
             return [
                 EpisodeRef(
                     trajectory_id=experiment_dir.name,
@@ -59,7 +62,9 @@ def discover_episodes(experiment_dir: Path) -> list[EpisodeRef]:
                     record=load_episode_record(experiment_dir / EPISODE_RECORD_FILENAME),
                 )
             ]
-        raise FileNotFoundError(f"No 'episodes/' under {experiment_dir} and no 'steps/' inside it")
+        raise FileNotFoundError(
+            f"No 'episodes/' under {experiment_dir} and no '{EVENTS_DIR}/' or '{STEPS_DIR}/' inside it"
+        )
 
     refs: list[EpisodeRef] = []
     for ep_dir in sorted(episodes_dir.iterdir()):

--- a/src/cube_harness/storage.py
+++ b/src/cube_harness/storage.py
@@ -43,6 +43,17 @@ STEPS_DIR = "steps"
 ARCHIVED_MARKER = ".archived_"
 
 
+def is_episode_dir(path: Path) -> bool:
+    """True if ``path`` is a single episode directory.
+
+    The on-disk layout is owned here: a real episode holds an ``events/``
+    (current event-stream) or legacy ``steps/`` subdir. Consumers that need to
+    recognize an episode directory (e.g. the investigator) must call this rather
+    than re-deriving the layout, so they don't drift when storage evolves.
+    """
+    return (path / EVENTS_DIR).is_dir() or (path / STEPS_DIR).is_dir()
+
+
 class LLMCallRef(BaseModel):
     llm_call_id: str
 

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -319,6 +319,23 @@ def test_discover_episodes_skips_archived_retry_dirs(tmp_path: Path) -> None:
     assert not any(".archived_" in r.trajectory_id for r in refs)
 
 
+def test_discover_episodes_accepts_single_episode_with_events_dir(tmp_path: Path) -> None:
+    """`ch-investigate run <episode_dir>` must work on the current `events/` layout.
+
+    Regression: single-episode discovery recognized only the legacy `steps/` dir,
+    so pointing at any episode produced by the event-stream storage raised
+    FileNotFoundError. discover_episodes now defers to storage.is_episode_dir.
+    """
+    ep = tmp_path / "click-button_ep0"
+    (ep / "events").mkdir(parents=True)
+    (ep / EPISODE_RECORD_FILENAME).write_text("{}")  # unparseable -> record=None, still discovered
+
+    refs = discover_episodes(ep)
+    assert len(refs) == 1
+    assert refs[0].trajectory_id == "click-button_ep0"
+    assert refs[0].episode_dir == ep
+
+
 def test_select_episodes_failures_only_skips_investigated(tmp_path: Path) -> None:
     exp = _make_experiment(
         tmp_path,

--- a/tests/test_storage_event_layout.py
+++ b/tests/test_storage_event_layout.py
@@ -22,7 +22,20 @@ from cube_harness.core import (
     TrajectoryMetadata,
 )
 from cube_harness.llm import LLMCall, LLMConfig, Prompt, Usage
-from cube_harness.storage import EVENTS_DIR, FileStorage
+from cube_harness.storage import EVENTS_DIR, STEPS_DIR, FileStorage, is_episode_dir
+
+
+def test_is_episode_dir_recognizes_events_steps_and_rejects_others(tmp_path: Path) -> None:
+    events_ep = tmp_path / "events_ep"
+    (events_ep / EVENTS_DIR).mkdir(parents=True)
+    steps_ep = tmp_path / "steps_ep"
+    (steps_ep / STEPS_DIR).mkdir(parents=True)
+    not_ep = tmp_path / "not_ep"
+    not_ep.mkdir()
+
+    assert is_episode_dir(events_ep)
+    assert is_episode_dir(steps_ep)
+    assert not is_episode_dir(not_ep)
 
 
 def _agent_event(tag: str = "act") -> LLMCallEvent:


### PR DESCRIPTION
## What
`ch-investigate run <episode_dir>` (single-episode mode) raised:
```
FileNotFoundError: No 'episodes/' under <dir> and no 'steps/' inside it
```
on **every** current episode, because `discover_episodes()` hand-rolled the on-disk layout check (`(dir/"steps").exists()`) while the event-stream storage writes `events/`.

## Why this is the upstream fix (not a patch)
The investigator already delegates trajectory *loading* to the storage layer — `transcript.py` routes through `FileStorage.load_episode`, which is layout-agnostic. Only *discovery* re-derived the layout, so it silently drifted when storage migrated `steps/` → `events/`. The first cut of this PR just taught the duplicate about `events/`; this version removes the duplication.

## Fix
- `storage.is_episode_dir(path)` — storage now owns the "what is an episode dir" rule (`events/` or legacy `steps/`), next to the layout constants it already owns.
- `discover_episodes()` calls it instead of poking the filesystem itself. The next layout change updates exactly one place.

## Tests
- `test_is_episode_dir_recognizes_events_steps_and_rejects_others` (direct, in `test_storage_event_layout.py`)
- `test_discover_episodes_accepts_single_episode_with_events_dir` (investigator regression)

`tests/test_storage_event_layout.py` + `tests/test_investigator.py` green (63 passed, 1 skipped); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)