### PR TITLE
build(lint): run ruff from uv.lock instead of unpinned uvx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,21 @@ update:
 	uv sync --all-extras --upgrade
 	uv run playwright install chromium --with-deps
 
+# Resolve ruff from the dev group in uv.lock, so CI and laptops run the same version. `uvx ruff`
+# floated to whatever was newest, which is how 0.16.0's expanded default rule set turned every
+# open PR red at once — 1937 findings on an unchanged tree, in files nobody had touched.
+# --only-group dev: lint needs ruff, not playwright and ray.
+RUFF := uv run --only-group dev ruff
+
 lint:
 	@echo "🧹 Linting code"
-	uvx ruff check --fix .
-	uvx ruff format .
+	$(RUFF) check --fix .
+	$(RUFF) format .
 
 lint-check:
 	@echo "🧹 Checking lint"
-	uvx ruff check --diff .
-	uvx ruff format --diff .
+	$(RUFF) check --diff .
+	$(RUFF) format --diff .
 
 test: install
 	@echo "🧪 Running unit tests"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "cube-harness"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
PR against #526 

Fixes the repo-wide lint failure: `make lint-check` ran `uvx ruff`, which resolves the newest release on every invocation. ruff 0.16.0 expanded its default rule set, so an unchanged tree went from **0 findings to 1937** across ~175 files — rules this repo never selected, since it only adds `extend-select = ["I"]`. Every open PR began failing lint on files it had not touched.

## Change

ruff is already a dev-group dependency and `uv.lock` already pins it to **0.15.12**, so running it through `uv run` makes CI and laptops agree with no new version constraint anywhere — the lockfile becomes the single source of truth, alongside the `uv sync --frozen` that `make ci-install` already does.

```make
RUFF := uv run --only-group dev ruff
```

`--only-group dev` keeps linting to ruff rather than syncing playwright and ray. In a clean checkout that's a 24-package venv in ~65ms.

Per review feedback on the issue, this takes the `uv run` route rather than pinning a version string in `pyproject.toml`. Worth noting `ruff>=X` there is a *floor*, not a pin — a fresh resolve still takes whatever is newest, so it would not have prevented this on its own. The lock is what pins.

## Also included

One-line `uv.lock` refresh: `cube-harness` was recorded as `0.1.0rc1` while `pyproject.toml` says `0.1.0rc2`. Without it `uv run` re-locks on every invocation and leaves contributors with a dirty `uv.lock` after linting.

## Verified

- `make lint-check` → exit 0, working tree clean afterwards
- `make lint` → `All checks passed!`, 406 files unchanged
- `uv run --only-group dev ruff --version` → `0.15.12`, matching the lock

## Follow-ups, deliberately not in this PR

- **Adopting 0.16's defaults** is a real decision with ~1937 findings behind it (958 auto-fixable; the rest manual — BLE001 ×437, RUF012 ×60, TRY002 ×39, …). It deserves its own PR with the fixes, rather than arriving by accident through an unpinned tool.
- **`--locked`** could be added to `lint-check` so CI fails loudly on lock drift. Left out here since it turns any un-relocked `pyproject.toml` edit into a confusing lint failure — maintainers' call.
- **`fix = true`** in `[tool.ruff]` means a bare `ruff check .` rewrites files instead of reporting; it silently auto-fixed 175 unrelated files while I was investigating this. The `lint` target already passes `--fix` explicitly, so dropping it would be safe.
