### PR TITLE
fix(browsercomp): ship a default config in BROWSECOMP_CONFIGS

### DIFF
--- a/cubes/browsercomp/src/browsercomp_cube/configs.py
+++ b/cubes/browsercomp/src/browsercomp_cube/configs.py
@@ -1,10 +1,10 @@
 """Canonical BrowseComp benchmark configs.
 
-    from browsercomp_cube import BrowseCompBenchmarkConfig
-    benchmark = BrowseCompBenchmarkConfig(scorer_model="openai/gpt-4o")
+    from browsercomp_cube import BROWSECOMP_CONFIGS
+    benchmark = BROWSECOMP_CONFIGS["default"]
 
-``scorer_model`` is required — the judge model used to grade answers — and has no
-sensible default, so the cube ships no pre-built default config. The cube's
+The ``default`` config grades with ``scorer_model="openai/gpt-4o"`` (override
+per-experiment, e.g. ``BrowseCompBenchmarkConfig(scorer_model=...)``). The cube's
 intrinsic tool is answer submission; richer browsing tools are a recipe-side
 concern (clone the recipe and extend the ToolboxConfig).
 """
@@ -12,4 +12,6 @@ concern (clone the recipe and extend the ToolboxConfig).
 from cube.core import ConfigRegistry
 from browsercomp_cube.benchmark import BrowseCompBenchmarkConfig
 
-BROWSECOMP_CONFIGS: ConfigRegistry[BrowseCompBenchmarkConfig] = ConfigRegistry({})
+BROWSECOMP_CONFIGS: ConfigRegistry[BrowseCompBenchmarkConfig] = ConfigRegistry(
+    {"default": BrowseCompBenchmarkConfig()}
+)

--- a/cubes/browsercomp/tests/test_smoke.py
+++ b/cubes/browsercomp/tests/test_smoke.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from browsercomp_cube import BrowseCompBenchmarkConfig
+from browsercomp_cube import BROWSECOMP_CONFIGS, BrowseCompBenchmarkConfig
 from browsercomp_cube.crypto import decrypt, derive_key, encrypt
 from browsercomp_cube.debug import DebugBrowseCompBenchmark, DebugBrowseCompBenchmarkConfig, get_debug_benchmark
 from browsercomp_cube.task import BrowseCompExecutionInfo, BrowseCompTask, BrowseCompTaskConfig, BrowseCompTaskMetadata
@@ -22,6 +22,12 @@ def test_browsecomp_benchmark_config_constructs() -> None:
     first_id = next(iter(bench.task_metadata))
     assert first_id.startswith("browsecomp-")
     assert bench.scorer_model == "gpt-5.4-mini"
+
+
+def test_browsecomp_configs_has_default() -> None:
+    # Every cube exposes <NAME>_CONFIGS["default"] (recipe-template contract).
+    assert "default" in list(BROWSECOMP_CONFIGS.keys())
+    assert BROWSECOMP_CONFIGS["default"].scorer_model == "openai/gpt-4o"
 
 
 def test_browsecomp_benchmark_config_round_trip() -> None:


### PR DESCRIPTION
## What
`BROWSECOMP_CONFIGS` was `ConfigRegistry({})` — empty — so `BROWSECOMP_CONFIGS["default"]` raised `KeyError`. Every other cube and the Auto-CUBE recipe templates use the `<NAME>_CONFIGS["default"]` contract, so browsercomp alone broke that pattern for downstream recipe authors. Found during the cross-cube downstream UX survey.

## Why it was empty (and why that's now stale)
`configs.py`'s docstring claimed `scorer_model` "has no sensible default, so the cube ships no pre-built default config." But `benchmark.py` since gave it one — `scorer_model: str = "openai/gpt-4o"` — explicitly "so the config is instantiable for introspection (registry compliance, `cube list`)". So `BrowseCompBenchmarkConfig()` is constructible; the empty registry + docstring were leftovers from before that default existed.

## Fix
- `BROWSECOMP_CONFIGS = ConfigRegistry({"default": BrowseCompBenchmarkConfig()})`
- Corrected the stale docstring.
- Smoke assertion that `default` exists with the expected scorer.

`scorer_model` remains overridable per-experiment. Tests green (`-k config`: 5 passed); `ruff` clean.

## Note
Reaches downstream users only after a `browsercomp-cube` republish to PyPI (current 0.1.2 still has the empty registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)