### PR TITLE
fix(waa): export get_debug_benchmark from __init__ (0.1.2)

### DIFF
--- a/cubes/windows-agent-arena-cube/pyproject.toml
+++ b/cubes/windows-agent-arena-cube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waa-cube"
-version = "0.1.1"
+version = "0.1.2"
 description = "WindowsAgentArena benchmark ported to the CUBE protocol"
 requires-python = ">=3.12"
 dependencies = [

--- a/cubes/windows-agent-arena-cube/src/waa_cube/__init__.py
+++ b/cubes/windows-agent-arena-cube/src/waa_cube/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from waa_cube.benchmark import WAABenchmark, WAABenchmarkRuntime, WAATaskConfig
 from waa_cube.computer import ComputerConfig
 from waa_cube.configs import WAA_CONFIGS
+from waa_cube.debug import get_debug_benchmark, make_debug_agent
 from waa_cube.task import WAATask, WAATaskExecutionInfo
 
 
@@ -19,4 +20,6 @@ __all__ = [
     "WAATask",
     "WAATaskExecutionInfo",
     "ComputerConfig",
+    "get_debug_benchmark",
+    "make_debug_agent",
 ]


### PR DESCRIPTION
Same fix as browsercomp #517 — re-export `get_debug_benchmark`/`make_debug_agent` from `waa_cube/__init__` so the registry finds the debug task. Bump 0.1.2. Unblocks cube-registry #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)