### PR TITLE
chore: remove stale STOP_ACTION comments and docs

### DIFF
--- a/cubes/swebench-verified-cube/README.md
+++ b/cubes/swebench-verified-cube/README.md
@@ -71,7 +71,6 @@ bench.close()
 - **`append_submission_instructions`** (default `True`) — appends `_TASK_INSTRUCTIONS` to the problem statement reminding the agent how to submit (`final_step` after `git diff > patch.txt && cat patch.txt`). Disable for raw-benchmark comparisons where the prompt must match upstream verbatim.
 - **`include_hints`** — surface the curated hints text shipped with each task (when present).
 - **`oracle_mode`** — writes the gold patch to `/tmp/gold_patch.diff` so an oracle agent can apply it directly. Used by the debug suite.
-- **`filter_actions()`** — patches `STOP_ACTION`'s empty parameters schema to `{"type": "object", "properties": {}}` so Anthropic models don't reject it.
 - **`_make_tool()`** — pre-flight `git config --global --add safe.directory` plus a writable-file `cp + mv` pass so non-root containers can edit the testbed.
 
 ## Evaluation

--- a/src/cube_harness/agents/react.py
+++ b/src/cube_harness/agents/react.py
@@ -70,9 +70,8 @@ class ReactAgent(Agent):
         super().__init__(config)
         self.llm = config.llm_config.make()
         self.token_counter = config.llm_config.make_counter()
-        # STOP (`final_step`) is always part of the task's `action_set` — it's a universal
-        # `@tool_action` on the Tool base, already Anthropic-safe
-        # (`{"type": "object", "properties": {}}`). We never append it manually.
+        # STOP (`final_step`) is automatically included in the task's `action_set`
+        # and has a safe schema provided by cube-standard.
         # `can_finish=False` opts the agent out of offering STOP to the LLM.
         self.tools: list[dict] = [tool.as_dict() for tool in tools]
         if not config.can_finish:

--- a/src/cube_harness/agents/react.py
+++ b/src/cube_harness/agents/react.py
@@ -70,8 +70,8 @@ class ReactAgent(Agent):
         super().__init__(config)
         self.llm = config.llm_config.make()
         self.token_counter = config.llm_config.make_counter()
-        # STOP (`final_step`) is automatically included in the task's `action_set`
-        # and has a safe schema provided by cube-standard.
+        # STOP (`final_step`) is provided by cube-standard in the task's `action_set` when
+        # `accept_agent_stop=True` (the default) and uses an Anthropic-safe empty-object schema.
         # `can_finish=False` opts the agent out of offering STOP to the LLM.
         self.tools: list[dict] = [tool.as_dict() for tool in tools]
         if not config.can_finish:


### PR DESCRIPTION
# PR Template: Documentation/Website Change

## Description of Changes
* **What content was added/modified/removed?** 
  Removed outdated comments in `react.py` and documentation in `swebench-verified-cube/README.md` that referenced manually appending the `STOP_ACTION` schema and patching it for Anthropic compatibility.
* **Why were these changes made?** 
  With The-AI-Alliance/cube-standard#139, `STOP_ACTION` is now automatically included with the Anthropic-safe empty-object schema whenever `accept_agent_stop=True`. The manual workarounds and references to them are no longer needed.
* **How do these changes improve the documentation/website?** 
  It cleans up stale and redundant information, preventing developers from mistakenly thinking they still need to manually patch the `STOP_ACTION` schema.

## Related Issues
* Fixes #385

## Testing Performed
- [x] Verified site builds successfully (i.e., `make view-local` runs successfully)
- [x] Checked links and formatting 
- [x] Tested in local development environment
- [ ] Screenshots of changes (if applicable)

## Code Changes
List all files modified/added:
* `cubes/swebench-verified-cube/README.md`
* `src/cube_harness/agents/react.py`

## Preview
Running `make view-local` is sufficient to see the updated documentation.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My changes follow the documentation style guide
- [x] I have updated any related documentation
- [ ] I have added/updated tests if applicable
- [ ] I have included necessary screenshots or examples

## Additional Context
N/A